### PR TITLE
[Chore] GitHub 라벨 시스템 정비 및 branch protection ruleset 설정

### DIFF
--- a/docs/05-team-rules/git-workflow-pr.md
+++ b/docs/05-team-rules/git-workflow-pr.md
@@ -136,3 +136,21 @@ Closes #이슈번호
 [Nit]      사소한 수정
 [Good]     좋은 구현 또는 유지하면 좋은 부분
 ```
+
+---
+
+## Branch Protection Rulesets
+
+`main`과 `develop` 브랜치에 GitHub Ruleset이 설정되어 있다.
+
+| 규칙 | main | develop |
+|------|------|---------|
+| PR 없이 직접 push | 차단 | 차단 |
+| PR 승인 필수 인원 | 1명 | 1명 |
+| Force push | 차단 | 차단 |
+| 브랜치 삭제 | 차단 | 차단 |
+| 새 커밋 push 시 기존 승인 무효화 | 적용 | 적용 |
+| Admin bypass | 불가 | 불가 |
+
+- `bypass_actors`를 빈 배열로 설정하여 Admin을 포함한 모든 계정에 동일하게 적용된다.
+- `feature/*` 브랜치에는 별도 ruleset이 없으며 컨벤션으로만 관리한다.


### PR DESCRIPTION
## 작업 개요
팀 컨벤션에 맞게 GitHub 라벨을 정비하고, main·develop 브랜치에 branch protection ruleset을 설정한다.

## 관련 Issue
Closes #30

## 변경 내용
- 기본 라벨 6개 삭제 (duplicate, enhancement, good first issue, help wanted, invalid, wontfix)
- `documentation` → `docs` 이름 변경
- 누락 라벨 8개 추가 (design, refactor, chore, discussion, decision, ai-context, blocked)
- `protect-main` ruleset 생성 완료
- `protect-develop` ruleset 생성 완료
- docs/05-team-rules/git-workflow-pr.md에 ruleset 규칙 문서화

## 결정 사항 및 이유
- bypass_actors를 빈 배열로 설정하여 Admin 포함 전원에게 ruleset 적용
- PR 승인 1명 필수, 새 커밋 push 시 기존 승인 무효화

## 테스트 / 확인 내용
- [x] GitHub API 검증 완료: `protect-main` ruleset
- [x] GitHub API 검증 완료: `protect-develop` ruleset
- [x] GitHub API 검증 완료: 팀 컨벤션 라벨 11개
- [x] 관련 문서 업데이트 확인
- 로컬 실행 및 에러 케이스 확인: 해당 없음 (코드 변경 없는 GitHub 설정·문서 작업)

## AI 사용 여부
- 사용 여부: 사용함
- 사용한 작업: ruleset JSON 구성, 문서 초안 작성
- 사람이 검토한 내용: ruleset 규칙 항목 전체, 문서 내용

## 리뷰어가 봐야 할 부분
- bypass_actors 빈 배열 설정 — Admin도 우회 불가한 점 팀 공유 필요