### PR TITLE
[Feature] Slice 1 Tick Engine 코어 구현

### DIFF
--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -2,7 +2,15 @@ from fastapi import APIRouter
 
 from app.api.auth import router as auth_router
 from app.api.simulations import router as simulations_router
+from app.api.ticks import make_tick_router
+from app.simulation.tick_engine import TickEngine
 
 api_router = APIRouter()
 api_router.include_router(auth_router)
 api_router.include_router(simulations_router)
+
+# TODO: PR #39 연결 후 실제 runtime 콜백으로 교체
+async def _stub_runtime(agents, event, snapshot):  # type: ignore[no-untyped-def]
+    return {}
+
+api_router.include_router(make_tick_router(TickEngine(runtime=_stub_runtime)))

--- a/backend/app/api/ticks.py
+++ b/backend/app/api/ticks.py
@@ -1,0 +1,82 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.simulation.tick_engine import (
+    Agent,
+    AgentType,
+    Event,
+    TickConflictError,
+    TickEngine,
+    TickResult,
+    TickRollbackError,
+    WorldSnapshot,
+)
+
+
+class AgentIn(BaseModel):
+    id: str
+    agent_type: AgentType
+    is_active: bool
+
+
+class EventIn(BaseModel):
+    id: str
+    event_type: str
+    participant_ids: list[str]
+
+
+class SnapshotIn(BaseModel):
+    simulation_id: str
+    current_tick: int
+
+
+class TickRequest(BaseModel):
+    agents: list[AgentIn]
+    event: EventIn
+    snapshot: SnapshotIn
+
+
+class TickResponse(BaseModel):
+    status: str
+    participant_ids: list[str]
+    runtime_outputs: dict[str, dict]
+
+
+def make_tick_router(engine: TickEngine) -> APIRouter:
+    router = APIRouter(tags=["ticks"])
+
+    @router.post(
+        "/simulations/{simulation_id}/tick",
+        response_model=TickResponse,
+    )
+    async def run_tick(simulation_id: str, body: TickRequest) -> TickResponse:
+        agents = [
+            Agent(id=a.id, agent_type=a.agent_type, is_active=a.is_active)
+            for a in body.agents
+        ]
+        event = Event(
+            id=body.event.id,
+            event_type=body.event.event_type,
+            participant_ids=set(body.event.participant_ids),
+        )
+        snapshot = WorldSnapshot(
+            simulation_id=body.snapshot.simulation_id,
+            current_tick=body.snapshot.current_tick,
+        )
+
+        try:
+            result: TickResult = await engine.run_tick(
+                agents=agents, event=event, snapshot=snapshot
+            )
+        except TickConflictError as exc:
+            raise HTTPException(status_code=409, detail="Tick is already running") from exc
+        except TickRollbackError as exc:
+            raise HTTPException(status_code=500, detail="Tick rolled back due to runtime failure") from exc
+
+        return TickResponse(
+            status=result.status,
+            participant_ids=result.participant_ids,
+            runtime_outputs=result.runtime_outputs,
+        )
+
+    return router

--- a/backend/app/api/ticks.py
+++ b/backend/app/api/ticks.py
@@ -1,42 +1,22 @@
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from uuid import UUID
 
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import require_user_role
+from app.domain.models import User
+from app.services.simulations import require_owned_simulation
 from app.simulation.tick_engine import (
-    AgentType,
-    TickAgent,
     TickConflictError,
     TickEngine,
-    TickEvent,
     TickResult,
     TickRollbackError,
-    WorldSnapshot,
 )
 
 
-class AgentIn(BaseModel):
-    id: str
-    agent_type: AgentType
-    is_active: bool
-
-
-class EventIn(BaseModel):
-    id: str
-    event_type: str
-    participant_ids: list[str]
-
-
-class SnapshotIn(BaseModel):
-    simulation_id: str
-    current_tick: int
-
-
-class TickRequest(BaseModel):
-    agents: list[AgentIn]
-    event: EventIn
-    snapshot: SnapshotIn
-
-
-class TickResponse(BaseModel):
+class TickAdvanceResponse(BaseModel):
     status: str
     participant_ids: list[str]
     runtime_outputs: dict[str, dict]
@@ -46,35 +26,29 @@ def make_tick_router(engine: TickEngine) -> APIRouter:
     router = APIRouter(tags=["ticks"])
 
     @router.post(
-        "/tick/{simulation_id}/run",
-        response_model=TickResponse,
+        "/simulations/{simulation_id}/ticks/advance",
+        response_model=TickAdvanceResponse,
     )
-    async def run_tick(simulation_id: str, body: TickRequest) -> TickResponse:
-        agents = [
-            TickAgent(id=a.id, agent_type=a.agent_type, is_active=a.is_active)
-            for a in body.agents
-        ]
-        event = TickEvent(
-            id=body.event.id,
-            event_type=body.event.event_type,
-            participant_ids=set(body.event.participant_ids),
-        )
-        snapshot = WorldSnapshot(
-            simulation_id=body.snapshot.simulation_id,
-            current_tick=body.snapshot.current_tick,
-        )
+    async def advance_tick(
+        simulation_id: UUID,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(require_user_role),
+    ) -> TickAdvanceResponse:
+        require_owned_simulation(db, simulation_id, current_user)
 
+        # TODO: PR #39 연결 후 DB에서 agents, events 조회 및 TickEngine 호출
         try:
             result: TickResult = await engine.run_tick(
-                agents=agents, event=event, snapshot=snapshot
+                agents=[],
+                event=None,  # type: ignore[arg-type]
+                snapshot=None,  # type: ignore[arg-type]
             )
         except TickConflictError as exc:
             raise HTTPException(status_code=409, detail="Tick is already running") from exc
         except TickRollbackError as exc:
             raise HTTPException(status_code=500, detail="Tick rolled back due to runtime failure") from exc
-        # TODO: 전체 에러 핸들링 리팩 시 RuntimeExecutionError 외 예외(코드 버그 등) 처리 추가
 
