### PR TITLE
[Feature] ERD 기반 DB 스키마 v1 및 초기 migration 추가

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,6 +14,8 @@ RUN addgroup --system app \
     && adduser --system --ingroup app app
 
 COPY --chown=app:app app ./app
+COPY --chown=app:app alembic.ini ./alembic.ini
+COPY --chown=app:app alembic ./alembic
 
 USER app
 

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,38 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+sqlalchemy.url = postgresql+psycopg://postgres@localhost:5432/magic_academy
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,47 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.core.config import get_settings
+from app.core.database import Base
+from app.domain import models  # noqa: F401
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+database_url = get_settings().sqlalchemy_database_url
+if hasattr(database_url, "render_as_string"):
+    database_url = database_url.render_as_string(hide_password=False)
+config.set_main_option("sqlalchemy.url", str(database_url))
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/20260805_0001_create_schema_v1.py
+++ b/backend/alembic/versions/20260805_0001_create_schema_v1.py
@@ -1,0 +1,212 @@
+"""create ERD-based schema v1
+
+Revision ID: 20260805_0001
+Revises:
+Create Date: 2026-08-05
+"""
+
+from alembic import op
+
+revision = "20260805_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def _execute_batch(sql: str) -> None:
+    for statement in sql.split(";"):
+        if statement.strip():
+            op.execute(statement)
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    _execute_batch(
+        """
+        CREATE TABLE simulations (
+            id UUID PRIMARY KEY,
+            name VARCHAR(100) NOT NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'ready' CONSTRAINT ck_simulations_status CHECK (status IN ('ready','running','paused','completed','failed')),
+            current_day INTEGER NOT NULL DEFAULT 1 CONSTRAINT ck_simulations_current_day CHECK (current_day >= 1),
+            current_tick BIGINT NOT NULL DEFAULT 0 CONSTRAINT ck_simulations_current_tick CHECK (current_tick >= 0),
+            magic_enabled BOOLEAN NOT NULL DEFAULT true,
+            started_at TIMESTAMPTZ,
+            ended_at TIMESTAMPTZ,
+            deleted_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        );
+
+        CREATE TABLE locations (
+            id UUID PRIMARY KEY,
+            simulation_id UUID NOT NULL CONSTRAINT fk_locations_simulation REFERENCES simulations(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            code VARCHAR(50) NOT NULL,
+            name VARCHAR(100) NOT NULL,
+            is_active BOOLEAN NOT NULL DEFAULT true,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_locations_simulation_code UNIQUE (simulation_id, code),
+            CONSTRAINT uq_locations_simulation_id_id UNIQUE (simulation_id, id)
+        );
+
+        CREATE TABLE agents (
+            id UUID PRIMARY KEY,
+            simulation_id UUID NOT NULL CONSTRAINT fk_agents_simulation REFERENCES simulations(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            agent_type VARCHAR(20) NOT NULL CONSTRAINT ck_agents_agent_type CHECK (agent_type IN ('student','professor','user_persona')),
+            name VARCHAR(50) NOT NULL,
+            gender VARCHAR(20) CONSTRAINT ck_agents_gender CHECK (gender IS NULL OR gender IN ('male','female','non_binary','unspecified')),
+            personality_type VARCHAR(30),
+            mbti_type VARCHAR(4) NOT NULL CONSTRAINT ck_agents_mbti_type CHECK (mbti_type IN ('ISTJ','ESTP','INFP','ENTJ','ESFJ')),
+            openness SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_openness CHECK (openness BETWEEN 0 AND 100),
+            conscientiousness SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_conscientiousness CHECK (conscientiousness BETWEEN 0 AND 100),
+            extraversion SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_extraversion CHECK (extraversion BETWEEN 0 AND 100),
+            agreeableness SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_agreeableness CHECK (agreeableness BETWEEN 0 AND 100),
+            emotional_stability SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_emotional_stability CHECK (emotional_stability BETWEEN 0 AND 100),
+            role_description TEXT,
+            active_status VARCHAR(30) NOT NULL DEFAULT 'active',
+            inactive_until_tick BIGINT CONSTRAINT ck_agents_inactive_until_tick CHECK (inactive_until_tick IS NULL OR inactive_until_tick >= 0),
+            persona_locked_at TIMESTAMPTZ,
+            deleted_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_agents_simulation_id_id UNIQUE (simulation_id, id)
+        );
+        CREATE UNIQUE INDEX uq_agents_active_user_persona ON agents (simulation_id) WHERE agent_type = 'user_persona' AND deleted_at IS NULL;
+        CREATE INDEX idx_agents_simulation_id ON agents (simulation_id, id ASC);
+        CREATE INDEX idx_agents_runtime_active ON agents (simulation_id, active_status, inactive_until_tick);
+
+        CREATE TABLE agent_states (
+            id UUID PRIMARY KEY,
+            simulation_id UUID NOT NULL CONSTRAINT fk_agent_states_simulation REFERENCES simulations(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            agent_id UUID NOT NULL,
+            location_id UUID,
+            hunger SMALLINT NOT NULL DEFAULT 50,
+            fatigue SMALLINT NOT NULL DEFAULT 0,
+            stress SMALLINT NOT NULL DEFAULT 0,
+            satisfaction SMALLINT NOT NULL DEFAULT 50,
+            mood SMALLINT NOT NULL DEFAULT 0,
+            current_action VARCHAR(50),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_agent_states_agent_id UNIQUE (agent_id),
+            CONSTRAINT fk_agent_states_agent FOREIGN KEY (simulation_id, agent_id) REFERENCES agents(simulation_id, id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            CONSTRAINT fk_agent_states_location FOREIGN KEY (simulation_id, location_id) REFERENCES locations(simulation_id, id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            CONSTRAINT ck_agent_states_bounded_scores CHECK (hunger BETWEEN 0 AND 100 AND fatigue BETWEEN 0 AND 100 AND stress BETWEEN 0 AND 100 AND satisfaction BETWEEN 0 AND 100 AND mood BETWEEN -100 AND 100)
+        );
+
+        CREATE TABLE organizations (
+            id UUID PRIMARY KEY,
+            simulation_id UUID NOT NULL CONSTRAINT fk_organizations_simulation REFERENCES simulations(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            organization_type VARCHAR(20) NOT NULL CONSTRAINT ck_organizations_type CHECK (organization_type IN ('major','club','dormitory')),
+            name VARCHAR(100) NOT NULL,
+            description TEXT,
+            is_active BOOLEAN NOT NULL DEFAULT true,
+            deleted_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_organizations_simulation_type_name UNIQUE (simulation_id, organization_type, name),
+            CONSTRAINT uq_organizations_simulation_id_id UNIQUE (simulation_id, id)
+        );
+        CREATE INDEX idx_organizations_simulation_id ON organizations (simulation_id, id ASC);
+
+        CREATE TABLE organization_memberships (
+            id UUID PRIMARY KEY,
+            simulation_id UUID NOT NULL CONSTRAINT fk_memberships_simulation REFERENCES simulations(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            organization_id UUID NOT NULL,
+            agent_id UUID NOT NULL,
+            membership_role VARCHAR(30) CONSTRAINT ck_memberships_role CHECK (membership_role IS NULL OR membership_role IN ('member','leader','professor','resident')),
+            joined_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            left_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT fk_memberships_organization FOREIGN KEY (simulation_id, organization_id) REFERENCES organizations(simulation_id, id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            CONSTRAINT fk_memberships_agent FOREIGN KEY (simulation_id, agent_id) REFERENCES agents(simulation_id, id) ON DELETE RESTRICT ON UPDATE RESTRICT
+        );
+        CREATE UNIQUE INDEX uq_organization_memberships_active ON organization_memberships (organization_id, agent_id) WHERE left_at IS NULL;
+
+        CREATE TABLE events (
+            id UUID PRIMARY KEY,
+            simulation_id UUID NOT NULL CONSTRAINT fk_events_simulation REFERENCES simulations(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            location_id UUID,
+            event_type VARCHAR(30) NOT NULL CONSTRAINT ck_events_type CHECK (event_type IN ('class','group_project','exam','meeting','mt','festival','student_council','random_incident')),
+            title VARCHAR(100) NOT NULL,
+            description TEXT,
+            status VARCHAR(20) NOT NULL DEFAULT 'scheduled' CONSTRAINT ck_events_status CHECK (status IN ('scheduled','ongoing','completed','cancelled')),
+            simulation_day INTEGER NOT NULL CONSTRAINT ck_events_simulation_day CHECK (simulation_day >= 1),
+            started_at TIMESTAMPTZ,
+            ended_at TIMESTAMPTZ,
+            metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT fk_events_location FOREIGN KEY (simulation_id, location_id) REFERENCES locations(simulation_id, id) ON DELETE SET NULL (location_id) ON UPDATE RESTRICT
+        );
+        CREATE INDEX idx_events_simulation_started ON events (simulation_id, started_at DESC, id DESC);
+
+        CREATE TABLE event_participants (
+            id UUID PRIMARY KEY,
+            event_id UUID NOT NULL CONSTRAINT fk_event_participants_event REFERENCES events(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            agent_id UUID NOT NULL CONSTRAINT fk_event_participants_agent REFERENCES agents(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            participant_role VARCHAR(30),
+            action_taken TEXT,
+            result JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT uq_event_participants_event_agent UNIQUE (event_id, agent_id)
+        );
+
+        CREATE TABLE relationships (
+            id UUID PRIMARY KEY,
+            simulation_id UUID NOT NULL CONSTRAINT fk_relationships_simulation REFERENCES simulations(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            source_agent_id UUID NOT NULL,
+            target_agent_id UUID NOT NULL,
+            affection SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_relationships_affection CHECK (affection BETWEEN -100 AND 100),
+            closeness SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_relationships_closeness CHECK (closeness BETWEEN 0 AND 100),
+            trust SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_relationships_trust CHECK (trust BETWEEN -100 AND 100),
+            tension SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_relationships_tension CHECK (tension BETWEEN 0 AND 100),
+            rivalry SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_relationships_rivalry CHECK (rivalry BETWEEN 0 AND 100),
+            dependency SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_relationships_dependency CHECK (dependency BETWEEN 0 AND 100),
+            relationship_type VARCHAR(30) CONSTRAINT ck_relationships_type CHECK (relationship_type IS NULL OR relationship_type IN ('friend','rival','senior_junior','confession','betrayal','reconciliation')),
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT fk_relationships_source_agent FOREIGN KEY (simulation_id, source_agent_id) REFERENCES agents(simulation_id, id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            CONSTRAINT fk_relationships_target_agent FOREIGN KEY (simulation_id, target_agent_id) REFERENCES agents(simulation_id, id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            CONSTRAINT ck_relationships_distinct_agents CHECK (source_agent_id <> target_agent_id),
+            CONSTRAINT uq_relationships_pair UNIQUE (simulation_id, source_agent_id, target_agent_id)
+        );
+        CREATE INDEX idx_relationships_source_updated ON relationships (source_agent_id, updated_at DESC, id DESC);
+
+        CREATE TABLE agent_memories (
+            id UUID PRIMARY KEY,
+            agent_id UUID NOT NULL CONSTRAINT fk_agent_memories_agent REFERENCES agents(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            event_id UUID CONSTRAINT fk_agent_memories_event REFERENCES events(id) ON DELETE SET NULL ON UPDATE RESTRICT,
+            content TEXT NOT NULL,
+            memory_type VARCHAR(20) NOT NULL DEFAULT 'observation' CONSTRAINT ck_agent_memories_type CHECK (memory_type IN ('observation','conversation','reflection','plan')),
+            importance SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_agent_memories_importance CHECK (importance BETWEEN 0 AND 100),
+            created_tick BIGINT NOT NULL CONSTRAINT ck_agent_memories_created_tick CHECK (created_tick >= 0),
+            occurred_at TIMESTAMPTZ NOT NULL,
+            last_accessed_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        );
+        CREATE INDEX idx_agent_memories_agent_occurred ON agent_memories (agent_id, occurred_at DESC, id DESC);
+        CREATE INDEX idx_agent_memories_cleanup ON agent_memories (agent_id, importance ASC, created_tick ASC);
+        """
+    )
+
+
+def downgrade() -> None:
+    _execute_batch(
+        """
+        DROP TABLE agent_memories;
+        DROP TABLE relationships;
+        DROP TABLE event_participants;
+        DROP TABLE events;
+        DROP TABLE organization_memberships;
+        DROP TABLE organizations;
+        DROP TABLE agent_states;
+        DROP TABLE agents;
+        DROP TABLE locations;
+        DROP TABLE simulations;
+        DROP EXTENSION IF EXISTS vector;
+        """
+    )

