### PR TITLE
[Feature] Slice 2 - Task 3 relationships migration + RelationshipRepository

### DIFF
--- a/backend/alembic/versions/20260812_0047_allow_signed_relationship_closeness.py
+++ b/backend/alembic/versions/20260812_0047_allow_signed_relationship_closeness.py
@@ -1,0 +1,49 @@
+"""allow signed relationship closeness values
+
+Revision ID: 20260812_0047
+Revises: 20260806_0003
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260812_0047"
+down_revision = "20260806_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_relationships_closeness",
+        "relationships",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_relationships_closeness",
+        "relationships",
+        "closeness BETWEEN -100 AND 100",
+    )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    has_negative_closeness = connection.execute(
+        sa.text("SELECT EXISTS (SELECT 1 FROM relationships WHERE closeness < 0)")
+    ).scalar()
+    if has_negative_closeness:
+        raise RuntimeError(
+            "negative relationship closeness values require an explicit backfill"
+        )
+
+    op.drop_constraint(
+        "ck_relationships_closeness",
+        "relationships",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_relationships_closeness",
+        "relationships",
+        "closeness BETWEEN 0 AND 100",
+    )

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -251,7 +251,7 @@ class Relationship(TimestampMixin, Base):
         UniqueConstraint("simulation_id", "source_agent_id", "target_agent_id", name="uq_relationships_pair"),
         CheckConstraint("source_agent_id <> target_agent_id", name="ck_relationships_distinct_agents"),
         CheckConstraint("affection BETWEEN -100 AND 100", name="ck_relationships_affection"),
-        CheckConstraint("closeness BETWEEN 0 AND 100", name="ck_relationships_closeness"),
+        CheckConstraint("closeness BETWEEN -100 AND 100", name="ck_relationships_closeness"),
         CheckConstraint("trust BETWEEN -100 AND 100", name="ck_relationships_trust"),
         CheckConstraint("tension BETWEEN 0 AND 100", name="ck_relationships_tension"),
         CheckConstraint("rivalry BETWEEN 0 AND 100", name="ck_relationships_rivalry"),

--- a/backend/app/domain/relationship_metrics.py
+++ b/backend/app/domain/relationship_metrics.py
@@ -1,0 +1,21 @@
+from typing import Literal, TypeAlias
+
+
+# TODO(issue-41-task5): PR #42 Policy Engine도 통합 시 이 공통 계약을 import한다.
+RelationshipMetric: TypeAlias = Literal[
+    "affection",
+    "closeness",
+    "trust",
+    "tension",
+    "rivalry",
+    "dependency",
+]
+
+RELATIONSHIP_METRIC_RANGES: dict[RelationshipMetric, tuple[int, int]] = {
+    "affection": (-100, 100),
+    "closeness": (-100, 100),
+    "trust": (-100, 100),
+    "tension": (0, 100),
+    "rivalry": (0, 100),
+    "dependency": (0, 100),
+}

--- a/backend/app/repositories/relationships.py
+++ b/backend/app/repositories/relationships.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal, TypeAlias
+from typing import TypeAlias
 from uuid import UUID, uuid4
 
 from sqlalchemy import select
@@ -7,26 +7,13 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
 from app.domain.models import Agent, Relationship
+from app.domain.relationship_metrics import (
+    RELATIONSHIP_METRIC_RANGES,
+    RelationshipMetric,
+)
 
 
-RelationshipMetric: TypeAlias = Literal[
-    "affection",
-    "closeness",
-    "trust",
-    "tension",
-    "rivalry",
-    "dependency",
-]
 RelationshipRow: TypeAlias = Relationship
-
-METRIC_RANGES: dict[str, tuple[int, int]] = {
-    "affection": (-100, 100),
-    "closeness": (-100, 100),
-    "trust": (-100, 100),
-    "tension": (0, 100),
-    "rivalry": (0, 100),
-    "dependency": (0, 100),
-}
 
 
 class RelationshipNotFoundError(LookupError):
@@ -70,8 +57,11 @@ def get_pair(
 
 
 def apply_deltas(session: Session, deltas: list[RelationshipDelta]) -> None:
+    if not deltas:
+        return
+
     seen: set[tuple[UUID, UUID, str]] = set()
-    pending: list[tuple[Relationship, RelationshipDelta]] = []
+    related_agent_ids: set[UUID] = set()
 
     for delta in deltas:
         key = (delta.source_agent_id, delta.target_agent_id, delta.metric)
@@ -81,7 +71,7 @@ def apply_deltas(session: Session, deltas: list[RelationshipDelta]) -> None:
             )
         seen.add(key)
 
-        bounds = METRIC_RANGES.get(delta.metric)
+        bounds = RELATIONSHIP_METRIC_RANGES.get(delta.metric)
         if bounds is None:
             raise InvalidRelationshipDeltaError(
                 f"unsupported relationship metric: {delta.metric}"
@@ -108,13 +98,17 @@ def apply_deltas(session: Session, deltas: list[RelationshipDelta]) -> None:
             raise InvalidRelationshipDeltaError(
                 f"resolved {delta.metric} value {delta.after} is outside {bounds}"
             )
+        related_agent_ids.update((delta.source_agent_id, delta.target_agent_id))
 
-        source_simulation_id = session.scalar(
-            select(Agent.simulation_id).where(Agent.id == delta.source_agent_id)
-        )
-        target_simulation_id = session.scalar(
-            select(Agent.simulation_id).where(Agent.id == delta.target_agent_id)
-        )
+    agent_simulation_ids = dict(
+        session.execute(
+            select(Agent.id, Agent.simulation_id).where(Agent.id.in_(related_agent_ids))
+        ).all()
+    )
+    pending: list[tuple[Relationship, RelationshipDelta]] = []
+    for delta in deltas:
+        source_simulation_id = agent_simulation_ids.get(delta.source_agent_id)
+        target_simulation_id = agent_simulation_ids.get(delta.target_agent_id)
         if source_simulation_id is None or target_simulation_id is None:
             raise RelationshipNotFoundError(
                 f"relationship agent not found: {delta.source_agent_id} -> {delta.target_agent_id}"

--- a/backend/app/repositories/relationships.py
+++ b/backend/app/repositories/relationships.py
@@ -1,0 +1,164 @@
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from app.domain.models import Agent, Relationship
+
+
+RelationshipMetric: TypeAlias = Literal[
+    "affection",
+    "closeness",
+    "trust",
+    "tension",
+    "rivalry",
+    "dependency",
+]
+RelationshipRow: TypeAlias = Relationship
+
+METRIC_RANGES: dict[str, tuple[int, int]] = {
+    "affection": (-100, 100),
+    "closeness": (-100, 100),
+    "trust": (-100, 100),
+    "tension": (0, 100),
+    "rivalry": (0, 100),
+    "dependency": (0, 100),
+}
+
+
+class RelationshipNotFoundError(LookupError):
+    pass
+
+
+class StaleRelationshipValueError(RuntimeError):
+    pass
+
+
+class InvalidRelationshipDeltaError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class RelationshipDelta:
+    source_agent_id: UUID
+    target_agent_id: UUID
+    metric: RelationshipMetric
+    before: int
+    requested_total: int
+    applied_delta: int
+    after: int
+    effect_ids: tuple[str, ...]
+    policy_version: str
+    resolver_version: str
+    resolution_id: str
+
+
+def get_pair(
+    session: Session,
+    source_agent_id: UUID,
+    target_agent_id: UUID,
+) -> RelationshipRow | None:
+    return session.scalar(
+        select(Relationship).where(
+            Relationship.source_agent_id == source_agent_id,
+            Relationship.target_agent_id == target_agent_id,
+        )
+    )
+
+
+def apply_deltas(session: Session, deltas: list[RelationshipDelta]) -> None:
+    seen: set[tuple[UUID, UUID, str]] = set()
+    pending: list[tuple[Relationship, RelationshipDelta]] = []
+
+    for delta in deltas:
+        key = (delta.source_agent_id, delta.target_agent_id, delta.metric)
+        if key in seen:
+            raise InvalidRelationshipDeltaError(
+                f"duplicate resolved relationship metric: {key}"
+            )
+        seen.add(key)
+
+        bounds = METRIC_RANGES.get(delta.metric)
+        if bounds is None:
+            raise InvalidRelationshipDeltaError(
+                f"unsupported relationship metric: {delta.metric}"
+            )
+        if not delta.effect_ids:
+            raise InvalidRelationshipDeltaError("effect_ids must not be empty")
+        if not delta.policy_version or not delta.resolver_version or not delta.resolution_id:
+            raise InvalidRelationshipDeltaError(
+                "policy_version, resolver_version, and resolution_id are required"
+            )
+        if abs(delta.applied_delta) > abs(delta.requested_total):
+            raise InvalidRelationshipDeltaError(
+                "applied_delta cannot exceed requested_total magnitude"
+            )
+        if delta.requested_total != 0 and delta.applied_delta * delta.requested_total < 0:
+            raise InvalidRelationshipDeltaError(
+                "applied_delta direction must match requested_total"
+            )
+        if delta.after != delta.before + delta.applied_delta:
+            raise InvalidRelationshipDeltaError(
+                "resolved relationship delta must satisfy after = before + applied_delta"
+            )
+        if not bounds[0] <= delta.after <= bounds[1]:
+            raise InvalidRelationshipDeltaError(
+                f"resolved {delta.metric} value {delta.after} is outside {bounds}"
+            )
+
+        source_simulation_id = session.scalar(
+            select(Agent.simulation_id).where(Agent.id == delta.source_agent_id)
+        )
+        target_simulation_id = session.scalar(
+            select(Agent.simulation_id).where(Agent.id == delta.target_agent_id)
+        )
+        if source_simulation_id is None or target_simulation_id is None:
+            raise RelationshipNotFoundError(
+                f"relationship agent not found: {delta.source_agent_id} -> {delta.target_agent_id}"
+            )
+        if source_simulation_id != target_simulation_id:
+            raise InvalidRelationshipDeltaError(
+                "relationship agents must belong to the same simulation"
+            )
+
+        session.execute(
+            insert(Relationship)
+            .values(
+                id=uuid4(),
+                simulation_id=source_simulation_id,
+                source_agent_id=delta.source_agent_id,
+                target_agent_id=delta.target_agent_id,
+            )
+            .on_conflict_do_nothing(
+                constraint="uq_relationships_pair",
+            )
+        )
+        relationship = session.scalar(
+            select(Relationship)
+            .where(
+                Relationship.source_agent_id == delta.source_agent_id,
+                Relationship.target_agent_id == delta.target_agent_id,
+            )
+            .with_for_update()
+        )
+        if relationship is None:
+            raise RelationshipNotFoundError(
+                f"relationship not found: {delta.source_agent_id} -> {delta.target_agent_id}"
+            )
+
+        current = getattr(relationship, delta.metric)
+        if current != delta.before:
+            raise StaleRelationshipValueError(
+                f"stale {delta.metric}: expected {delta.before}, found {current}"
+            )
+        pending.append((relationship, delta))
+
+    for relationship, delta in pending:
+        setattr(relationship, delta.metric, delta.after)
+
+    # TODO(issue-41-task5): 상위 Tick Commit 경계에서 State, Memory,
+    # Event, Outbox 변경과 함께 commit/rollback하도록 통합한다.
+    session.flush()

--- a/backend/tests/test_relationship_repository.py
+++ b/backend/tests/test_relationship_repository.py
@@ -2,7 +2,7 @@ import os
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import create_engine, select, text
+from sqlalchemy import create_engine, event, select, text
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.domain.models import Agent, Relationship, Simulation, User
@@ -197,7 +197,7 @@ def test_apply_deltas_creates_missing_directional_pair(relationship_db) -> None:
         assert get_pair(session, target_agent_id, source_agent_id) is None
 
 
-def test_apply_deltas_rejects_inconsistent_resolver_result(relationship_db) -> None:
+def test_apply_deltas_rejects_delta_exceeding_requested_total(relationship_db) -> None:
     session_factory, _, source_agent_id, target_agent_id = relationship_db
     invalid = make_delta(
         source_agent_id,
@@ -209,3 +209,61 @@ def test_apply_deltas_rejects_inconsistent_resolver_result(relationship_db) -> N
     with session_factory() as session:
         with pytest.raises(InvalidRelationshipDeltaError):
             apply_deltas(session, [invalid])
+
+
+def test_apply_deltas_rejects_after_value_inconsistent_with_applied_delta(
+    relationship_db,
+) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    invalid = make_delta(
+        source_agent_id,
+        target_agent_id,
+        requested_total=5,
+        applied_delta=5,
+        after=27,
+    )
+    with session_factory() as session:
+        with pytest.raises(
+            InvalidRelationshipDeltaError,
+            match="after = before \\+ applied_delta",
+        ):
+            apply_deltas(session, [invalid])
+
+
+def test_apply_deltas_loads_agent_simulations_in_one_query(relationship_db) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    statements: list[str] = []
+
+    def record_statement(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    engine = session_factory.kw["bind"]
+    event.listen(engine, "before_cursor_execute", record_statement)
+    try:
+        with session_factory() as session:
+            apply_deltas(
+                session,
+                [
+                    make_delta(source_agent_id, target_agent_id),
+                    make_delta(
+                        source_agent_id,
+                        target_agent_id,
+                        metric="affection",
+                        before=10,
+                        requested_total=2,
+                        applied_delta=2,
+                        after=12,
+                        resolution_id="resolution-2",
+                    ),
+                ],
+            )
+            session.rollback()
+    finally:
+        event.remove(engine, "before_cursor_execute", record_statement)
+
+    agent_queries = [
+        statement
+        for statement in statements
+        if "FROM agents" in statement and "agents.simulation_id" in statement
+    ]
+    assert len(agent_queries) == 1

--- a/backend/tests/test_relationship_repository.py
+++ b/backend/tests/test_relationship_repository.py
@@ -1,0 +1,211 @@
+import os
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.domain.models import Agent, Relationship, Simulation, User
+from app.repositories.relationships import (
+    InvalidRelationshipDeltaError,
+    RelationshipDelta,
+    StaleRelationshipValueError,
+    apply_deltas,
+    get_pair,
+)
+
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def relationship_db():
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE users, simulations, agents, relationships "
+                "RESTART IDENTITY CASCADE"
+            )
+        )
+
+    user_id = uuid4()
+    simulation_id = uuid4()
+    source_agent_id = uuid4()
+    target_agent_id = uuid4()
+    relationship_id = uuid4()
+    with session_factory.begin() as session:
+        session.add(
+            User(
+                id=user_id,
+                username="relationship-owner",
+                display_name="Relationship Owner",
+                password_hash="not-used-in-this-test",
+                roles=["USER"],
+            )
+        )
+        session.flush()
+        session.add(
+            Simulation(id=simulation_id, owner_id=user_id, name="Relationship Test")
+        )
+        session.flush()
+        session.add_all(
+            [
+                Agent(
+                    id=source_agent_id,
+                    simulation_id=simulation_id,
+                    fixture_key="student-01",
+                    fixture_version="relationship-test-v1",
+                    agent_type="student",
+                    name="Source",
+                    gender="unspecified",
+                    mbti_type="ISTJ",
+                ),
+                Agent(
+                    id=target_agent_id,
+                    simulation_id=simulation_id,
+                    fixture_key="student-02",
+                    fixture_version="relationship-test-v1",
+                    agent_type="student",
+                    name="Target",
+                    gender="unspecified",
+                    mbti_type="ESTP",
+                ),
+            ]
+        )
+        session.flush()
+        session.add(
+            Relationship(
+                id=relationship_id,
+                simulation_id=simulation_id,
+                source_agent_id=source_agent_id,
+                target_agent_id=target_agent_id,
+                affection=10,
+                closeness=0,
+                trust=20,
+                tension=5,
+                rivalry=0,
+                dependency=0,
+            )
+        )
+
+    yield session_factory, simulation_id, source_agent_id, target_agent_id
+    engine.dispose()
+
+
+def make_delta(source_agent_id, target_agent_id, **overrides) -> RelationshipDelta:
+    values = {
+        "source_agent_id": source_agent_id,
+        "target_agent_id": target_agent_id,
+        "metric": "trust",
+        "before": 20,
+        "requested_total": 5,
+        "applied_delta": 5,
+        "after": 25,
+        "effect_ids": ("effect-1",),
+        "policy_version": "policy-mvp-0.1",
+        "resolver_version": "resolver-mvp-0.1",
+        "resolution_id": "resolution-1",
+    }
+    values.update(overrides)
+    return RelationshipDelta(**values)
+
+
+def test_get_pair_is_directional(relationship_db) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    with session_factory() as session:
+        assert get_pair(session, source_agent_id, target_agent_id) is not None
+        assert get_pair(session, target_agent_id, source_agent_id) is None
+
+
+def test_apply_deltas_flushes_without_committing(relationship_db) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    with session_factory() as session:
+        apply_deltas(session, [make_delta(source_agent_id, target_agent_id)])
+        assert get_pair(session, source_agent_id, target_agent_id).trust == 25
+        session.rollback()
+
+    with session_factory() as session:
+        assert get_pair(session, source_agent_id, target_agent_id).trust == 20
+
+
+def test_apply_deltas_accepts_negative_closeness(relationship_db) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    delta = make_delta(
+        source_agent_id,
+        target_agent_id,
+        metric="closeness",
+        before=0,
+        requested_total=-3,
+        applied_delta=-3,
+        after=-3,
+    )
+    with session_factory.begin() as session:
+        apply_deltas(session, [delta])
+
+    with session_factory() as session:
+        assert get_pair(session, source_agent_id, target_agent_id).closeness == -3
+
+
+def test_stale_delta_causes_caller_rollback_of_entire_batch(relationship_db) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    valid = make_delta(source_agent_id, target_agent_id)
+    stale = make_delta(
+        source_agent_id,
+        target_agent_id,
+        metric="affection",
+        before=999,
+        requested_total=-899,
+        applied_delta=-899,
+        after=100,
+        resolution_id="resolution-2",
+    )
+
+    with pytest.raises(StaleRelationshipValueError):
+        with session_factory.begin() as session:
+            apply_deltas(session, [valid, stale])
+
+    with session_factory() as session:
+        relationship = session.scalar(select(Relationship))
+        assert relationship.trust == 20
+        assert relationship.affection == 10
+
+
+def test_apply_deltas_creates_missing_directional_pair(relationship_db) -> None:
+    session_factory, simulation_id, source_agent_id, target_agent_id = relationship_db
+    with session_factory.begin() as session:
+        session.execute(text("DELETE FROM relationships"))
+
+    delta = make_delta(
+        source_agent_id,
+        target_agent_id,
+        before=0,
+        requested_total=3,
+        applied_delta=3,
+        after=3,
+    )
+    with session_factory.begin() as session:
+        apply_deltas(session, [delta])
+
+    with session_factory() as session:
+        relationship = get_pair(session, source_agent_id, target_agent_id)
+        assert relationship is not None
+        assert relationship.simulation_id == simulation_id
+        assert relationship.trust == 3
+        assert get_pair(session, target_agent_id, source_agent_id) is None
+
+
+def test_apply_deltas_rejects_inconsistent_resolver_result(relationship_db) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    invalid = make_delta(
+        source_agent_id,
+        target_agent_id,
+        requested_total=5,
+        applied_delta=6,
+        after=26,
+    )
+    with session_factory() as session:
+        with pytest.raises(InvalidRelationshipDeltaError):
+            apply_deltas(session, [invalid])

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -125,6 +125,24 @@ class SchemaModelTests(unittest.TestCase):
             self.assertIn("BETWEEN -50 AND 50", expression)
             self.assertIn("% 5 = 0", expression)
 
+    def test_relationship_metric_constraints_match_slice_two_contract(self) -> None:
+        relationships = Base.metadata.tables["relationships"]
+        constraints = {
+            constraint.name: str(constraint.sqltext)
+            for constraint in relationships.constraints
+            if isinstance(constraint, CheckConstraint)
+        }
+        for metric in ("affection", "closeness", "trust"):
+            self.assertIn(
+                "BETWEEN -100 AND 100",
+                constraints[f"ck_relationships_{metric}"],
+            )
+        for metric in ("tension", "rivalry", "dependency"):
+            self.assertIn(
+                "BETWEEN 0 AND 100",
+                constraints[f"ck_relationships_{metric}"],
+            )
+
     def test_embedding_column_is_deferred_until_dimension_is_decided(self) -> None:
         self.assertNotIn("embedding", Base.metadata.tables["agent_memories"].c)
 


### PR DESCRIPTION
## 작업 개요

Slice 2에서 Resolver가 확정한 방향성 관계 delta를 PostgreSQL에 안전하게 반영할 수 있도록 `RelationshipRepository`와 보완 migration을 구현했습니다.

기존 `relationships` DDL의 방향성·자기 관계 금지·pair 중복 금지·Simulation 복합 FK는 유지하고, 최신 확정 계약과 달랐던 `closeness` CHECK 범위만 `-100~100`으로 수정했습니다.

## 관련 Issue

Closes #47
Related to #41

## 변경 내용

- `closeness` CHECK 범위를 `0~100`에서 `-100~100`으로 수정하는 보완 migration 추가
- 최종 Resolver 결과 계약을 표현하는 `RelationshipDelta` 타입 추가
- 방향성 관계 조회 `get_pair(session, source_agent_id, target_agent_id)` 구현
- `apply_deltas(session, deltas)` 구현
  - 최초 관계 pair의 idempotent 생성
  - 동일 Simulation Agent 검증
  - `SELECT FOR UPDATE` 기반 동시성 제어
  - stale `before` 및 Resolver 결과 일관성 검증
  - Repository 내부 `commit()`·`rollback()` 없이 `flush()`만 수행
- 방향성 조회·음수 closeness·최초 pair 생성·commit 미수행·batch rollback 테스트 추가

## 결정 사항 및 이유

`relationships` 테이블은 초기 migration에 이미 존재하므로 신규 테이블 생성 migration은 추가하지 않았습니다. 확정 계약과 불일치한 `closeness` CHECK만 보완해 migration 책임 중복을 피했습니다.

트랜잭션 소유권은 상위 Tick Commit 경계에 있으므로 Repository는 `flush()`까지만 수행합니다. Task 5 통합 시 State·Memory·Event·Outbox·Tick 완료 처리와 하나의 transaction으로 commit/rollback하도록 TODO를 남겼습니다.

관계 snapshot이 없는 첫 상호작용은 정상 시나리오이므로, 같은 Simulation의 두 Agent인지 검증한 후 방향성 pair를 PostgreSQL `ON CONFLICT DO NOTHING`으로 생성합니다.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [x] 관련 문서 업데이트 확인 — 확정 계약 범위 내 코드 변경으로 별도 문서 수정 없음

검증 결과:
- 새 PostgreSQL 테스트 DB에서 Alembic 전체 upgrade 성공
- `alembic check`: migration/model drift 없음
- Repository·스키마 집중 테스트: `16 passed`
- 전체 Backend 회귀 테스트: `29 passed, 1 warning`
- 실제 DB CHECK·복합 FK·자기 관계 금지·방향 pair UNIQUE 확인
- `compileall`, `git diff --check` 통과

Migration downgrade는 음수 closeness 데이터가 존재할 경우 명시적 backfill 없이는 중단하도록 보호했습니다. 실제 downgrade 실행은 데이터 변경 작업이므로 수행하지 않았습니다.

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 기존 DDL·Policy 계약 대조, migration·Repository·테스트 구현, PostgreSQL 검증
사람이 검토한 내용: Confluence 확정 범위, `RelationshipDelta` 필드, transaction 책임, PR base/head 및 테스트 결과

## 리뷰어가 봐야 할 부분

- `RelationshipDelta`가 Resolver 최종 결과 계약과 일치하는지
- `apply_deltas()`가 상위 Tick transaction 소유권을 침범하지 않는지
- 최초 관계 pair 생성과 `SELECT FOR UPDATE`의 동시성 처리
- stale snapshot 및 부분 실패 시 전체 rollback 보장
- 보완 migration이 기존 DDL 중 `closeness` CHECK만 변경하는지

참고: PR #42의 `METRIC_RANGE[closeness]`는 아직 `(0, 100)`이며 별도 리뷰로 `(-100, 100)` 수정 요청했습니다. 본 PR의 DB·Repository는 최신 확정 계약인 `-100~100`을 기준으로 구현했습니다.