-        return TickResponse(
+        return TickAdvanceResponse(
             status=result.status,
             participant_ids=result.participant_ids,
             runtime_outputs=result.runtime_outputs,

--- a/backend/app/api/ticks.py
+++ b/backend/app/api/ticks.py
@@ -2,11 +2,11 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from app.simulation.tick_engine import (
-    Agent,
     AgentType,
-    Event,
+    TickAgent,
     TickConflictError,
     TickEngine,
+    TickEvent,
     TickResult,
     TickRollbackError,
     WorldSnapshot,
@@ -51,10 +51,10 @@ def make_tick_router(engine: TickEngine) -> APIRouter:
     )
     async def run_tick(simulation_id: str, body: TickRequest) -> TickResponse:
         agents = [
-            Agent(id=a.id, agent_type=a.agent_type, is_active=a.is_active)
+            TickAgent(id=a.id, agent_type=a.agent_type, is_active=a.is_active)
             for a in body.agents
         ]
-        event = Event(
+        event = TickEvent(
             id=body.event.id,
             event_type=body.event.event_type,
             participant_ids=set(body.event.participant_ids),

--- a/backend/app/api/ticks.py
+++ b/backend/app/api/ticks.py
@@ -72,6 +72,7 @@ def make_tick_router(engine: TickEngine) -> APIRouter:
             raise HTTPException(status_code=409, detail="Tick is already running") from exc
         except TickRollbackError as exc:
             raise HTTPException(status_code=500, detail="Tick rolled back due to runtime failure") from exc
+        # TODO: 전체 에러 핸들링 리팩 시 RuntimeExecutionError 외 예외(코드 버그 등) 처리 추가
 
         return TickResponse(
             status=result.status,

--- a/backend/app/api/ticks.py
+++ b/backend/app/api/ticks.py
@@ -46,7 +46,7 @@ def make_tick_router(engine: TickEngine) -> APIRouter:
     router = APIRouter(tags=["ticks"])
 
     @router.post(
-        "/simulations/{simulation_id}/tick",
+        "/tick/{simulation_id}/run",
         response_model=TickResponse,
     )
     async def run_tick(simulation_id: str, body: TickRequest) -> TickResponse:

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -9,14 +9,14 @@ class AgentType(str, Enum):
 
 
 @dataclass
-class Agent:
+class TickAgent:
     id: str
     agent_type: AgentType
     is_active: bool
 
 
 @dataclass
-class Event:
+class TickEvent:
     id: str
     event_type: str
     participant_ids: set[str]
@@ -69,8 +69,8 @@ class TickEngine:
 
     async def run_tick(
         self,
-        agents: list[Agent],
-        event: Event,
+        agents: list[TickAgent],
+        event: TickEvent,
         snapshot: WorldSnapshot,
     ) -> TickResult:
         if self._running:
@@ -108,7 +108,7 @@ class TickEngine:
         finally:
             self._running = False
 
-    def _select_participants(self, agents: list[Agent], event: Event) -> list[Agent]:
+    def _select_participants(self, agents: list[TickAgent], event: TickEvent) -> list[TickAgent]:
         result = []
         for agent in agents:
             if not agent.is_active:

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -29,6 +29,22 @@ class WorldSnapshot:
     data: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass
+class PolicyInput:
+    """Runtime 결과를 Policy로 전달하는 단위"""
+    agent_id: str
+    event_id: str
+    runtime_result: dict[str, Any]
+
+
+@dataclass
+class TickResult:
+    """Tick 실행 결과"""
+    status: str  # "completed" | "failed"
+    participant_ids: list[str]
+    runtime_outputs: dict[str, dict[str, Any]]
+
+
 class TickConflictError(Exception):
     """Tick이 이미 실행 중일 때 발생"""
 
@@ -38,11 +54,17 @@ class TickRollbackError(Exception):
 
 
 AgentRuntimeFn = Callable[..., Coroutine[Any, Any, dict]]
+PolicyFn = Callable[[list[PolicyInput]], Coroutine[Any, Any, None]]
 
 
 class TickEngine:
-    def __init__(self, runtime: AgentRuntimeFn) -> None:
+    def __init__(
+        self,
+        runtime: AgentRuntimeFn,
+        policy: PolicyFn | None = None,
+    ) -> None:
         self._runtime = runtime
+        self._policy = policy
         self._running = False
 
     async def run_tick(
@@ -50,18 +72,35 @@ class TickEngine:
         agents: list[Agent],
         event: Event,
         snapshot: WorldSnapshot,
-    ) -> list[dict]:
+    ) -> TickResult:
         if self._running:
             raise TickConflictError("Tick is already running")
 
         self._running = True
         try:
             participants = self._select_participants(agents, event)
-            results = []
+            runtime_outputs: dict[str, dict] = {}
+
             for agent in participants:
                 result = await self._runtime(agent=agent, event=event, snapshot=snapshot)
-                results.append(result)
-            return results
+                runtime_outputs[agent.id] = result
+
+            if self._policy and runtime_outputs:
+                policy_inputs = [
+                    PolicyInput(
+                        agent_id=agent_id,
+                        event_id=event.id,
+                        runtime_result=output,
+                    )
+                    for agent_id, output in runtime_outputs.items()
+                ]
+                await self._policy(policy_inputs)
+
+            return TickResult(
+                status="completed",
+                participant_ids=[a.id for a in participants],
+                runtime_outputs=runtime_outputs,
+            )
         except TickConflictError:
             raise
         except Exception as exc:
@@ -74,11 +113,7 @@ class TickEngine:
         for agent in agents:
             if not agent.is_active:
                 continue
-            # Professor는 해당 Event 참여자 목록에 있을 때만 실행
-            if agent.agent_type == AgentType.PROFESSOR and agent.id not in event.participant_ids:
-                continue
-            # Student는 Event 참여자 목록에 있을 때만 실행
-            if agent.agent_type == AgentType.STUDENT and agent.id not in event.participant_ids:
+            if agent.id not in event.participant_ids:
                 continue
             result.append(agent)
         return result

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -57,7 +57,11 @@ class TickRollbackError(Exception):
     """RuntimeExecutionError로 Tick 전체가 rollback될 때 발생"""
 
 
-AgentRuntimeFn = Callable[..., Coroutine[Any, Any, dict]]
+# (agents, event, snapshot) → {agent_id: result} batch 방식 1회 호출
+AgentRuntimeFn = Callable[
+    [list[TickAgent], TickEvent, WorldSnapshot],
+    Coroutine[Any, Any, dict[str, Any]],
+]
 PolicyFn = Callable[[list[PolicyInput]], Coroutine[Any, Any, None]]
 
 
@@ -69,6 +73,7 @@ class TickEngine:
     ) -> None:
         self._runtime = runtime
         self._policy = policy
+        # TODO: PR #60 연결 후 DB 기반 상태 전이로 교체
         self._running = False
 
     async def run_tick(
@@ -76,18 +81,21 @@ class TickEngine:
         agents: list[TickAgent],
         event: TickEvent,
         snapshot: WorldSnapshot,
+        *,
+        schedule_requires_professor: bool = False,
     ) -> TickResult:
         if self._running:
             raise TickConflictError("Tick is already running")
 
         self._running = True
         try:
-            participants = self._select_participants(agents, event)
-            runtime_outputs: dict[str, dict] = {}
+            participants = self._select_participants(
+                agents, event, schedule_requires_professor=schedule_requires_professor
+            )
+            runtime_outputs: dict[str, Any] = {}
 
-            for agent in participants:
-                result = await self._runtime(agent=agent, event=event, snapshot=snapshot)
-                runtime_outputs[agent.id] = result
+            if participants:
+                runtime_outputs = await self._runtime(participants, event, snapshot)
 
             if self._policy and runtime_outputs:
                 policy_inputs = [
@@ -112,12 +120,22 @@ class TickEngine:
         finally:
             self._running = False
 
-    def _select_participants(self, agents: list[TickAgent], event: TickEvent) -> list[TickAgent]:
+    def _select_participants(
+        self,
+        agents: list[TickAgent],
+        event: TickEvent,
+        *,
+        schedule_requires_professor: bool = False,
+    ) -> list[TickAgent]:
+        """
+        실행 대상 선정. is_active 여부와 무관하게 선정하고 Runtime에 전달.
+        비활성 Agent는 Runtime이 LLM 호출 없이 SKIPPED 결과를 반환.
+        """
         result = []
         for agent in agents:
-            if not agent.is_active:
-                continue
-            if agent.id not in event.participant_ids:
-                continue
-            result.append(agent)
+            if agent.agent_type == AgentType.STUDENT:
+                result.append(agent)
+            elif agent.agent_type == AgentType.PROFESSOR:
+                if schedule_requires_professor or agent.id in event.participant_ids:
+                    result.append(agent)
         return result

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -49,8 +49,12 @@ class TickConflictError(Exception):
     """Tick이 이미 실행 중일 때 발생"""
 
 
+class RuntimeExecutionError(Exception):
+    """Runtime 콜백의 예상된 실패 (타임아웃, LLM 오류 등)"""
+
+
 class TickRollbackError(Exception):
-    """Runtime 실패로 Tick 전체가 rollback될 때 발생"""
+    """RuntimeExecutionError로 Tick 전체가 rollback될 때 발생"""
 
 
 AgentRuntimeFn = Callable[..., Coroutine[Any, Any, dict]]
@@ -103,7 +107,7 @@ class TickEngine:
             )
         except TickConflictError:
             raise
-        except Exception as exc:
+        except RuntimeExecutionError as exc:
             raise TickRollbackError("Tick rolled back due to runtime failure") from exc
         finally:
             self._running = False

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Coroutine
+
+
+class AgentType(str, Enum):
+    STUDENT = "student"
+    PROFESSOR = "professor"
+
+
+@dataclass
+class Agent:
+    id: str
+    agent_type: AgentType
+    is_active: bool
+
+
+@dataclass
+class Event:
+    id: str
+    event_type: str
+    participant_ids: set[str]
+
+
+@dataclass
+class WorldSnapshot:
+    simulation_id: str
+    current_tick: int
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+class TickConflictError(Exception):
+    """Tick이 이미 실행 중일 때 발생"""
+
+
+class TickRollbackError(Exception):
+    """Runtime 실패로 Tick 전체가 rollback될 때 발생"""
+
+
+AgentRuntimeFn = Callable[..., Coroutine[Any, Any, dict]]
+
+
+class TickEngine:
+    def __init__(self, runtime: AgentRuntimeFn) -> None:
+        self._runtime = runtime
+        self._running = False
+
+    async def run_tick(
+        self,
+        agents: list[Agent],
+        event: Event,
+        snapshot: WorldSnapshot,
+    ) -> list[dict]:
+        if self._running:
+            raise TickConflictError("Tick is already running")
+
+        self._running = True
+        try:
+            participants = self._select_participants(agents, event)
+            results = []
+            for agent in participants:
+                result = await self._runtime(agent=agent, event=event, snapshot=snapshot)
+                results.append(result)
+            return results
+        except TickConflictError:
+            raise
+        except Exception as exc:
+            raise TickRollbackError("Tick rolled back due to runtime failure") from exc
+        finally:
+            self._running = False
+
+    def _select_participants(self, agents: list[Agent], event: Event) -> list[Agent]:
+        result = []
+        for agent in agents:
+            if not agent.is_active:
+                continue
+            # Professor는 해당 Event 참여자 목록에 있을 때만 실행
+            if agent.agent_type == AgentType.PROFESSOR and agent.id not in event.participant_ids:
+                continue
+            # Student는 Event 참여자 목록에 있을 때만 실행
+            if agent.agent_type == AgentType.STUDENT and agent.id not in event.participant_ids:
+                continue
+            result.append(agent)
+        return result

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.0.0
+pytest-asyncio>=0.24.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# 테스트 환경에서 Settings 초기화에 필요한 최소 환경 변수
+os.environ.setdefault("JWT_SECRET", "test-secret-key-minimum-32-characters-long")

--- a/backend/tests/test_slice0_acceptance.py
+++ b/backend/tests/test_slice0_acceptance.py
@@ -7,9 +7,9 @@ Tick Engine이 6-Agent roster를 올바르게 수신·처리할 수 있는지를
 import pytest
 
 from app.simulation.tick_engine import (
-    Agent,
+    TickAgent,
     AgentType,
-    Event,
+    TickEvent,
     TickEngine,
     WorldSnapshot,
 )
@@ -22,18 +22,18 @@ TOTAL_AGENT_COUNT = STUDENT_COUNT + PROFESSOR_COUNT
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
 
-def initial_roster() -> list[Agent]:
+def initial_roster() -> list[TickAgent]:
     """Slice 0 seed 후 기대하는 6-Agent roster (mock)"""
     students = [
-        Agent(id=f"student-0{i}", agent_type=AgentType.STUDENT, is_active=True)
+        TickAgent(id=f"student-0{i}", agent_type=AgentType.STUDENT, is_active=True)
         for i in range(1, STUDENT_COUNT + 1)
     ]
-    professor = Agent(id="professor-01", agent_type=AgentType.PROFESSOR, is_active=True)
+    professor = TickAgent(id="professor-01", agent_type=AgentType.PROFESSOR, is_active=True)
     return students + [professor]
 
 
-def class_event(participant_ids: set[str]) -> Event:
-    return Event(id="evt-class-1", event_type="class", participant_ids=participant_ids)
+def class_event(participant_ids: set[str]) -> TickEvent:
+    return TickEvent(id="evt-class-1", event_type="class", participant_ids=participant_ids)
 
 
 def initial_snapshot() -> WorldSnapshot:

--- a/backend/tests/test_slice0_acceptance.py
+++ b/backend/tests/test_slice0_acceptance.py
@@ -4,13 +4,15 @@ Slice 0 인수 조건 — 은혜님 파트 (Tick Engine 진입 조건)
 지유님(통합 Owner)의 Slice 0 구현 완료 후 이 테스트들이 전부 통과해야 한다.
 Tick Engine이 6-Agent roster를 올바르게 수신·처리할 수 있는지를 검증한다.
 """
+import asyncio
 import pytest
 
 from app.simulation.tick_engine import (
-    TickAgent,
     AgentType,
-    TickEvent,
+    TickAgent,
+    TickConflictError,
     TickEngine,
+    TickEvent,
     WorldSnapshot,
 )
 
@@ -67,12 +69,12 @@ def test_all_agents_active_at_simulation_start():
 
 
 async def test_tick_engine_runs_all_students_in_class_event():
-    """수업 Event에서 Student 5명 전원이 Runtime을 실행한다"""
+    """수업 Event에서 Student 5명 전원이 Runtime batch에 포함된다"""
     called_ids: list[str] = []
 
-    async def runtime(agent, event, snapshot):
-        called_ids.append(agent.id)
-        return {"intent": "attend"}
+    async def runtime(agents, event, snapshot):
+        called_ids.extend(a.id for a in agents)
+        return {a.id: {"intent": "attend"} for a in agents}
 
     roster = initial_roster()
     student_ids = {a.id for a in roster if a.agent_type == AgentType.STUDENT}
@@ -86,15 +88,14 @@ async def test_tick_engine_runs_all_students_in_class_event():
 
 
 async def test_professor_not_called_when_not_in_class_event():
-    """Professor가 수업 Event 참여자가 아닐 때 Runtime을 호출하지 않는다"""
-    called_types: list[AgentType] = []
+    """Professor가 수업 Event 참여자가 아닐 때 Runtime batch에 포함되지 않는다"""
+    received_types: list[AgentType] = []
 
-    async def runtime(agent, event, snapshot):
-        called_types.append(agent.agent_type)
-        return {"intent": "attend"}
+    async def runtime(agents, event, snapshot):
+        received_types.extend(a.agent_type for a in agents)
+        return {a.id: {"intent": "attend"} for a in agents}
 
     roster = initial_roster()
-    # Professor를 제외한 Student만 참여자로 지정
     student_ids = {a.id for a in roster if a.agent_type == AgentType.STUDENT}
     event = class_event(participant_ids=student_ids)
 
@@ -102,16 +103,16 @@ async def test_professor_not_called_when_not_in_class_event():
         agents=roster, event=event, snapshot=initial_snapshot()
     )
 
-    assert AgentType.PROFESSOR not in called_types
+    assert AgentType.PROFESSOR not in received_types
 
 
 async def test_professor_called_when_in_class_event():
-    """Professor가 수업 Event 참여자일 때 Runtime을 실행한다"""
-    called_types: list[AgentType] = []
+    """Professor가 수업 Event 참여자일 때 Runtime batch에 포함된다"""
+    received_types: list[AgentType] = []
 
-    async def runtime(agent, event, snapshot):
-        called_types.append(agent.agent_type)
-        return {"intent": "lecture"}
+    async def runtime(agents, event, snapshot):
+        received_types.extend(a.agent_type for a in agents)
+        return {a.id: {"intent": "lecture"} for a in agents}
 
     roster = initial_roster()
     all_ids = {a.id for a in roster}
@@ -121,17 +122,17 @@ async def test_professor_called_when_in_class_event():
         agents=roster, event=event, snapshot=initial_snapshot()
     )
 
-    assert AgentType.PROFESSOR in called_types
-    assert called_types.count(AgentType.PROFESSOR) == 1
+    assert AgentType.PROFESSOR in received_types
+    assert received_types.count(AgentType.PROFESSOR) == 1
 
 
 async def test_same_snapshot_delivered_to_all_participants():
-    """모든 참여 Agent가 동일한 WorldSnapshot을 전달받는다"""
-    received: list[WorldSnapshot] = []
+    """Runtime batch 호출 시 모든 참여 Agent에게 동일한 WorldSnapshot이 전달된다"""
+    received_snapshot: list[WorldSnapshot] = []
 
-    async def runtime(agent, event, snapshot):
-        received.append(snapshot)
-        return {"intent": "attend"}
+    async def runtime(agents, event, snapshot):
+        received_snapshot.append(snapshot)
+        return {a.id: {"intent": "attend"} for a in agents}
 
     roster = initial_roster()
     all_ids = {a.id for a in roster}
@@ -142,18 +143,16 @@ async def test_same_snapshot_delivered_to_all_participants():
         agents=roster, event=event, snapshot=snapshot
     )
 
-    assert len(received) == TOTAL_AGENT_COUNT
-    assert all(s is snapshot for s in received)
+    # batch 방식에서 snapshot은 1회 전달되며 원본과 동일해야 한다
+    assert len(received_snapshot) == 1
+    assert received_snapshot[0] is snapshot
 
 
 async def test_tick_engine_rejects_second_tick_while_running():
     """Tick 실행 중 두 번째 Tick 요청을 거부한다 (중복 실행 방지)"""
-    import asyncio
-    from app.simulation.tick_engine import TickConflictError
-
-    async def slow_runtime(agent, event, snapshot):
+    async def slow_runtime(agents, event, snapshot):
         await asyncio.sleep(0.05)
-        return {"intent": "attend"}
+        return {a.id: {"intent": "attend"} for a in agents}
 
     engine = TickEngine(runtime=slow_runtime)
     roster = initial_roster()

--- a/backend/tests/test_slice0_acceptance.py
+++ b/backend/tests/test_slice0_acceptance.py
@@ -1,0 +1,172 @@
+"""
+Slice 0 인수 조건 — 은혜님 파트 (Tick Engine 진입 조건)
+
+지유님(통합 Owner)의 Slice 0 구현 완료 후 이 테스트들이 전부 통과해야 한다.
+Tick Engine이 6-Agent roster를 올바르게 수신·처리할 수 있는지를 검증한다.
+"""
+import pytest
+
+from app.simulation.tick_engine import (
+    Agent,
+    AgentType,
+    Event,
+    TickEngine,
+    WorldSnapshot,
+)
+
+STUDENT_COUNT = 5
+PROFESSOR_COUNT = 1
+TOTAL_AGENT_COUNT = STUDENT_COUNT + PROFESSOR_COUNT
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+def initial_roster() -> list[Agent]:
+    """Slice 0 seed 후 기대하는 6-Agent roster (mock)"""
+    students = [
+        Agent(id=f"student-0{i}", agent_type=AgentType.STUDENT, is_active=True)
+        for i in range(1, STUDENT_COUNT + 1)
+    ]
+    professor = Agent(id="professor-01", agent_type=AgentType.PROFESSOR, is_active=True)
+    return students + [professor]
+
+
+def class_event(participant_ids: set[str]) -> Event:
+    return Event(id="evt-class-1", event_type="class", participant_ids=participant_ids)
+
+
+def initial_snapshot() -> WorldSnapshot:
+    return WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
+
+
+# ── Agent roster 계약 ─────────────────────────────────────────────────────────
+
+
+def test_roster_has_5_students():
+    roster = initial_roster()
+    students = [a for a in roster if a.agent_type == AgentType.STUDENT]
+    assert len(students) == STUDENT_COUNT
+
+
+def test_roster_has_1_professor():
+    roster = initial_roster()
+    professors = [a for a in roster if a.agent_type == AgentType.PROFESSOR]
+    assert len(professors) == PROFESSOR_COUNT
+
+
+def test_roster_total_is_6():
+    assert len(initial_roster()) == TOTAL_AGENT_COUNT
+
+
+def test_all_agents_active_at_simulation_start():
+    assert all(a.is_active for a in initial_roster())
+
+
+# ── Tick Engine 진입 조건 ─────────────────────────────────────────────────────
+
+
+async def test_tick_engine_runs_all_students_in_class_event():
+    """수업 Event에서 Student 5명 전원이 Runtime을 실행한다"""
+    called_ids: list[str] = []
+
+    async def runtime(agent, event, snapshot):
+        called_ids.append(agent.id)
+        return {"intent": "attend"}
+
+    roster = initial_roster()
+    student_ids = {a.id for a in roster if a.agent_type == AgentType.STUDENT}
+    event = class_event(participant_ids=student_ids)
+
+    await TickEngine(runtime=runtime).run_tick(
+        agents=roster, event=event, snapshot=initial_snapshot()
+    )
+
+    assert len(called_ids) == STUDENT_COUNT
+
+
+async def test_professor_not_called_when_not_in_class_event():
+    """Professor가 수업 Event 참여자가 아닐 때 Runtime을 호출하지 않는다"""
+    called_types: list[AgentType] = []
+
+    async def runtime(agent, event, snapshot):
+        called_types.append(agent.agent_type)
+        return {"intent": "attend"}
+
+    roster = initial_roster()
+    # Professor를 제외한 Student만 참여자로 지정
+    student_ids = {a.id for a in roster if a.agent_type == AgentType.STUDENT}
+    event = class_event(participant_ids=student_ids)
+
+    await TickEngine(runtime=runtime).run_tick(
+        agents=roster, event=event, snapshot=initial_snapshot()
+    )
+
+    assert AgentType.PROFESSOR not in called_types
+
+
+async def test_professor_called_when_in_class_event():
+    """Professor가 수업 Event 참여자일 때 Runtime을 실행한다"""
+    called_types: list[AgentType] = []
+
+    async def runtime(agent, event, snapshot):
+        called_types.append(agent.agent_type)
+        return {"intent": "lecture"}
+
+    roster = initial_roster()
+    all_ids = {a.id for a in roster}
+    event = class_event(participant_ids=all_ids)
+
+    await TickEngine(runtime=runtime).run_tick(
+        agents=roster, event=event, snapshot=initial_snapshot()
+    )
+
+    assert AgentType.PROFESSOR in called_types
+    assert called_types.count(AgentType.PROFESSOR) == 1
+
+
+async def test_same_snapshot_delivered_to_all_participants():
+    """모든 참여 Agent가 동일한 WorldSnapshot을 전달받는다"""
+    received: list[WorldSnapshot] = []
+
+    async def runtime(agent, event, snapshot):
+        received.append(snapshot)
+        return {"intent": "attend"}
+
+    roster = initial_roster()
+    all_ids = {a.id for a in roster}
+    event = class_event(participant_ids=all_ids)
+    snapshot = initial_snapshot()
+
+    await TickEngine(runtime=runtime).run_tick(
+        agents=roster, event=event, snapshot=snapshot
+    )
+
+    assert len(received) == TOTAL_AGENT_COUNT
+    assert all(s is snapshot for s in received)
+
+
+async def test_tick_engine_rejects_second_tick_while_running():
+    """Tick 실행 중 두 번째 Tick 요청을 거부한다 (중복 실행 방지)"""
+    import asyncio
+    from app.simulation.tick_engine import TickConflictError
+
+    async def slow_runtime(agent, event, snapshot):
+        await asyncio.sleep(0.05)
+        return {"intent": "attend"}
+
+    engine = TickEngine(runtime=slow_runtime)
+    roster = initial_roster()
+    student_ids = {a.id for a in roster if a.agent_type == AgentType.STUDENT}
+    event = class_event(participant_ids=student_ids)
+    snapshot = initial_snapshot()
+
+    first = asyncio.create_task(
+        engine.run_tick(agents=roster, event=event, snapshot=snapshot)
+    )
+    await asyncio.sleep(0)
+
+    with pytest.raises(TickConflictError):
+        await engine.run_tick(agents=roster, event=event, snapshot=snapshot)
+
+    await first

--- a/backend/tests/test_slice1_acceptance.py
+++ b/backend/tests/test_slice1_acceptance.py
@@ -1,0 +1,213 @@
+"""
+Slice 1 인수 조건 — 은혜님 파트 (Tick·Event 흐름)
+
+완료 기준:
+- 수동 Tick 실행 시 활성 Student 1명이 Runtime을 실행한다.
+- Professor는 관련 Event가 있을 때만 Runtime을 실행한다.
+- Runtime 결과가 Policy로 정확히 전달된다.
+- Runtime 최종 실패 시 Tick 전체가 rollback된다.
+- Tick 완료 후 TickResult에 참여 Agent ID와 Runtime 결과가 담긴다.
+"""
+import pytest
+
+from app.simulation.tick_engine import (
+    Agent,
+    AgentType,
+    Event,
+    PolicyInput,
+    TickConflictError,
+    TickEngine,
+    TickResult,
+    TickRollbackError,
+    WorldSnapshot,
+)
+
+
+def student(sid: str) -> Agent:
+    return Agent(id=sid, agent_type=AgentType.STUDENT, is_active=True)
+
+
+def professor(pid: str) -> Agent:
+    return Agent(id=pid, agent_type=AgentType.PROFESSOR, is_active=True)
+
+
+def class_event(*participant_ids: str) -> Event:
+    return Event(id="evt-1", event_type="class", participant_ids=set(participant_ids))
+
+
+def snapshot() -> WorldSnapshot:
+    return WorldSnapshot(simulation_id="sim-1", current_tick=1, data={})
+
+
+# ── Runtime 결과 → Policy 전달 ────────────────────────────────────────────────
+
+
+async def test_runtime_result_passed_to_policy():
+    """Runtime 결과가 PolicyInput에 담겨 Policy 콜백으로 전달된다"""
+    policy_inputs: list[PolicyInput] = []
+
+    async def runtime(agent, event, snapshot):
+        return {"intent": "study", "reaction": {"trust": +5}}
+
+    async def policy(inputs: list[PolicyInput]) -> None:
+        policy_inputs.extend(inputs)
+
+    s1 = student("s-1")
+    event = class_event("s-1")
+
+    await TickEngine(runtime=runtime, policy=policy).run_tick(
+        agents=[s1], event=event, snapshot=snapshot()
+    )
+
+    assert len(policy_inputs) == 1
+    assert policy_inputs[0].agent_id == "s-1"
+    assert policy_inputs[0].runtime_result == {"intent": "study", "reaction": {"trust": +5}}
+
+
+async def test_all_participants_results_passed_to_policy():
+    """참여 Agent 전원의 Runtime 결과가 Policy에 한꺼번에 전달된다"""
+    received: list[PolicyInput] = []
+
+    async def runtime(agent, event, snapshot):
+        return {"intent": "attend"}
+
+    async def policy(inputs: list[PolicyInput]) -> None:
+        received.extend(inputs)
+
+    agents = [student("s-1"), student("s-2"), professor("p-1")]
+    event = class_event("s-1", "s-2", "p-1")
+
+    await TickEngine(runtime=runtime, policy=policy).run_tick(
+        agents=agents, event=event, snapshot=snapshot()
+    )
+
+    assert len(received) == 3
+    assert {p.agent_id for p in received} == {"s-1", "s-2", "p-1"}
+
+
+async def test_policy_receives_event_context():
+    """Policy 입력에 Event 정보가 포함된다"""
+    received: list[PolicyInput] = []
+
+    async def runtime(agent, event, snapshot):
+        return {"intent": "study"}
+
+    async def policy(inputs: list[PolicyInput]) -> None:
+        received.extend(inputs)
+
+    s1 = student("s-1")
+    event = class_event("s-1")
+
+    await TickEngine(runtime=runtime, policy=policy).run_tick(
+        agents=[s1], event=event, snapshot=snapshot()
+    )
+
+    assert received[0].event_id == "evt-1"
+
+
+# ── TickResult ────────────────────────────────────────────────────────────────
+
+
+async def test_tick_result_contains_participant_ids():
+    """TickResult에 실제 Runtime이 실행된 Agent ID 목록이 담긴다"""
+
+    async def runtime(agent, event, snapshot):
+        return {"intent": "study"}
+
+    agents = [student("s-1"), student("s-2"), professor("p-1")]
+    # Professor는 참여자 아님
+    event = class_event("s-1", "s-2")
+
+    result: TickResult = await TickEngine(runtime=runtime).run_tick(
+        agents=agents, event=event, snapshot=snapshot()
+    )
+
+    assert set(result.participant_ids) == {"s-1", "s-2"}
+
+
+async def test_tick_result_contains_runtime_outputs():
+    """TickResult에 각 Agent의 Runtime 결과가 담긴다"""
+
+    async def runtime(agent, event, snapshot):
+        return {"intent": f"action-{agent.id}"}
+
+    agents = [student("s-1"), student("s-2")]
+    event = class_event("s-1", "s-2")
+
+    result: TickResult = await TickEngine(runtime=runtime).run_tick(
+        agents=agents, event=event, snapshot=snapshot()
+    )
+
+    assert result.runtime_outputs["s-1"] == {"intent": "action-s-1"}
+    assert result.runtime_outputs["s-2"] == {"intent": "action-s-2"}
+
+
+async def test_tick_result_skipped_agents_not_in_participants():
+    """비활성 Agent는 TickResult participant_ids에 포함되지 않는다"""
+
+    async def runtime(agent, event, snapshot):
+        return {"intent": "study"}
+
+    active = student("s-active")
+    inactive = Agent(id="s-inactive", agent_type=AgentType.STUDENT, is_active=False)
+    event = class_event("s-active", "s-inactive")
+
+    result: TickResult = await TickEngine(runtime=runtime).run_tick(
+        agents=[active, inactive], event=event, snapshot=snapshot()
+    )
+
+    assert "s-inactive" not in result.participant_ids
+    assert "s-active" in result.participant_ids
+
+
+# ── Tick 상태 전이 ────────────────────────────────────────────────────────────
+
+
+async def test_tick_state_transitions_on_success():
+    """Tick 완료 후 TickResult status가 completed다"""
+
+    async def runtime(agent, event, snapshot):
+        return {"intent": "study"}
+
+    s1 = student("s-1")
+    event = class_event("s-1")
+
+    result: TickResult = await TickEngine(runtime=runtime).run_tick(
+        agents=[s1], event=event, snapshot=snapshot()
+    )
+
+    assert result.status == "completed"
+
+
+async def test_tick_state_is_failed_on_rollback():
+    """Runtime 실패로 rollback 시 TickRollbackError가 발생한다"""
+
+    async def failing_runtime(agent, event, snapshot):
+        raise RuntimeError("timeout")
+
+    s1 = student("s-1")
+    event = class_event("s-1")
+
+    with pytest.raises(TickRollbackError):
+        await TickEngine(runtime=failing_runtime).run_tick(
+            agents=[s1], event=event, snapshot=snapshot()
+        )
+
+
+async def test_no_participants_tick_completes_with_empty_result():
+    """참여 Agent가 없으면 빈 결과로 완료된다"""
+
+    async def runtime(agent, event, snapshot):
+        return {"intent": "study"}
+
+    # 모든 Agent가 Event 참여자가 아닌 경우
+    s1 = student("s-1")
+    event = class_event()  # 참여자 없음
+
+    result: TickResult = await TickEngine(runtime=runtime).run_tick(
+        agents=[s1], event=event, snapshot=snapshot()
+    )
+
+    assert result.status == "completed"
+    assert result.participant_ids == []
+    assert result.runtime_outputs == {}

--- a/backend/tests/test_slice1_acceptance.py
+++ b/backend/tests/test_slice1_acceptance.py
@@ -19,6 +19,7 @@ from app.simulation.tick_engine import (
     TickEngine,
     TickResult,
     TickRollbackError,
+    RuntimeExecutionError,
     WorldSnapshot,
 )
 
@@ -183,7 +184,7 @@ async def test_tick_state_is_failed_on_rollback():
     """Runtime 실패로 rollback 시 TickRollbackError가 발생한다"""
 
     async def failing_runtime(agent, event, snapshot):
-        raise RuntimeError("timeout")
+        raise RuntimeExecutionError("timeout")
 
     s1 = student("s-1")
     event = class_event("s-1")

--- a/backend/tests/test_slice1_acceptance.py
+++ b/backend/tests/test_slice1_acceptance.py
@@ -2,34 +2,35 @@
 Slice 1 인수 조건 — 은혜님 파트 (Tick·Event 흐름)
 
 완료 기준:
-- 수동 Tick 실행 시 활성 Student 1명이 Runtime을 실행한다.
-- Professor는 관련 Event가 있을 때만 Runtime을 실행한다.
+- 수동 Tick 실행 시 Student가 Runtime batch에 포함된다.
+- Professor는 관련 Event가 있거나 schedule이 요구할 때만 Runtime에 포함된다.
 - Runtime 결과가 Policy로 정확히 전달된다.
 - Runtime 최종 실패 시 Tick 전체가 rollback된다.
 - Tick 완료 후 TickResult에 참여 Agent ID와 Runtime 결과가 담긴다.
+- 비활성 Agent도 Runtime batch에 포함되며 SKIPPED 결과가 저장된다.
 """
 import pytest
 
 from app.simulation.tick_engine import (
-    TickAgent,
     AgentType,
-    TickEvent,
     PolicyInput,
+    RuntimeExecutionError,
+    TickAgent,
     TickConflictError,
     TickEngine,
     TickResult,
     TickRollbackError,
-    RuntimeExecutionError,
     WorldSnapshot,
+    TickEvent,
 )
 
 
-def student(sid: str) -> TickAgent:
-    return TickAgent(id=sid, agent_type=AgentType.STUDENT, is_active=True)
+def student(sid: str, *, is_active: bool = True) -> TickAgent:
+    return TickAgent(id=sid, agent_type=AgentType.STUDENT, is_active=is_active)
 
 
-def professor(pid: str) -> TickAgent:
-    return TickAgent(id=pid, agent_type=AgentType.PROFESSOR, is_active=True)
+def professor(pid: str, *, is_active: bool = True) -> TickAgent:
+    return TickAgent(id=pid, agent_type=AgentType.PROFESSOR, is_active=is_active)
 
 
 def class_event(*participant_ids: str) -> TickEvent:
@@ -47,8 +48,8 @@ async def test_runtime_result_passed_to_policy():
     """Runtime 결과가 PolicyInput에 담겨 Policy 콜백으로 전달된다"""
     policy_inputs: list[PolicyInput] = []
 
-    async def runtime(agent, event, snapshot):
-        return {"intent": "study", "reaction": {"trust": +5}}
+    async def runtime(agents, event, snap):
+        return {a.id: {"intent": "study", "reaction": {"trust": +5}} for a in agents}
 
     async def policy(inputs: list[PolicyInput]) -> None:
         policy_inputs.extend(inputs)
@@ -69,29 +70,29 @@ async def test_all_participants_results_passed_to_policy():
     """참여 Agent 전원의 Runtime 결과가 Policy에 한꺼번에 전달된다"""
     received: list[PolicyInput] = []
 
-    async def runtime(agent, event, snapshot):
-        return {"intent": "attend"}
+    async def runtime(agents, event, snap):
+        return {a.id: {"intent": "attend"} for a in agents}
 
     async def policy(inputs: list[PolicyInput]) -> None:
         received.extend(inputs)
 
-    agents = [student("s-1"), student("s-2"), professor("p-1")]
-    event = class_event("s-1", "s-2", "p-1")
+    agents = [student("s-1"), professor("p-1")]
+    event = class_event("s-1", "p-1")
 
     await TickEngine(runtime=runtime, policy=policy).run_tick(
         agents=agents, event=event, snapshot=snapshot()
     )
 
-    assert len(received) == 3
-    assert {p.agent_id for p in received} == {"s-1", "s-2", "p-1"}
+    assert len(received) == 2
+    assert {p.agent_id for p in received} == {"s-1", "p-1"}
 
 
 async def test_policy_receives_event_context():
     """Policy 입력에 Event 정보가 포함된다"""
     received: list[PolicyInput] = []
 
-    async def runtime(agent, event, snapshot):
-        return {"intent": "study"}
+    async def runtime(agents, event, snap):
+        return {a.id: {"intent": "study"} for a in agents}
 
     async def policy(inputs: list[PolicyInput]) -> None:
         received.extend(inputs)
@@ -110,27 +111,28 @@ async def test_policy_receives_event_context():
 
 
 async def test_tick_result_contains_participant_ids():
-    """TickResult에 실제 Runtime이 실행된 Agent ID 목록이 담긴다"""
+    """TickResult에 Runtime batch에 전달된 Agent ID 목록이 담긴다"""
 
-    async def runtime(agent, event, snapshot):
-        return {"intent": "study"}
+    async def runtime(agents, event, snap):
+        return {a.id: {"intent": "study"} for a in agents}
 
-    agents = [student("s-1"), student("s-2"), professor("p-1")]
-    # Professor는 참여자 아님
-    event = class_event("s-1", "s-2")
+    # Student는 모두 포함, Professor는 Event 미참여 시 제외
+    agents = [student("s-1"), professor("p-1")]
+    event = class_event("s-1")
 
     result: TickResult = await TickEngine(runtime=runtime).run_tick(
         agents=agents, event=event, snapshot=snapshot()
     )
 
-    assert set(result.participant_ids) == {"s-1", "s-2"}
+    assert "s-1" in result.participant_ids
+    assert "p-1" not in result.participant_ids
 
 
 async def test_tick_result_contains_runtime_outputs():
     """TickResult에 각 Agent의 Runtime 결과가 담긴다"""
 
-    async def runtime(agent, event, snapshot):
-        return {"intent": f"action-{agent.id}"}
+    async def runtime(agents, event, snap):
+        return {a.id: {"intent": f"action-{a.id}"} for a in agents}
 
     agents = [student("s-1"), student("s-2")]
     event = class_event("s-1", "s-2")
@@ -143,22 +145,37 @@ async def test_tick_result_contains_runtime_outputs():
     assert result.runtime_outputs["s-2"] == {"intent": "action-s-2"}
 
 
-async def test_tick_result_skipped_agents_not_in_participants():
-    """비활성 Agent는 TickResult participant_ids에 포함되지 않는다"""
+async def test_inactive_agent_in_runtime_batch_with_skipped_result():
+    """비활성 Agent도 Runtime batch에 포함되며 SKIPPED 결과가 저장된다"""
 
-    async def runtime(agent, event, snapshot):
-        return {"intent": "study"}
+    llm_call_count = 0
+
+    async def runtime(agents, event, snap):
+        result = {}
+        for a in agents:
+            if not a.is_active:
+                result[a.id] = {"status": "SKIPPED"}
+            else:
+                nonlocal llm_call_count
+                llm_call_count += 1
+                result[a.id] = {"intent": "study"}
+        return result
 
     active = student("s-active")
-    inactive = TickAgent(id="s-inactive", agent_type=AgentType.STUDENT, is_active=False)
+    inactive = student("s-inactive", is_active=False)
     event = class_event("s-active", "s-inactive")
 
     result: TickResult = await TickEngine(runtime=runtime).run_tick(
         agents=[active, inactive], event=event, snapshot=snapshot()
     )
 
-    assert "s-inactive" not in result.participant_ids
+    # 비활성 Agent도 participant_ids에 포함
+    assert "s-inactive" in result.participant_ids
     assert "s-active" in result.participant_ids
+    # SKIPPED 결과가 runtime_outputs에 포함
+    assert result.runtime_outputs["s-inactive"] == {"status": "SKIPPED"}
+    # LLM 호출은 활성 Agent에만
+    assert llm_call_count == 1
 
 
 # ── Tick 상태 전이 ────────────────────────────────────────────────────────────
@@ -167,8 +184,8 @@ async def test_tick_result_skipped_agents_not_in_participants():
 async def test_tick_state_transitions_on_success():
     """Tick 완료 후 TickResult status가 completed다"""
 
-    async def runtime(agent, event, snapshot):
-        return {"intent": "study"}
+    async def runtime(agents, event, snap):
+        return {a.id: {"intent": "study"} for a in agents}
 
     s1 = student("s-1")
     event = class_event("s-1")
@@ -183,7 +200,7 @@ async def test_tick_state_transitions_on_success():
 async def test_tick_state_is_failed_on_rollback():
     """Runtime 실패로 rollback 시 TickRollbackError가 발생한다"""
 
-    async def failing_runtime(agent, event, snapshot):
+    async def failing_runtime(agents, event, snap):
         raise RuntimeExecutionError("timeout")
 
     s1 = student("s-1")
@@ -198,15 +215,15 @@ async def test_tick_state_is_failed_on_rollback():
 async def test_no_participants_tick_completes_with_empty_result():
     """참여 Agent가 없으면 빈 결과로 완료된다"""
 
-    async def runtime(agent, event, snapshot):
-        return {"intent": "study"}
+    async def runtime(agents, event, snap):
+        return {}
 
-    # 모든 Agent가 Event 참여자가 아닌 경우
-    s1 = student("s-1")
-    event = class_event()  # 참여자 없음
+    # Professor만 있고 Event 미참여, schedule_requires_professor=False
+    p1 = professor("p-1")
+    event = class_event()
 
     result: TickResult = await TickEngine(runtime=runtime).run_tick(
-        agents=[s1], event=event, snapshot=snapshot()
+        agents=[p1], event=event, snapshot=snapshot()
     )
 
     assert result.status == "completed"

--- a/backend/tests/test_slice1_acceptance.py
+++ b/backend/tests/test_slice1_acceptance.py
@@ -11,9 +11,9 @@ Slice 1 인수 조건 — 은혜님 파트 (Tick·Event 흐름)
 import pytest
 
 from app.simulation.tick_engine import (
-    Agent,
+    TickAgent,
     AgentType,
-    Event,
+    TickEvent,
     PolicyInput,
     TickConflictError,
     TickEngine,
@@ -23,16 +23,16 @@ from app.simulation.tick_engine import (
 )
 
 
-def student(sid: str) -> Agent:
-    return Agent(id=sid, agent_type=AgentType.STUDENT, is_active=True)
+def student(sid: str) -> TickAgent:
+    return TickAgent(id=sid, agent_type=AgentType.STUDENT, is_active=True)
 
 
-def professor(pid: str) -> Agent:
-    return Agent(id=pid, agent_type=AgentType.PROFESSOR, is_active=True)
+def professor(pid: str) -> TickAgent:
+    return TickAgent(id=pid, agent_type=AgentType.PROFESSOR, is_active=True)
 
 
-def class_event(*participant_ids: str) -> Event:
-    return Event(id="evt-1", event_type="class", participant_ids=set(participant_ids))
+def class_event(*participant_ids: str) -> TickEvent:
+    return TickEvent(id="evt-1", event_type="class", participant_ids=set(participant_ids))
 
 
 def snapshot() -> WorldSnapshot:
@@ -149,7 +149,7 @@ async def test_tick_result_skipped_agents_not_in_participants():
         return {"intent": "study"}
 
     active = student("s-active")
-    inactive = Agent(id="s-inactive", agent_type=AgentType.STUDENT, is_active=False)
+    inactive = TickAgent(id="s-inactive", agent_type=AgentType.STUDENT, is_active=False)
     event = class_event("s-active", "s-inactive")
 
     result: TickResult = await TickEngine(runtime=runtime).run_tick(

--- a/backend/tests/test_tick_api.py
+++ b/backend/tests/test_tick_api.py
@@ -1,7 +1,7 @@
 """
 Tick API 엔드포인트 테스트
 
-POST /v1/simulations/{simulation_id}/tick
+POST /v1/tick/{simulationId}/run
 
 DB 연결 없이 TickEngine 의존성 주입으로 검증한다.
 """
@@ -42,7 +42,7 @@ def make_engine(runtime=None) -> TickEngine:
 
 def test_tick_returns_200_on_success():
     client = TestClient(make_test_app(make_engine()))
-    response = client.post("/v1/simulations/sim-1/tick", json={
+    response = client.post("/v1/tick/sim-1/run", json={
         "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
         "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
         "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
@@ -52,7 +52,7 @@ def test_tick_returns_200_on_success():
 
 def test_tick_response_contains_participant_ids():
     client = TestClient(make_test_app(make_engine()))
-    response = client.post("/v1/simulations/sim-1/tick", json={
+    response = client.post("/v1/tick/sim-1/run", json={
         "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
         "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
         "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
@@ -64,7 +64,7 @@ def test_tick_response_contains_participant_ids():
 
 def test_tick_with_professor_not_in_event_excludes_professor():
     client = TestClient(make_test_app(make_engine()))
-    response = client.post("/v1/simulations/sim-1/tick", json={
+    response = client.post("/v1/tick/sim-1/run", json={
         "agents": [
             {"id": "s-1", "agent_type": "student", "is_active": True},
             {"id": "p-1", "agent_type": "professor", "is_active": True},
@@ -97,7 +97,7 @@ def test_duplicate_tick_returns_409():
     engine._running = True
 
     client = TestClient(make_test_app(engine))
-    response = client.post("/v1/simulations/sim-1/tick", json={
+    response = client.post("/v1/tick/sim-1/run", json={
         "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
         "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
         "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
@@ -113,7 +113,7 @@ def test_runtime_failure_returns_500():
         raise RuntimeError("LLM timeout")
 
     client = TestClient(make_test_app(make_engine(runtime=failing_runtime)))
-    response = client.post("/v1/simulations/sim-1/tick", json={
+    response = client.post("/v1/tick/sim-1/run", json={
         "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
         "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
         "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
@@ -126,7 +126,7 @@ def test_runtime_failure_returns_500():
 
 def test_invalid_agent_type_returns_422():
     client = TestClient(make_test_app(make_engine()))
-    response = client.post("/v1/simulations/sim-1/tick", json={
+    response = client.post("/v1/tick/sim-1/run", json={
         "agents": [{"id": "x-1", "agent_type": "unknown", "is_active": True}],
         "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["x-1"]},
         "snapshot": {"simulation_id": "sim-1", "current_tick": 0},

--- a/backend/tests/test_tick_api.py
+++ b/backend/tests/test_tick_api.py
@@ -16,6 +16,7 @@ from app.simulation.tick_engine import (
     TickConflictError,
     TickEngine,
     TickResult,
+    RuntimeExecutionError,
     WorldSnapshot,
 )
 
@@ -110,7 +111,7 @@ def test_duplicate_tick_returns_409():
 
 def test_runtime_failure_returns_500():
     async def failing_runtime(agent, event, snapshot):
-        raise RuntimeError("LLM timeout")
+        raise RuntimeExecutionError("LLM timeout")
 
     client = TestClient(make_test_app(make_engine(runtime=failing_runtime)))
     response = client.post("/v1/tick/sim-1/run", json={

--- a/backend/tests/test_tick_api.py
+++ b/backend/tests/test_tick_api.py
@@ -1,0 +1,134 @@
+"""
+Tick API 엔드포인트 테스트
+
+POST /v1/simulations/{simulation_id}/tick
+
+DB 연결 없이 TickEngine 의존성 주입으로 검증한다.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.simulation.tick_engine import (
+    Agent,
+    AgentType,
+    Event,
+    TickConflictError,
+    TickEngine,
+    TickResult,
+    WorldSnapshot,
+)
+
+
+# ── 테스트용 앱 픽스처 ──────────────────────────────────────────────────────────
+
+
+def make_test_app(engine: TickEngine) -> FastAPI:
+    from app.api.ticks import make_tick_router
+    app = FastAPI()
+    app.include_router(make_tick_router(engine), prefix="/v1")
+    return app
+
+
+def make_engine(runtime=None) -> TickEngine:
+    async def default_runtime(agent, event, snapshot):
+        return {"intent": "study"}
+
+    return TickEngine(runtime=runtime or default_runtime)
+
+
+# ── 정상 케이스 ───────────────────────────────────────────────────────────────
+
+
+def test_tick_returns_200_on_success():
+    client = TestClient(make_test_app(make_engine()))
+    response = client.post("/v1/simulations/sim-1/tick", json={
+        "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
+        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
+        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
+    })
+    assert response.status_code == 200
+
+
+def test_tick_response_contains_participant_ids():
+    client = TestClient(make_test_app(make_engine()))
+    response = client.post("/v1/simulations/sim-1/tick", json={
+        "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
+        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
+        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
+    })
+    body = response.json()
+    assert body["status"] == "completed"
+    assert "s-1" in body["participant_ids"]
+
+
+def test_tick_with_professor_not_in_event_excludes_professor():
+    client = TestClient(make_test_app(make_engine()))
+    response = client.post("/v1/simulations/sim-1/tick", json={
+        "agents": [
+            {"id": "s-1", "agent_type": "student", "is_active": True},
+            {"id": "p-1", "agent_type": "professor", "is_active": True},
+        ],
+        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
+        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
+    })
+    body = response.json()
+    assert "s-1" in body["participant_ids"]
+    assert "p-1" not in body["participant_ids"]
+
+
+# ── 중복 Tick → 409 ───────────────────────────────────────────────────────────
+
+
+def test_duplicate_tick_returns_409():
+    import asyncio
+
+    call_count = 0
+
+    async def slow_runtime(agent, event, snapshot):
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.1)
+        return {"intent": "study"}
+
+    engine = make_engine(runtime=slow_runtime)
+
+    # 엔진을 이미 실행 중 상태로 만든다
+    engine._running = True
+
+    client = TestClient(make_test_app(engine))
+    response = client.post("/v1/simulations/sim-1/tick", json={
+        "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
+        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
+        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
+    })
+    assert response.status_code == 409
+
+
+# ── Runtime 실패 → 500 ────────────────────────────────────────────────────────
+
+
+def test_runtime_failure_returns_500():
+    async def failing_runtime(agent, event, snapshot):
+        raise RuntimeError("LLM timeout")
+
+    client = TestClient(make_test_app(make_engine(runtime=failing_runtime)))
+    response = client.post("/v1/simulations/sim-1/tick", json={
+        "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
+        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
+        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
+    })
+    assert response.status_code == 500
+
+
+# ── 입력 검증 ─────────────────────────────────────────────────────────────────
+
+
+def test_invalid_agent_type_returns_422():
+    client = TestClient(make_test_app(make_engine()))
+    response = client.post("/v1/simulations/sim-1/tick", json={
+        "agents": [{"id": "x-1", "agent_type": "unknown", "is_active": True}],
+        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["x-1"]},
+        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
+    })
+    assert response.status_code == 422

--- a/backend/tests/test_tick_api.py
+++ b/backend/tests/test_tick_api.py
@@ -10,9 +10,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.simulation.tick_engine import (
-    Agent,
+    TickAgent,
     AgentType,
-    Event,
+    TickEvent,
     TickConflictError,
     TickEngine,
     TickResult,

--- a/backend/tests/test_tick_api.py
+++ b/backend/tests/test_tick_api.py
@@ -1,39 +1,39 @@
 """
 Tick API 엔드포인트 테스트
 
-POST /v1/tick/{simulationId}/run
+POST /v1/simulations/{simulation_id}/ticks/advance
 
-DB 연결 없이 TickEngine 의존성 주입으로 검증한다.
+DB·인증 의존성은 mock으로 대체하고 TickEngine DI로 핵심 동작을 검증한다.
 """
+from unittest.mock import MagicMock, patch
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.simulation.tick_engine import (
-    TickAgent,
-    AgentType,
-    TickEvent,
-    TickConflictError,
-    TickEngine,
-    TickResult,
     RuntimeExecutionError,
-    WorldSnapshot,
+    TickEngine,
 )
 
-
-# ── 테스트용 앱 픽스처 ──────────────────────────────────────────────────────────
+SIM_ID = "00000000-0000-0000-0000-000000000001"
 
 
 def make_test_app(engine: TickEngine) -> FastAPI:
     from app.api.ticks import make_tick_router
+    from app.core.database import get_db
+    from app.core.security import require_user_role
+
     app = FastAPI()
     app.include_router(make_tick_router(engine), prefix="/v1")
+    app.dependency_overrides[get_db] = lambda: MagicMock()
+    app.dependency_overrides[require_user_role] = lambda: MagicMock()
     return app
 
 
 def make_engine(runtime=None) -> TickEngine:
-    async def default_runtime(agent, event, snapshot):
-        return {"intent": "study"}
+    async def default_runtime(agents, event, snapshot):
+        return {a.id: {"intent": "study"} for a in agents}
 
     return TickEngine(runtime=runtime or default_runtime)
 
@@ -41,95 +41,42 @@ def make_engine(runtime=None) -> TickEngine:
 # ── 정상 케이스 ───────────────────────────────────────────────────────────────
 
 
-def test_tick_returns_200_on_success():
+@patch("app.api.ticks.require_owned_simulation")
+def test_tick_returns_200_on_success(mock_require):
     client = TestClient(make_test_app(make_engine()))
-    response = client.post("/v1/tick/sim-1/run", json={
-        "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
-        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
-        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
-    })
+    response = client.post(f"/v1/simulations/{SIM_ID}/ticks/advance")
     assert response.status_code == 200
 
 
-def test_tick_response_contains_participant_ids():
+@patch("app.api.ticks.require_owned_simulation")
+def test_tick_response_shape(mock_require):
     client = TestClient(make_test_app(make_engine()))
-    response = client.post("/v1/tick/sim-1/run", json={
-        "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
-        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
-        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
-    })
+    response = client.post(f"/v1/simulations/{SIM_ID}/ticks/advance")
     body = response.json()
-    assert body["status"] == "completed"
-    assert "s-1" in body["participant_ids"]
-
-
-def test_tick_with_professor_not_in_event_excludes_professor():
-    client = TestClient(make_test_app(make_engine()))
-    response = client.post("/v1/tick/sim-1/run", json={
-        "agents": [
-            {"id": "s-1", "agent_type": "student", "is_active": True},
-            {"id": "p-1", "agent_type": "professor", "is_active": True},
-        ],
-        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
-        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
-    })
-    body = response.json()
-    assert "s-1" in body["participant_ids"]
-    assert "p-1" not in body["participant_ids"]
+    assert "status" in body
+    assert "participant_ids" in body
+    assert "runtime_outputs" in body
 
 
 # ── 중복 Tick → 409 ───────────────────────────────────────────────────────────
 
 
-def test_duplicate_tick_returns_409():
-    import asyncio
-
-    call_count = 0
-
-    async def slow_runtime(agent, event, snapshot):
-        nonlocal call_count
-        call_count += 1
-        await asyncio.sleep(0.1)
-        return {"intent": "study"}
-
-    engine = make_engine(runtime=slow_runtime)
-
-    # 엔진을 이미 실행 중 상태로 만든다
-    engine._running = True
+@patch("app.api.ticks.require_owned_simulation")
+def test_duplicate_tick_returns_409(mock_require):
+    # TODO: PR #60 연결 후 실제 동시 요청 또는 transaction 경계 검증으로 교체
+    engine = make_engine()
+    engine._running = True  # type: ignore[attr-defined]
 
     client = TestClient(make_test_app(engine))
-    response = client.post("/v1/tick/sim-1/run", json={
-        "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
-        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
-        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
-    })
+    response = client.post(f"/v1/simulations/{SIM_ID}/ticks/advance")
     assert response.status_code == 409
-
-
-# ── Runtime 실패 → 500 ────────────────────────────────────────────────────────
-
-
-def test_runtime_failure_returns_500():
-    async def failing_runtime(agent, event, snapshot):
-        raise RuntimeExecutionError("LLM timeout")
-
-    client = TestClient(make_test_app(make_engine(runtime=failing_runtime)))
-    response = client.post("/v1/tick/sim-1/run", json={
-        "agents": [{"id": "s-1", "agent_type": "student", "is_active": True}],
-        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["s-1"]},
-        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
-    })
-    assert response.status_code == 500
 
 
 # ── 입력 검증 ─────────────────────────────────────────────────────────────────
 
 
-def test_invalid_agent_type_returns_422():
+@patch("app.api.ticks.require_owned_simulation")
+def test_invalid_simulation_id_returns_422(mock_require):
     client = TestClient(make_test_app(make_engine()))
-    response = client.post("/v1/tick/sim-1/run", json={
-        "agents": [{"id": "x-1", "agent_type": "unknown", "is_active": True}],
-        "event": {"id": "evt-1", "event_type": "class", "participant_ids": ["x-1"]},
-        "snapshot": {"simulation_id": "sim-1", "current_tick": 0},
-    })
+    response = client.post("/v1/simulations/not-a-uuid/ticks/advance")
     assert response.status_code == 422

--- a/backend/tests/test_tick_engine.py
+++ b/backend/tests/test_tick_engine.py
@@ -3,23 +3,23 @@ import pytest
 from unittest.mock import AsyncMock
 
 from app.simulation.tick_engine import (
-    TickEngine,
-    TickConflictError,
-    TickRollbackError,
+    AgentType,
     RuntimeExecutionError,
     TickAgent,
-    AgentType,
+    TickConflictError,
+    TickEngine,
     TickEvent,
+    TickRollbackError,
     WorldSnapshot,
 )
 
 
-def make_student(agent_id: str) -> TickAgent:
-    return TickAgent(id=agent_id, agent_type=AgentType.STUDENT, is_active=True)
+def make_student(agent_id: str, *, is_active: bool = True) -> TickAgent:
+    return TickAgent(id=agent_id, agent_type=AgentType.STUDENT, is_active=is_active)
 
 
-def make_professor(agent_id: str) -> TickAgent:
-    return TickAgent(id=agent_id, agent_type=AgentType.PROFESSOR, is_active=True)
+def make_professor(agent_id: str, *, is_active: bool = True) -> TickAgent:
+    return TickAgent(id=agent_id, agent_type=AgentType.PROFESSOR, is_active=is_active)
 
 
 def make_event(participant_ids: list[str]) -> TickEvent:
@@ -30,28 +30,29 @@ def make_snapshot() -> WorldSnapshot:
     return WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
 
 
-# ── RED ──────────────────────────────────────────────────────────────────────
+# ── Runtime batch 호출 ────────────────────────────────────────────────────────
 
 
 async def test_tick_runs_student_runtime():
-    runtime = AsyncMock(return_value={"intent": "study"})
+    """Student가 있으면 Runtime batch가 1회 호출된다"""
+    student = make_student("s-1")
+    runtime = AsyncMock(return_value={"s-1": {"intent": "study"}})
     engine = TickEngine(runtime=runtime)
 
-    student = make_student("s-1")
     event = make_event(participant_ids=["s-1"])
     snapshot = make_snapshot()
 
     await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
 
-    runtime.assert_awaited_once_with(agent=student, event=event, snapshot=snapshot)
+    runtime.assert_awaited_once_with([student], event, snapshot)
 
 
 async def test_professor_runs_only_when_in_event():
-    runtime = AsyncMock(return_value={"intent": "lecture"})
+    """Professor가 Event 참여자가 아니고 schedule_requires_professor=False면 Runtime 미호출"""
+    runtime = AsyncMock(return_value={})
     engine = TickEngine(runtime=runtime)
 
     professor = make_professor("p-1")
-    # Professor가 Event 참여자 목록에 없는 경우
     event = make_event(participant_ids=["s-1"])
     snapshot = make_snapshot()
 
@@ -61,10 +62,11 @@ async def test_professor_runs_only_when_in_event():
 
 
 async def test_professor_runs_when_in_event():
-    runtime = AsyncMock(return_value={"intent": "lecture"})
+    """Professor가 Event 참여자면 Runtime batch 호출된다"""
+    professor = make_professor("p-1")
+    runtime = AsyncMock(return_value={"p-1": {"intent": "lecture"}})
     engine = TickEngine(runtime=runtime)
 
-    professor = make_professor("p-1")
     event = make_event(participant_ids=["p-1"])
     snapshot = make_snapshot()
 
@@ -73,10 +75,48 @@ async def test_professor_runs_when_in_event():
     runtime.assert_awaited_once()
 
 
+async def test_professor_runs_when_schedule_requires():
+    """schedule_requires_professor=True면 Event 미참여 Professor도 Runtime batch 호출된다"""
+    professor = make_professor("p-1")
+    runtime = AsyncMock(return_value={"p-1": {"intent": "lecture"}})
+    engine = TickEngine(runtime=runtime)
+
+    event = make_event(participant_ids=[])
+    snapshot = make_snapshot()
+
+    await engine.run_tick(
+        agents=[professor], event=event, snapshot=snapshot, schedule_requires_professor=True
+    )
+
+    runtime.assert_awaited_once()
+
+
+# ── 비활성 Agent 처리 ─────────────────────────────────────────────────────────
+
+
+async def test_inactive_student_in_runtime_batch():
+    """비활성 Student도 Runtime batch에 포함된다 (Runtime이 SKIPPED 결과를 반환)"""
+    inactive_student = make_student("s-inactive", is_active=False)
+    runtime = AsyncMock(return_value={"s-inactive": {"status": "SKIPPED"}})
+    engine = TickEngine(runtime=runtime)
+
+    event = make_event(["s-inactive"])
+    snapshot = make_snapshot()
+
+    result = await engine.run_tick(agents=[inactive_student], event=event, snapshot=snapshot)
+
+    runtime.assert_awaited_once()
+    assert "s-inactive" in result.participant_ids
+    assert result.runtime_outputs["s-inactive"] == {"status": "SKIPPED"}
+
+
+# ── 중복 Tick 방지 ────────────────────────────────────────────────────────────
+
+
 async def test_duplicate_tick_raises_conflict():
-    async def slow_runtime(**kwargs):
+    async def slow_runtime(agents, event, snapshot):
         await asyncio.sleep(0.05)
-        return {"intent": "study"}
+        return {a.id: {"intent": "study"} for a in agents}
 
     engine = TickEngine(runtime=slow_runtime)
     student = make_student("s-1")
@@ -86,7 +126,6 @@ async def test_duplicate_tick_raises_conflict():
     first = asyncio.create_task(
         engine.run_tick(agents=[student], event=event, snapshot=snapshot)
     )
-    # 첫 Tick이 시작된 직후 두 번째 요청
     await asyncio.sleep(0)
 
     with pytest.raises(TickConflictError):
@@ -95,8 +134,11 @@ async def test_duplicate_tick_raises_conflict():
     await first
 
 
+# ── Rollback ──────────────────────────────────────────────────────────────────
+
+
 async def test_runtime_failure_triggers_rollback():
-    async def failing_runtime(**kwargs):
+    async def failing_runtime(agents, event, snapshot):
         raise RuntimeExecutionError("LLM timeout")
 
     engine = TickEngine(runtime=failing_runtime)
@@ -109,7 +151,7 @@ async def test_runtime_failure_triggers_rollback():
 
 
 async def test_tick_unlocks_after_completion():
-    runtime = AsyncMock(return_value={"intent": "study"})
+    runtime = AsyncMock(return_value={"s-1": {"intent": "study"}})
     engine = TickEngine(runtime=runtime)
 
     student = make_student("s-1")
@@ -117,7 +159,6 @@ async def test_tick_unlocks_after_completion():
     snapshot = make_snapshot()
 
     await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
-    # 완료 후 두 번째 Tick이 정상 실행돼야 한다
     await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
 
     assert runtime.await_count == 2
@@ -126,12 +167,12 @@ async def test_tick_unlocks_after_completion():
 async def test_tick_unlocks_after_failure():
     call_count = 0
 
-    async def sometimes_failing(**kwargs):
+    async def sometimes_failing(agents, event, snapshot):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             raise RuntimeExecutionError("first call fails")
-        return {"intent": "study"}
+        return {a.id: {"intent": "study"} for a in agents}
 
     engine = TickEngine(runtime=sometimes_failing)
     student = make_student("s-1")
@@ -141,14 +182,13 @@ async def test_tick_unlocks_after_failure():
     with pytest.raises(TickRollbackError):
         await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
 
-    # 실패 후에도 lock이 해제돼 두 번째 Tick이 실행돼야 한다
     await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
     assert call_count == 2
 
 
 async def test_code_bug_propagates_without_wrapping():
     """RuntimeExecutionError가 아닌 예외(코드 버그)는 TickRollbackError로 감싸지 않고 propagate한다"""
-    async def buggy_runtime(**kwargs):
+    async def buggy_runtime(agents, event, snapshot):
         raise TypeError("unexpected argument")
 
     engine = TickEngine(runtime=buggy_runtime)
@@ -164,12 +204,12 @@ async def test_tick_unlocks_after_code_bug():
     """코드 버그로 Tick이 실패해도 lock이 해제된다"""
     call_count = 0
 
-    async def buggy_then_ok(**kwargs):
+    async def buggy_then_ok(agents, event, snapshot):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             raise TypeError("bug")
-        return {"intent": "study"}
+        return {a.id: {"intent": "study"} for a in agents}
 
     engine = TickEngine(runtime=buggy_then_ok)
     student = make_student("s-1")
@@ -181,34 +221,3 @@ async def test_tick_unlocks_after_code_bug():
 
     await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
     assert call_count == 2
-
-
-async def test_inactive_agent_skipped():
-    runtime = AsyncMock(return_value={"intent": "study"})
-    engine = TickEngine(runtime=runtime)
-
-    inactive_student = TickAgent(id="s-inactive", agent_type=AgentType.STUDENT, is_active=False)
-    event = make_event(["s-inactive"])
-    snapshot = make_snapshot()
-
-    await engine.run_tick(agents=[inactive_student], event=event, snapshot=snapshot)
-
-    runtime.assert_not_awaited()
-
-
-async def test_same_snapshot_passed_to_all_agents():
-    received_snapshots: list[WorldSnapshot] = []
-
-    async def capturing_runtime(agent, event, snapshot):
-        received_snapshots.append(snapshot)
-        return {"intent": "study"}
-
-    engine = TickEngine(runtime=capturing_runtime)
-    agents = [make_student("s-1"), make_student("s-2")]
-    event = make_event(["s-1", "s-2"])
-    snapshot = make_snapshot()
-
-    await engine.run_tick(agents=agents, event=event, snapshot=snapshot)
-
-    assert len(received_snapshots) == 2
-    assert received_snapshots[0] is received_snapshots[1]

--- a/backend/tests/test_tick_engine.py
+++ b/backend/tests/test_tick_engine.py
@@ -6,23 +6,23 @@ from app.simulation.tick_engine import (
     TickEngine,
     TickConflictError,
     TickRollbackError,
-    Agent,
+    TickAgent,
     AgentType,
-    Event,
+    TickEvent,
     WorldSnapshot,
 )
 
 
-def make_student(agent_id: str) -> Agent:
-    return Agent(id=agent_id, agent_type=AgentType.STUDENT, is_active=True)
+def make_student(agent_id: str) -> TickAgent:
+    return TickAgent(id=agent_id, agent_type=AgentType.STUDENT, is_active=True)
 
 
-def make_professor(agent_id: str) -> Agent:
-    return Agent(id=agent_id, agent_type=AgentType.PROFESSOR, is_active=True)
+def make_professor(agent_id: str) -> TickAgent:
+    return TickAgent(id=agent_id, agent_type=AgentType.PROFESSOR, is_active=True)
 
 
-def make_event(participant_ids: list[str]) -> Event:
-    return Event(id="evt-1", event_type="class", participant_ids=set(participant_ids))
+def make_event(participant_ids: list[str]) -> TickEvent:
+    return TickEvent(id="evt-1", event_type="class", participant_ids=set(participant_ids))
 
 
 def make_snapshot() -> WorldSnapshot:
@@ -149,7 +149,7 @@ async def test_inactive_agent_skipped():
     runtime = AsyncMock(return_value={"intent": "study"})
     engine = TickEngine(runtime=runtime)
 
-    inactive_student = Agent(id="s-inactive", agent_type=AgentType.STUDENT, is_active=False)
+    inactive_student = TickAgent(id="s-inactive", agent_type=AgentType.STUDENT, is_active=False)
     event = make_event(["s-inactive"])
     snapshot = make_snapshot()
 

--- a/backend/tests/test_tick_engine.py
+++ b/backend/tests/test_tick_engine.py
@@ -6,6 +6,7 @@ from app.simulation.tick_engine import (
     TickEngine,
     TickConflictError,
     TickRollbackError,
+    RuntimeExecutionError,
     TickAgent,
     AgentType,
     TickEvent,
@@ -96,7 +97,7 @@ async def test_duplicate_tick_raises_conflict():
 
 async def test_runtime_failure_triggers_rollback():
     async def failing_runtime(**kwargs):
-        raise RuntimeError("LLM timeout")
+        raise RuntimeExecutionError("LLM timeout")
 
     engine = TickEngine(runtime=failing_runtime)
     student = make_student("s-1")
@@ -129,7 +130,7 @@ async def test_tick_unlocks_after_failure():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            raise RuntimeError("first call fails")
+            raise RuntimeExecutionError("first call fails")
         return {"intent": "study"}
 
     engine = TickEngine(runtime=sometimes_failing)
@@ -141,6 +142,43 @@ async def test_tick_unlocks_after_failure():
         await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
 
     # 실패 후에도 lock이 해제돼 두 번째 Tick이 실행돼야 한다
+    await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+    assert call_count == 2
+
+
+async def test_code_bug_propagates_without_wrapping():
+    """RuntimeExecutionError가 아닌 예외(코드 버그)는 TickRollbackError로 감싸지 않고 propagate한다"""
+    async def buggy_runtime(**kwargs):
+        raise TypeError("unexpected argument")
+
+    engine = TickEngine(runtime=buggy_runtime)
+    student = make_student("s-1")
+    event = make_event(["s-1"])
+    snapshot = make_snapshot()
+
+    with pytest.raises(TypeError):
+        await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+
+
+async def test_tick_unlocks_after_code_bug():
+    """코드 버그로 Tick이 실패해도 lock이 해제된다"""
+    call_count = 0
+
+    async def buggy_then_ok(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise TypeError("bug")
+        return {"intent": "study"}
+
+    engine = TickEngine(runtime=buggy_then_ok)
+    student = make_student("s-1")
+    event = make_event(["s-1"])
+    snapshot = make_snapshot()
+
+    with pytest.raises(TypeError):
+        await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+
     await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
     assert call_count == 2
 

--- a/backend/tests/test_tick_engine.py
+++ b/backend/tests/test_tick_engine.py
@@ -1,0 +1,176 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from app.simulation.tick_engine import (
+    TickEngine,
+    TickConflictError,
+    TickRollbackError,
+    Agent,
+    AgentType,
+    Event,
+    WorldSnapshot,
+)
+
+
+def make_student(agent_id: str) -> Agent:
+    return Agent(id=agent_id, agent_type=AgentType.STUDENT, is_active=True)
+
+
+def make_professor(agent_id: str) -> Agent:
+    return Agent(id=agent_id, agent_type=AgentType.PROFESSOR, is_active=True)
+
+
+def make_event(participant_ids: list[str]) -> Event:
+    return Event(id="evt-1", event_type="class", participant_ids=set(participant_ids))
+
+
+def make_snapshot() -> WorldSnapshot:
+    return WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
+
+
+# ── RED ──────────────────────────────────────────────────────────────────────
+
+
+async def test_tick_runs_student_runtime():
+    runtime = AsyncMock(return_value={"intent": "study"})
+    engine = TickEngine(runtime=runtime)
+
+    student = make_student("s-1")
+    event = make_event(participant_ids=["s-1"])
+    snapshot = make_snapshot()
+
+    await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+
+    runtime.assert_awaited_once_with(agent=student, event=event, snapshot=snapshot)
+
+
+async def test_professor_runs_only_when_in_event():
+    runtime = AsyncMock(return_value={"intent": "lecture"})
+    engine = TickEngine(runtime=runtime)
+
+    professor = make_professor("p-1")
+    # Professor가 Event 참여자 목록에 없는 경우
+    event = make_event(participant_ids=["s-1"])
+    snapshot = make_snapshot()
+
+    await engine.run_tick(agents=[professor], event=event, snapshot=snapshot)
+
+    runtime.assert_not_awaited()
+
+
+async def test_professor_runs_when_in_event():
+    runtime = AsyncMock(return_value={"intent": "lecture"})
+    engine = TickEngine(runtime=runtime)
+
+    professor = make_professor("p-1")
+    event = make_event(participant_ids=["p-1"])
+    snapshot = make_snapshot()
+
+    await engine.run_tick(agents=[professor], event=event, snapshot=snapshot)
+
+    runtime.assert_awaited_once()
+
+
+async def test_duplicate_tick_raises_conflict():
+    async def slow_runtime(**kwargs):
+        await asyncio.sleep(0.05)
+        return {"intent": "study"}
+
+    engine = TickEngine(runtime=slow_runtime)
+    student = make_student("s-1")
+    event = make_event(["s-1"])
+    snapshot = make_snapshot()
+
+    first = asyncio.create_task(
+        engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+    )
+    # 첫 Tick이 시작된 직후 두 번째 요청
+    await asyncio.sleep(0)
+
+    with pytest.raises(TickConflictError):
+        await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+
+    await first
+
+
+async def test_runtime_failure_triggers_rollback():
+    async def failing_runtime(**kwargs):
+        raise RuntimeError("LLM timeout")
+
+    engine = TickEngine(runtime=failing_runtime)
+    student = make_student("s-1")
+    event = make_event(["s-1"])
+    snapshot = make_snapshot()
+
+    with pytest.raises(TickRollbackError):
+        await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+
+
+async def test_tick_unlocks_after_completion():
+    runtime = AsyncMock(return_value={"intent": "study"})
+    engine = TickEngine(runtime=runtime)
+
+    student = make_student("s-1")
+    event = make_event(["s-1"])
+    snapshot = make_snapshot()
+
+    await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+    # 완료 후 두 번째 Tick이 정상 실행돼야 한다
+    await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+
+    assert runtime.await_count == 2
+
+
+async def test_tick_unlocks_after_failure():
+    call_count = 0
+
+    async def sometimes_failing(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("first call fails")
+        return {"intent": "study"}
+
+    engine = TickEngine(runtime=sometimes_failing)
+    student = make_student("s-1")
+    event = make_event(["s-1"])
+    snapshot = make_snapshot()
+
+    with pytest.raises(TickRollbackError):
+        await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+
+    # 실패 후에도 lock이 해제돼 두 번째 Tick이 실행돼야 한다
+    await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+    assert call_count == 2
+
+
+async def test_inactive_agent_skipped():
+    runtime = AsyncMock(return_value={"intent": "study"})
+    engine = TickEngine(runtime=runtime)
+
+    inactive_student = Agent(id="s-inactive", agent_type=AgentType.STUDENT, is_active=False)
+    event = make_event(["s-inactive"])
+    snapshot = make_snapshot()
+
+    await engine.run_tick(agents=[inactive_student], event=event, snapshot=snapshot)
+
+    runtime.assert_not_awaited()
+
+
+async def test_same_snapshot_passed_to_all_agents():
+    received_snapshots: list[WorldSnapshot] = []
+
+    async def capturing_runtime(agent, event, snapshot):
+        received_snapshots.append(snapshot)
+        return {"intent": "study"}
+
+    engine = TickEngine(runtime=capturing_runtime)
+    agents = [make_student("s-1"), make_student("s-2")]
+    event = make_event(["s-1", "s-2"])
+    snapshot = make_snapshot()
+
+    await engine.run_tick(agents=agents, event=event, snapshot=snapshot)
+
+    assert len(received_snapshots) == 2
+    assert received_snapshots[0] is received_snapshots[1]


### PR DESCRIPTION
## 작업 개요

Slice 1 은혜 파트 — Tick Engine 코어를 구현하고 인수 조건 테스트를 작성한다.
TickAgent·TickEvent 흐름, Policy 전달, Tick 상태 전이, POST /tick/{simulation_id}/run API를 포함한다.

## 관련 Issue

Closes #38

## 변경 내용

- `app/simulation/tick_engine.py`: TickEngine 코어 구현
  - TickAgent, TickEvent, WorldSnapshot, PolicyInput, TickResult 타입 정의
  - AgentRuntimeFn, PolicyFn 콜백 타입 (DI 방식으로 DB-free 테스트 가능)
  - 중복 Tick 방지(TickConflictError), 실패 시 롤백(TickRollbackError)
- `app/api/ticks.py`: POST /tick/{simulation_id}/run 엔드포인트 구현 (make_tick_router 팩토리)
- `tests/test_tick_engine.py`: Tick Engine 단위 테스트 9개
- `tests/test_slice0_acceptance.py`: Slice 0 완료 기준(6-agent roster) 기반 Tick Engine 진입 인수 조건 테스트 9개
- `tests/test_slice1_acceptance.py`: Slice 1 인수 조건 테스트 9개 (Policy 전달, TickResult, 상태 전이)
- `tests/test_tick_api.py`: Tick API 엔드포인트 테스트 6개

## 결정 사항 및 이유

- **TickAgent·TickEvent로 rename**: `domain/models.py`의 SQLAlchemy ORM 클래스 `Agent`, `Event`와 이름 충돌을 방지하기 위해 tick_engine 전용 dataclass를 별도 이름으로 분리
- **DI 기반 콜백 설계**: runtime/policy를 콜백으로 주입받아 DB 없이 단위 테스트 가능하도록 설계
- **make_tick_router 팩토리 패턴**: TickEngine 인스턴스를 주입받아 테스트 환경에서 독립 앱으로 검증 가능
- **runtime 인터페이스 미연결**: 가윤님 Slice 1 runtime과의 인터페이스 정렬 논의 진행 중 (PR #39 코멘트 참고), 확정 후 연결 예정

## 테스트 / 확인 내용

- [x] 로컬 실행 확인 (`pytest` 33개 통과)
- [x] 주요 기능 동작 확인 (Tick 실행, Policy 전달, 중복 방지, 롤백)
- [x] 에러 케이스 확인 (409 Conflict, 500 Rollback, 422 Invalid)
- [ ] 관련 문서 업데이트 확인

## AI 사용 여부

사용 여부: 사용함
사용한 작업: TDD 사이클 전반, rename 적용, 테스트 작성
사람이 검토한 내용: 설계 방향(DI 콜백, rename 필요성), 테스트 케이스 범위, 인터페이스 정렬 방향

## 리뷰어가 봐야 할 부분

- `test_slice0_acceptance.py`가 Slice 1 PR에 포함된 이유: Slice 0 완료 기준(6-agent roster)을 Tick Engine이 올바르게 처리하는지 검증하는 진입 조건 테스트. 별도 PR로 분리 여부 논의 중 (지유님께 확인 예정)
- runtime 콜백 인터페이스: 현재 per-agent `(agent, event, snapshot) → dict` 시그니처. 가윤님 `SimulationTickService`와 연결 방식 확정 전