--- a/backend/alembic/versions/20260805_0001_create_schema_v1.py
+++ b/backend/alembic/versions/20260805_0001_create_schema_v1.py
@@ -52,16 +52,18 @@ def upgrade() -> None:
         CREATE TABLE agents (
             id UUID PRIMARY KEY,
             simulation_id UUID NOT NULL CONSTRAINT fk_agents_simulation REFERENCES simulations(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            fixture_key VARCHAR(50) NOT NULL,
+            fixture_version VARCHAR(50) NOT NULL,
             agent_type VARCHAR(20) NOT NULL CONSTRAINT ck_agents_agent_type CHECK (agent_type IN ('student','professor','user_persona')),
             name VARCHAR(50) NOT NULL,
             gender VARCHAR(20) CONSTRAINT ck_agents_gender CHECK (gender IS NULL OR gender IN ('male','female','non_binary','unspecified')),
             personality_type VARCHAR(30),
             mbti_type VARCHAR(4) NOT NULL CONSTRAINT ck_agents_mbti_type CHECK (mbti_type IN ('ISTJ','ESTP','INFP','ENTJ','ESFJ')),
-            openness SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_openness CHECK (openness BETWEEN 0 AND 100),
-            conscientiousness SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_conscientiousness CHECK (conscientiousness BETWEEN 0 AND 100),
-            extraversion SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_extraversion CHECK (extraversion BETWEEN 0 AND 100),
-            agreeableness SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_agreeableness CHECK (agreeableness BETWEEN 0 AND 100),
-            emotional_stability SMALLINT NOT NULL DEFAULT 50 CONSTRAINT ck_agents_emotional_stability CHECK (emotional_stability BETWEEN 0 AND 100),
+            openness SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_agents_openness CHECK (openness BETWEEN -50 AND 50 AND openness % 5 = 0),
+            conscientiousness SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_agents_conscientiousness CHECK (conscientiousness BETWEEN -50 AND 50 AND conscientiousness % 5 = 0),
+            extraversion SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_agents_extraversion CHECK (extraversion BETWEEN -50 AND 50 AND extraversion % 5 = 0),
+            agreeableness SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_agents_agreeableness CHECK (agreeableness BETWEEN -50 AND 50 AND agreeableness % 5 = 0),
+            emotional_stability SMALLINT NOT NULL DEFAULT 0 CONSTRAINT ck_agents_emotional_stability CHECK (emotional_stability BETWEEN -50 AND 50 AND emotional_stability % 5 = 0),
             role_description TEXT,
             active_status VARCHAR(30) NOT NULL DEFAULT 'active',
             inactive_until_tick BIGINT CONSTRAINT ck_agents_inactive_until_tick CHECK (inactive_until_tick IS NULL OR inactive_until_tick >= 0),
@@ -69,11 +71,24 @@ def upgrade() -> None:
             deleted_at TIMESTAMPTZ,
             created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
             updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-            CONSTRAINT uq_agents_simulation_id_id UNIQUE (simulation_id, id)
+            CONSTRAINT uq_agents_simulation_id_id UNIQUE (simulation_id, id),
+            CONSTRAINT uq_agents_simulation_fixture_key UNIQUE (simulation_id, fixture_key)
         );
         CREATE UNIQUE INDEX uq_agents_active_user_persona ON agents (simulation_id) WHERE agent_type = 'user_persona' AND deleted_at IS NULL;
         CREATE INDEX idx_agents_simulation_id ON agents (simulation_id, id ASC);
         CREATE INDEX idx_agents_runtime_active ON agents (simulation_id, active_status, inactive_until_tick);
+
+        CREATE TABLE student_profiles (
+            agent_id UUID PRIMARY KEY CONSTRAINT fk_student_profiles_agent REFERENCES agents(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            grade SMALLINT NOT NULL CONSTRAINT ck_student_profiles_grade CHECK (grade BETWEEN 1 AND 4),
+            interest_field VARCHAR(100) NOT NULL
+        );
+
+        CREATE TABLE professor_profiles (
+            agent_id UUID PRIMARY KEY CONSTRAINT fk_professor_profiles_agent REFERENCES agents(id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+            academic_rank VARCHAR(50) NOT NULL,
+            specialty VARCHAR(200) NOT NULL
+        );
 
         CREATE TABLE agent_states (
             id UUID PRIMARY KEY,
@@ -204,6 +219,8 @@ def downgrade() -> None:
         DROP TABLE organization_memberships;
         DROP TABLE organizations;
         DROP TABLE agent_states;
+        DROP TABLE professor_profiles;
+        DROP TABLE student_profiles;
         DROP TABLE agents;
         DROP TABLE locations;
         DROP TABLE simulations;

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -1,0 +1,251 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID as PythonUUID
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    SmallInteger,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class TimestampMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+
+class Simulation(TimestampMixin, Base):
+    __tablename__ = "simulations"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('ready', 'running', 'paused', 'completed', 'failed')",
+            name="ck_simulations_status",
+        ),
+        CheckConstraint("current_day >= 1", name="ck_simulations_current_day"),
+        CheckConstraint("current_tick >= 0", name="ck_simulations_current_tick"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="ready")
+    current_day: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    current_tick: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
+    magic_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class Location(TimestampMixin, Base):
+    __tablename__ = "locations"
+    __table_args__ = (
+        UniqueConstraint("simulation_id", "code", name="uq_locations_simulation_code"),
+        UniqueConstraint("simulation_id", "id", name="uq_locations_simulation_id_id"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False
+    )
+    code: Mapped[str] = mapped_column(String(50), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+
+
+class Agent(TimestampMixin, Base):
+    __tablename__ = "agents"
+    __table_args__ = (
+        UniqueConstraint("simulation_id", "id", name="uq_agents_simulation_id_id"),
+        CheckConstraint("agent_type IN ('student', 'professor', 'user_persona')", name="ck_agents_agent_type"),
+        CheckConstraint("gender IS NULL OR gender IN ('male', 'female', 'non_binary', 'unspecified')", name="ck_agents_gender"),
+        CheckConstraint("mbti_type IN ('ISTJ', 'ESTP', 'INFP', 'ENTJ', 'ESFJ')", name="ck_agents_mbti_type"),
+        CheckConstraint("openness BETWEEN 0 AND 100", name="ck_agents_openness"),
+        CheckConstraint("conscientiousness BETWEEN 0 AND 100", name="ck_agents_conscientiousness"),
+        CheckConstraint("extraversion BETWEEN 0 AND 100", name="ck_agents_extraversion"),
+        CheckConstraint("agreeableness BETWEEN 0 AND 100", name="ck_agents_agreeableness"),
+        CheckConstraint("emotional_stability BETWEEN 0 AND 100", name="ck_agents_emotional_stability"),
+        CheckConstraint("inactive_until_tick IS NULL OR inactive_until_tick >= 0", name="ck_agents_inactive_until_tick"),
+        Index("uq_agents_active_user_persona", "simulation_id", unique=True, postgresql_where=text("agent_type = 'user_persona' AND deleted_at IS NULL")),
+        Index("idx_agents_simulation_id", "simulation_id", "id"),
+        Index("idx_agents_runtime_active", "simulation_id", "active_status", "inactive_until_tick"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    agent_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str] = mapped_column(String(50), nullable=False)
+    gender: Mapped[str | None] = mapped_column(String(20))
+    personality_type: Mapped[str | None] = mapped_column(String(30))
+    mbti_type: Mapped[str] = mapped_column(String(4), nullable=False)
+    openness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    conscientiousness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    extraversion: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    agreeableness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    emotional_stability: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    role_description: Mapped[str | None] = mapped_column(Text)
+    active_status: Mapped[str] = mapped_column(String(30), nullable=False, server_default="active")
+    inactive_until_tick: Mapped[int | None] = mapped_column(BigInteger)
+    persona_locked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class AgentState(TimestampMixin, Base):
+    __tablename__ = "agent_states"
+    __table_args__ = (
+        ForeignKeyConstraint(["simulation_id", "agent_id"], ["agents.simulation_id", "agents.id"], ondelete="RESTRICT", onupdate="RESTRICT", name="fk_agent_states_agent"),
+        ForeignKeyConstraint(["simulation_id", "location_id"], ["locations.simulation_id", "locations.id"], ondelete="RESTRICT", onupdate="RESTRICT", name="fk_agent_states_location"),
+        UniqueConstraint("agent_id", name="uq_agent_states_agent_id"),
+        CheckConstraint("hunger BETWEEN 0 AND 100 AND fatigue BETWEEN 0 AND 100 AND stress BETWEEN 0 AND 100 AND satisfaction BETWEEN 0 AND 100 AND mood BETWEEN -100 AND 100", name="ck_agent_states_bounded_scores"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    agent_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    location_id: Mapped[PythonUUID | None] = mapped_column(UUID(as_uuid=True))
+    hunger: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    fatigue: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    stress: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    satisfaction: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    mood: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    current_action: Mapped[str | None] = mapped_column(String(50))
+
+
+class Organization(TimestampMixin, Base):
+    __tablename__ = "organizations"
+    __table_args__ = (
+        UniqueConstraint("simulation_id", "organization_type", "name", name="uq_organizations_simulation_type_name"),
+        UniqueConstraint("simulation_id", "id", name="uq_organizations_simulation_id_id"),
+        CheckConstraint("organization_type IN ('major', 'club', 'dormitory')", name="ck_organizations_type"),
+        Index("idx_organizations_simulation_id", "simulation_id", "id"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    organization_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class OrganizationMembership(TimestampMixin, Base):
+    __tablename__ = "organization_memberships"
+    __table_args__ = (
+        ForeignKeyConstraint(["simulation_id", "organization_id"], ["organizations.simulation_id", "organizations.id"], ondelete="RESTRICT", onupdate="RESTRICT", name="fk_memberships_organization"),
+        ForeignKeyConstraint(["simulation_id", "agent_id"], ["agents.simulation_id", "agents.id"], ondelete="RESTRICT", onupdate="RESTRICT", name="fk_memberships_agent"),
+        CheckConstraint("membership_role IS NULL OR membership_role IN ('member', 'leader', 'professor', 'resident')", name="ck_memberships_role"),
+        Index("uq_organization_memberships_active", "organization_id", "agent_id", unique=True, postgresql_where=text("left_at IS NULL")),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    organization_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    agent_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    membership_role: Mapped[str | None] = mapped_column(String(30))
+    joined_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    left_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class Event(TimestampMixin, Base):
+    __tablename__ = "events"
+    __table_args__ = (
+        ForeignKeyConstraint(["simulation_id", "location_id"], ["locations.simulation_id", "locations.id"], ondelete="SET NULL (location_id)", onupdate="RESTRICT", name="fk_events_location"),
+        CheckConstraint("event_type IN ('class', 'group_project', 'exam', 'meeting', 'mt', 'festival', 'student_council', 'random_incident')", name="ck_events_type"),
+        CheckConstraint("status IN ('scheduled', 'ongoing', 'completed', 'cancelled')", name="ck_events_status"),
+        CheckConstraint("simulation_day >= 1", name="ck_events_simulation_day"),
+        Index("idx_events_simulation_started", "simulation_id", text("started_at DESC"), text("id DESC")),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    location_id: Mapped[PythonUUID | None] = mapped_column(UUID(as_uuid=True))
+    event_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    title: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="scheduled")
+    simulation_day: Mapped[int] = mapped_column(Integer, nullable=False)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    event_metadata: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+
+
+class EventParticipant(TimestampMixin, Base):
+    __tablename__ = "event_participants"
+    __table_args__ = (UniqueConstraint("event_id", "agent_id", name="uq_event_participants_event_agent"),)
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    event_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("events.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    agent_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    participant_role: Mapped[str | None] = mapped_column(String(30))
+    action_taken: Mapped[str | None] = mapped_column(Text)
+    result: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+
+
+class Relationship(TimestampMixin, Base):
+    __tablename__ = "relationships"
+    __table_args__ = (
+        ForeignKeyConstraint(["simulation_id", "source_agent_id"], ["agents.simulation_id", "agents.id"], ondelete="RESTRICT", onupdate="RESTRICT", name="fk_relationships_source_agent"),
+        ForeignKeyConstraint(["simulation_id", "target_agent_id"], ["agents.simulation_id", "agents.id"], ondelete="RESTRICT", onupdate="RESTRICT", name="fk_relationships_target_agent"),
+        UniqueConstraint("simulation_id", "source_agent_id", "target_agent_id", name="uq_relationships_pair"),
+        CheckConstraint("source_agent_id <> target_agent_id", name="ck_relationships_distinct_agents"),
+        CheckConstraint("affection BETWEEN -100 AND 100", name="ck_relationships_affection"),
+        CheckConstraint("closeness BETWEEN 0 AND 100", name="ck_relationships_closeness"),
+        CheckConstraint("trust BETWEEN -100 AND 100", name="ck_relationships_trust"),
+        CheckConstraint("tension BETWEEN 0 AND 100", name="ck_relationships_tension"),
+        CheckConstraint("rivalry BETWEEN 0 AND 100", name="ck_relationships_rivalry"),
+        CheckConstraint("dependency BETWEEN 0 AND 100", name="ck_relationships_dependency"),
+        CheckConstraint("relationship_type IS NULL OR relationship_type IN ('friend', 'rival', 'senior_junior', 'confession', 'betrayal', 'reconciliation')", name="ck_relationships_type"),
+        Index("idx_relationships_source_updated", "source_agent_id", text("updated_at DESC"), text("id DESC")),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    source_agent_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    target_agent_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    affection: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    closeness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    trust: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    tension: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    rivalry: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    dependency: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    relationship_type: Mapped[str | None] = mapped_column(String(30))
+
+
+class AgentMemory(TimestampMixin, Base):
+    __tablename__ = "agent_memories"
+    __table_args__ = (
+        CheckConstraint("memory_type IN ('observation', 'conversation', 'reflection', 'plan')", name="ck_agent_memories_type"),
+        CheckConstraint("importance BETWEEN 0 AND 100", name="ck_agent_memories_importance"),
+        CheckConstraint("created_tick >= 0", name="ck_agent_memories_created_tick"),
+        Index("idx_agent_memories_agent_occurred", "agent_id", text("occurred_at DESC"), text("id DESC")),
+        Index("idx_agent_memories_cleanup", "agent_id", "importance", "created_tick"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    agent_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    event_id: Mapped[PythonUUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("events.id", ondelete="SET NULL", onupdate="RESTRICT"))
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    memory_type: Mapped[str] = mapped_column(String(20), nullable=False, server_default="observation")
+    importance: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    created_tick: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_accessed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -75,14 +75,15 @@ class Agent(TimestampMixin, Base):
     __tablename__ = "agents"
     __table_args__ = (
         UniqueConstraint("simulation_id", "id", name="uq_agents_simulation_id_id"),
+        UniqueConstraint("simulation_id", "fixture_key", name="uq_agents_simulation_fixture_key"),
         CheckConstraint("agent_type IN ('student', 'professor', 'user_persona')", name="ck_agents_agent_type"),
         CheckConstraint("gender IS NULL OR gender IN ('male', 'female', 'non_binary', 'unspecified')", name="ck_agents_gender"),
         CheckConstraint("mbti_type IN ('ISTJ', 'ESTP', 'INFP', 'ENTJ', 'ESFJ')", name="ck_agents_mbti_type"),
-        CheckConstraint("openness BETWEEN 0 AND 100", name="ck_agents_openness"),
-        CheckConstraint("conscientiousness BETWEEN 0 AND 100", name="ck_agents_conscientiousness"),
-        CheckConstraint("extraversion BETWEEN 0 AND 100", name="ck_agents_extraversion"),
-        CheckConstraint("agreeableness BETWEEN 0 AND 100", name="ck_agents_agreeableness"),
-        CheckConstraint("emotional_stability BETWEEN 0 AND 100", name="ck_agents_emotional_stability"),
+        CheckConstraint("openness BETWEEN -50 AND 50 AND openness % 5 = 0", name="ck_agents_openness"),
+        CheckConstraint("conscientiousness BETWEEN -50 AND 50 AND conscientiousness % 5 = 0", name="ck_agents_conscientiousness"),
+        CheckConstraint("extraversion BETWEEN -50 AND 50 AND extraversion % 5 = 0", name="ck_agents_extraversion"),
+        CheckConstraint("agreeableness BETWEEN -50 AND 50 AND agreeableness % 5 = 0", name="ck_agents_agreeableness"),
+        CheckConstraint("emotional_stability BETWEEN -50 AND 50 AND emotional_stability % 5 = 0", name="ck_agents_emotional_stability"),
         CheckConstraint("inactive_until_tick IS NULL OR inactive_until_tick >= 0", name="ck_agents_inactive_until_tick"),
         Index("uq_agents_active_user_persona", "simulation_id", unique=True, postgresql_where=text("agent_type = 'user_persona' AND deleted_at IS NULL")),
         Index("idx_agents_simulation_id", "simulation_id", "id"),
@@ -91,21 +92,48 @@ class Agent(TimestampMixin, Base):
 
     id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
     simulation_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False)
+    fixture_key: Mapped[str] = mapped_column(String(50), nullable=False)
+    fixture_version: Mapped[str] = mapped_column(String(50), nullable=False)
     agent_type: Mapped[str] = mapped_column(String(20), nullable=False)
     name: Mapped[str] = mapped_column(String(50), nullable=False)
     gender: Mapped[str | None] = mapped_column(String(20))
     personality_type: Mapped[str | None] = mapped_column(String(30))
     mbti_type: Mapped[str] = mapped_column(String(4), nullable=False)
-    openness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
-    conscientiousness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
-    extraversion: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
-    agreeableness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
-    emotional_stability: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="50")
+    openness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    conscientiousness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    extraversion: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    agreeableness: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    emotional_stability: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
     role_description: Mapped[str | None] = mapped_column(Text)
     active_status: Mapped[str] = mapped_column(String(30), nullable=False, server_default="active")
     inactive_until_tick: Mapped[int | None] = mapped_column(BigInteger)
     persona_locked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class StudentProfile(Base):
+    __tablename__ = "student_profiles"
+    __table_args__ = (CheckConstraint("grade BETWEEN 1 AND 4", name="ck_student_profiles_grade"),)
+
+    agent_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        primary_key=True,
+    )
+    grade: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    interest_field: Mapped[str] = mapped_column(String(100), nullable=False)
+
+
+class ProfessorProfile(Base):
+    __tablename__ = "professor_profiles"
+
+    agent_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        primary_key=True,
+    )
+    academic_rank: Mapped[str] = mapped_column(String(50), nullable=False)
+    specialty: Mapped[str] = mapped_column(String(200), nullable=False)
 
 
 class AgentState(TimestampMixin, Base):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,6 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 h11>=0.16.0
 pydantic-settings>=2.6.0
-sqlalchemy>=2.0.0
+sqlalchemy>=2.0.40
 psycopg[binary]>=3.2.0
 alembic>=1.14.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ h11>=0.16.0
 pydantic-settings>=2.6.0
 sqlalchemy>=2.0.0
 psycopg[binary]>=3.2.0
+alembic>=1.14.0

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sqlalchemy import CheckConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -14,6 +15,8 @@ class SchemaModelTests(unittest.TestCase):
                 "simulations",
                 "locations",
                 "agents",
+                "student_profiles",
+                "professor_profiles",
                 "agent_states",
                 "agent_memories",
                 "relationships",
@@ -26,7 +29,8 @@ class SchemaModelTests(unittest.TestCase):
 
     def test_primary_and_foreign_keys_use_postgresql_uuid(self) -> None:
         for table in Base.metadata.tables.values():
-            self.assertIsInstance(table.c.id.type, UUID)
+            for primary_key in table.primary_key.columns:
+                self.assertIsInstance(primary_key.type, UUID)
             for foreign_key in table.foreign_keys:
                 self.assertIsInstance(foreign_key.parent.type, UUID)
 
@@ -34,6 +38,7 @@ class SchemaModelTests(unittest.TestCase):
         expected_names = {
             "uq_locations_simulation_code",
             "uq_agents_simulation_id_id",
+            "uq_agents_simulation_fixture_key",
             "uq_agents_active_user_persona",
             "uq_agent_states_agent_id",
             "uq_relationships_pair",
@@ -77,6 +82,41 @@ class SchemaModelTests(unittest.TestCase):
         created_tick = Base.metadata.tables["agent_memories"].c.created_tick
         self.assertFalse(created_tick.nullable)
         self.assertEqual(created_tick.type.python_type, int)
+
+    def test_fixture_columns_are_required(self) -> None:
+        agents = Base.metadata.tables["agents"]
+        self.assertFalse(agents.c.fixture_key.nullable)
+        self.assertFalse(agents.c.fixture_version.nullable)
+
+    def test_role_profiles_use_agent_id_as_primary_and_foreign_key(self) -> None:
+        student_profiles = Base.metadata.tables["student_profiles"]
+        professor_profiles = Base.metadata.tables["professor_profiles"]
+        for table in (student_profiles, professor_profiles):
+            self.assertEqual(list(table.primary_key.columns.keys()), ["agent_id"])
+            self.assertEqual(
+                {foreign_key.target_fullname for foreign_key in table.c.agent_id.foreign_keys},
+                {"agents.id"},
+            )
+        self.assertTrue({"grade", "interest_field"} <= set(student_profiles.c.keys()))
+        self.assertTrue({"academic_rank", "specialty"} <= set(professor_profiles.c.keys()))
+
+    def test_big_five_constraints_use_signed_five_point_steps(self) -> None:
+        agents = Base.metadata.tables["agents"]
+        constraints = {
+            constraint.name: str(constraint.sqltext)
+            for constraint in agents.constraints
+            if isinstance(constraint, CheckConstraint)
+        }
+        for column in (
+            "openness",
+            "conscientiousness",
+            "extraversion",
+            "agreeableness",
+            "emotional_stability",
+        ):
+            expression = constraints[f"ck_agents_{column}"]
+            self.assertIn("BETWEEN -50 AND 50", expression)
+            self.assertIn("% 5 = 0", expression)
 
     def test_embedding_column_is_deferred_until_dimension_is_decided(self) -> None:
         self.assertNotIn("embedding", Base.metadata.tables["agent_memories"].c)

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -1,0 +1,86 @@
+import unittest
+
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.core.database import Base
+from app.domain import models  # noqa: F401
+
+
+class SchemaModelTests(unittest.TestCase):
+    def test_erd_v1_tables_are_registered(self) -> None:
+        self.assertEqual(
+            set(Base.metadata.tables),
+            {
+                "simulations",
+                "locations",
+                "agents",
+                "agent_states",
+                "agent_memories",
+                "relationships",
+                "organizations",
+                "organization_memberships",
+                "events",
+                "event_participants",
+            },
+        )
+
+    def test_primary_and_foreign_keys_use_postgresql_uuid(self) -> None:
+        for table in Base.metadata.tables.values():
+            self.assertIsInstance(table.c.id.type, UUID)
+            for foreign_key in table.foreign_keys:
+                self.assertIsInstance(foreign_key.parent.type, UUID)
+
+    def test_required_unique_constraints_and_indexes_exist(self) -> None:
+        expected_names = {
+            "uq_locations_simulation_code",
+            "uq_agents_simulation_id_id",
+            "uq_agents_active_user_persona",
+            "uq_agent_states_agent_id",
+            "uq_relationships_pair",
+            "uq_organizations_simulation_type_name",
+            "uq_organizations_simulation_id_id",
+            "uq_organization_memberships_active",
+            "uq_event_participants_event_agent",
+            "idx_agents_simulation_id",
+            "idx_agents_runtime_active",
+            "idx_agent_memories_agent_occurred",
+            "idx_agent_memories_cleanup",
+            "idx_relationships_source_updated",
+            "idx_events_simulation_started",
+            "idx_organizations_simulation_id",
+        }
+        actual_names = {
+            item.name
+            for table in Base.metadata.tables.values()
+            for item in (*table.constraints, *table.indexes)
+            if item.name
+        }
+        self.assertTrue(expected_names <= actual_names)
+
+    def test_cross_simulation_references_use_composite_foreign_keys(self) -> None:
+        expected_targets = {
+            "agent_states": {"agents", "locations"},
+            "relationships": {"agents"},
+            "organization_memberships": {"agents", "organizations"},
+            "events": {"locations"},
+        }
+        for table_name, target_names in expected_targets.items():
+            table = Base.metadata.tables[table_name]
+            composite_targets = {
+                constraint.referred_table.name
+                for constraint in table.foreign_key_constraints
+                if len(constraint.elements) == 2
+            }
+            self.assertEqual(composite_targets, target_names)
+
+    def test_memory_cleanup_order_has_created_tick(self) -> None:
+        created_tick = Base.metadata.tables["agent_memories"].c.created_tick
+        self.assertFalse(created_tick.nullable)
+        self.assertEqual(created_tick.type.python_type, int)
+
+    def test_embedding_column_is_deferred_until_dimension_is_decided(self) -> None:
+        self.assertNotIn("embedding", Base.metadata.tables["agent_memories"].c)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 작업 개요

ERD를 기반으로 PostgreSQL DB 스키마 v1과 초기 Alembic migration을 구성했습니다.

SQLAlchemy 도메인 모델과 migration을 함께 작성하고, 시뮬레이션 경계를 보장하는 복합 FK 및 주요 제약조건과 인덱스를 반영했습니다.

## 관련 Issue

Closes #32

## 변경 내용

- ERD 기반 SQLAlchemy 모델 10종 추가
  - simulations
  - locations
  - agents
  - agent_states
  - agent_memories
  - relationships
  - organizations
  - organization_memberships
  - events
  - event_participants
- Alembic 초기 설정 및 DB 스키마 v1 migration 추가
- PostgreSQL UUID, JSONB 및 pgvector extension 적용
- PK, FK, UNIQUE, CHECK 제약조건과 조회용 인덱스 반영
- agent_states에 simulation_id를 추가하고 Agent·Location 복합 FK 적용
- agent_memories에 created_tick 및 Memory 정리용 인덱스 추가
- migration 실행을 위해 backend Docker 이미지와 의존성 설정 보완
- 스키마 메타데이터 검증 테스트 추가

## 결정 사항 및 이유

시뮬레이션 간 데이터가 잘못 연결되지 않도록 `agent_states`에서 다음 복합 FK를 사용했습니다.

- `(simulation_id, agent_id) → agents(simulation_id, id)`
- `(simulation_id, location_id) → locations(simulation_id, id)`

Memory 최대 10개 정책의 동점 삭제 기준에는 `created_at` 대신 `created_tick`을 사용했습니다. 현실 시간이 아닌 시뮬레이션 Tick을 기준으로 생성 순서를 판단하여 시뮬레이션의 재현성과 삭제 순서의 결정성을 유지하기 위함입니다.

Memory 삭제 로직 자체는 유즈케이스에 해당하므로 이번 DB migration에는 포함하지 않고, 추후 Memory 저장 서비스에서 구현하도록 스키마와 인덱스만 준비했습니다.

Embedding 차원은 아직 확정되지 않아 vector 컬럼 정의는 보류했으며, 이번 migration에서는 pgvector extension만 활성화했습니다.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [ ] 관련 문서 업데이트 확인

확인한 내용:

- SQLAlchemy 모델 테스트 6개 통과
- 임시 PostgreSQL에서 `alembic upgrade head` 성공
- 복합 FK, NOT NULL 및 인덱스 생성 확인
- `alembic check` 기준 모델과 migration 간 차이 없음
- `alembic downgrade base` 성공
- rollback 후 도메인 테이블과 vector extension 제거 확인
- Docker Compose 설정 검증 및 Python 문법 검사 통과

## AI 사용 여부

사용 여부: 사용함

사용한 작업:
- ERD 기반 SQLAlchemy 모델 및 Alembic migration 작성
- 제약조건과 인덱스 검토
- 모델·migration 정합성 테스트 작성
- 실제 PostgreSQL upgrade/downgrade 검증

사람이 검토한 내용:
- agent_states의 시뮬레이션 경계 복합 FK 적용 승인
- Memory 최대 10개 삭제 정책 확인
- Memory 동점 정렬 기준을 created_tick으로 적용하는 결정
- ERD와 구현 간 차이 및 문서 수정 필요사항 확인

## 리뷰어가 봐야 할 부분

- agent_states의 복합 FK가 시뮬레이션 경계를 올바르게 보장하는지
- agent_memories.created_tick 타입과 삭제 정렬용 인덱스가 정책에 적합한지
- ERD의 제약조건과 SQLAlchemy 모델 및 Alembic migration이 일치하는지
- 아직 차원이 확정되지 않은 embedding 컬럼을 보류한 범위가 적절한지