### PR TITLE
[Feature] Slice 2 Task 4 - delta 표시 UI 및 React Flow 엣지 하이라이트 (mock)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@xyflow/react": "^12.11.3",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
       },
@@ -1121,6 +1122,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1139,7 +1189,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1149,7 +1199,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -1294,6 +1344,48 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.3",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.3.tgz",
+      "integrity": "sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.80",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.80",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.80.tgz",
+      "integrity": "sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1359,6 +1451,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1391,8 +1489,113 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2420,6 +2623,15 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
@@ -2669,6 +2881,34 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@xyflow/react": "^12.11.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/frontend/src/components/DeltaDisplay.jsx
+++ b/frontend/src/components/DeltaDisplay.jsx
@@ -1,0 +1,202 @@
+import React, { useState } from "react";
+
+const METRIC_VALENCE = {
+  trust: "positive",
+  affection: "positive",
+  closeness: "positive",
+  tension: "negative",
+  rivalry: "negative",
+  dependency: "neutral", // TODO: §4.2 확인 필요
+
+  hunger: "negative",
+  fatigue: "negative",
+  stress: "negative",
+  satisfaction: "positive",
+  mood: "positive",
+};
+
+const METRIC_LABEL_KO = {
+  trust: "신뢰",
+  affection: "호감",
+  closeness: "친밀도",
+  tension: "긴장",
+  rivalry: "경쟁심",
+  dependency: "의존도",
+  hunger: "허기",
+  fatigue: "피로",
+  stress: "스트레스",
+  satisfaction: "만족감",
+  mood: "기분",
+};
+
+function isRelationshipEffect(effect) {
+  if (effect.target_type) return effect.target_type === "RELATIONSHIP";
+  return ["trust", "affection", "closeness", "tension", "rivalry", "dependency"].includes(
+    effect.metric
+  );
+}
+
+function getDeltaColor(metric, delta) {
+  if (delta === 0) return { fg: "#8b8f97", bg: "#f1f2f4", ring: "#e1e3e6" };
+
+  const valence = METRIC_VALENCE[metric] ?? "neutral";
+  if (valence === "neutral") {
+    return { fg: "#6b6f76", bg: "#f1f2f4", ring: "#d8dade" };
+  }
+
+  const isGood = valence === "positive" ? delta > 0 : delta < 0;
+  return isGood
+    ? { fg: "#1a7f4e", bg: "#e6f6ee", ring: "#b8e6cc" }
+    : { fg: "#c22b2b", bg: "#fdecec", ring: "#f6c6c6" };
+}
+
+export function DeltaBadge({ effect, compact = false }) {
+  const {
+    metric,
+    delta,
+    before,
+    after_preview,
+    reason,
+    rule_id,
+    source_agent_id,
+    target_agent_id,
+  } = effect;
+  const color = getDeltaColor(metric, delta);
+  const arrow = delta > 0 ? "▲" : delta < 0 ? "▼" : "▬";
+  const sign = delta > 0 ? `+${delta}` : `${delta}`;
+  const isRelationship = isRelationshipEffect(effect);
+  const tooltip = [reason, rule_id ? `rule: ${rule_id}` : null]
+    .filter(Boolean)
+    .join("\n");
+
+  return (
+    <div
+      title={tooltip}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: compact ? "3px 8px" : "5px 10px",
+        borderRadius: 999,
+        background: color.bg,
+        border: `1px solid ${color.ring}`,
+        fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+        fontSize: compact ? 11 : 12,
+        lineHeight: 1,
+        cursor: reason ? "help" : "default",
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span
+        style={{
+          fontSize: 9,
+          textTransform: "uppercase",
+          letterSpacing: 0.4,
+          color: "#9a9da3",
+        }}
+      >
+        {isRelationship ? "REL" : "STATE"}
+      </span>
+      {isRelationship && source_agent_id != null && target_agent_id != null && (
+        <span style={{ color: "#b0b3b9", fontSize: 10 }}>
+          {source_agent_id}→{target_agent_id}
+        </span>
+      )}
+      <span style={{ color: "#3b3d42", fontWeight: 600 }}>
+        {METRIC_LABEL_KO[metric] ?? metric}
+      </span>
+      <span style={{ color: color.fg, fontWeight: 700 }}>
+        {arrow} {sign}
+      </span>
+      {!compact && (
+        <span style={{ color: "#9a9da3" }}>
+          {before} → {after_preview}
+          <sup style={{ marginLeft: 3, color: "#c7c9cd", fontSize: 9 }}>
+            preview
+          </sup>
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function DeltaGroup({ effects, compact = false }) {
+  if (!effects?.length) return null;
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+      {effects.map((e) => (
+        <DeltaBadge key={e.effect_id} effect={e} compact={compact} />
+      ))}
+    </div>
+  );
+}
+
+const FIXTURE = [
+  {
+    effect_id: "sim-20260721-01:42:3:reaction:TRUST_UP:7",
+    source_type: "AGENT_REACTION",
+    source_id: "3",
+    rule_id: "REL_SIGNAL_TRUST_UP_MEDIUM",
+    target_type: "RELATIONSHIP",
+    source_agent_id: 3,
+    target_agent_id: 7,
+    metric: "trust",
+    delta: 3,
+    before: 21,
+    after_preview: 24,
+    reason: "TALK의 MEDIUM TRUST_UP 반응",
+  },
+  {
+    effect_id: "sim-20260721-01:42:3:reaction:TENSION_UP:7",
+    source_type: "AGENT_REACTION",
+    source_id: "3",
+    rule_id: "REL_SIGNAL_TENSION_UP_LOW",
+    target_type: "RELATIONSHIP",
+    source_agent_id: 7,
+    target_agent_id: 3,
+    metric: "tension",
+    delta: 2,
+    before: 20,
+    after_preview: 22,
+    reason: "의식 실패로 긴장 고조",
+  },
+  {
+    effect_id: "sim-20260721-01:42:3:state:FATIGUE_UP",
+    source_type: "AGENT_REACTION",
+    source_id: "3",
+    rule_id: "STATE_FATIGUE_RITUAL_PARTICIPATION",
+    target_type: "AGENT_STATE",
+    source_agent_id: 3,
+    target_agent_id: null,
+    metric: "fatigue",
+    delta: 8,
+    before: 30,
+    after_preview: 38,
+    reason: "장시간 의식 참여로 피로 누적",
+  },
+  {
+    effect_id: "sim-20260721-01:42:3:reaction:DEPENDENCY_UP:7",
+    source_type: "AGENT_REACTION",
+    source_id: "3",
+    rule_id: "REL_SIGNAL_DEPENDENCY_UP_LOW",
+    target_type: "RELATIONSHIP",
+    source_agent_id: 3,
+    target_agent_id: 7,
+    metric: "dependency",
+    delta: 4,
+    before: 10,
+    after_preview: 14,
+    reason: "위기 상황에서 상대에게 의존 증가 (valence 확인 필요)",
+  },
+];
+
+export default function DeltaDisplay() {
+  return (
+    <div style={{ padding: 16 }}>
+      <h3 style={{ fontSize: 13, fontWeight: 700, marginBottom: 8 }}>
+        Delta 표시 (mock)
+      </h3>
+      <DeltaGroup effects={FIXTURE} />
+    </div>
+  );
+}

--- a/frontend/src/components/DeltaDisplay.jsx
+++ b/frontend/src/components/DeltaDisplay.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 const METRIC_VALENCE = {
   trust: "positive",
@@ -63,7 +63,7 @@ export function DeltaBadge({ effect, compact = false }) {
   } = effect;
   const color = getDeltaColor(metric, delta);
   const arrow = delta > 0 ? "▲" : delta < 0 ? "▼" : "▬";
-  const sign = delta > 0 ? `+${delta}` : `${delta}`;
+  const sign = delta > 0 ? `+${delta}` : `${Math.abs(delta)}`;
   const isRelationship = isRelationshipEffect(effect);
   const tooltip = [reason, rule_id ? `rule: ${rule_id}` : null]
     .filter(Boolean)

--- a/frontend/src/components/DeltaDisplay.test.jsx
+++ b/frontend/src/components/DeltaDisplay.test.jsx
@@ -36,8 +36,33 @@ describe("DeltaBadge", () => {
   it("delta가 0이면 중립(회색) 표시가 된다", () => {
     const flat = { ...trustUp, delta: 0, after_preview: 21 };
     render(<DeltaBadge effect={flat} />);
-    // 정확히 0 이라는 텍스트가 뜨는지만 확인 (색상은 스냅샷/시각 테스트 영역이라 여기선 값만 검증)
+    
     expect(screen.getByText(/0/)).toBeInTheDocument();
+  });
+  
+  it("delta가 음수이면 절댓값으로 표시된다", () => {
+    const down = { ...tensionUp, delta: -2, after_preview: 18 };
+    render(<DeltaBadge effect={down} />);
+    expect(screen.getByText(/▼\s*2/)).toBeInTheDocument();
+  });
+
+  it("negative valence 지표(fatigue) 증가는 경고색으로 표시된다", () => {
+    const fatigueUp = {
+      effect_id: "e3",
+      target_type: "AGENT_STATE",
+      metric: "fatigue",
+      delta: 8,
+      before: 30,
+      after_preview: 38,
+      reason: "피로 누적",
+    };
+    render(<DeltaBadge effect={fatigueUp} />);
+    expect(screen.getByText("피로")).toBeInTheDocument();
+  });
+
+  it("compact 모드에서는 preview 영역이 렌더링되지 않는다", () => {
+    render(<DeltaBadge effect={trustUp} compact />);
+    expect(screen.queryByText(/preview/)).not.toBeInTheDocument();
   });
 });
 
@@ -48,7 +73,6 @@ describe("DeltaGroup", () => {
     expect(screen.getByText("긴장")).toBeInTheDocument();
   });
 
-  // 7번에서 다룬 "빈 결과" 케이스
   it("effects가 빈 배열이면 아무것도 렌더링하지 않는다", () => {
     const { container } = render(<DeltaGroup effects={[]} />);
     expect(container).toBeEmptyDOMElement();

--- a/frontend/src/components/DeltaDisplay.test.jsx
+++ b/frontend/src/components/DeltaDisplay.test.jsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DeltaBadge, DeltaGroup } from "./DeltaDisplay";
+
+const trustUp = {
+  effect_id: "e1",
+  target_type: "RELATIONSHIP",
+  source_agent_id: 3,
+  target_agent_id: 7,
+  metric: "trust",
+  delta: 3,
+  before: 21,
+  after_preview: 24,
+  reason: "TALK의 MEDIUM TRUST_UP 반응",
+};
+
+const tensionUp = {
+  effect_id: "e2",
+  target_type: "RELATIONSHIP",
+  source_agent_id: 7,
+  target_agent_id: 3,
+  metric: "tension",
+  delta: 2,
+  before: 20,
+  after_preview: 22,
+  reason: "긴장 고조",
+};
+
+describe("DeltaBadge", () => {
+  it("metric 이름과 증감 표시를 렌더링한다", () => {
+    render(<DeltaBadge effect={trustUp} />);
+    expect(screen.getByText("신뢰")).toBeInTheDocument();
+    expect(screen.getByText(/\+3/)).toBeInTheDocument();
+  });
+
+  it("delta가 0이면 중립(회색) 표시가 된다", () => {
+    const flat = { ...trustUp, delta: 0, after_preview: 21 };
+    render(<DeltaBadge effect={flat} />);
+    // 정확히 0 이라는 텍스트가 뜨는지만 확인 (색상은 스냅샷/시각 테스트 영역이라 여기선 값만 검증)
+    expect(screen.getByText(/0/)).toBeInTheDocument();
+  });
+});
+
+describe("DeltaGroup", () => {
+  it("effect가 여러 개면 모두 렌더링한다", () => {
+    render(<DeltaGroup effects={[trustUp, tensionUp]} />);
+    expect(screen.getByText("신뢰")).toBeInTheDocument();
+    expect(screen.getByText("긴장")).toBeInTheDocument();
+  });
+
+  // 7번에서 다룬 "빈 결과" 케이스
+  it("effects가 빈 배열이면 아무것도 렌더링하지 않는다", () => {
+    const { container } = render(<DeltaGroup effects={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("effects가 undefined여도 에러 없이 아무것도 렌더링하지 않는다", () => {
+    const { container } = render(<DeltaGroup effects={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/RelationshipFlow.jsx
+++ b/frontend/src/components/RelationshipFlow.jsx
@@ -30,7 +30,7 @@ function DeltaEdge({ id, sourceX, sourceY, targetX, targetY, data }) {
             pointerEvents: "all",
           }}
         >
-          <DeltaGroup effects={data.effects} compact />
+          <DeltaGroup effects={data?.effects} compact />
         </div>
       </EdgeLabelRenderer>
     </>
@@ -89,17 +89,17 @@ const edges = [
     },
   },
 ];
-export default function RelationshipFlow({ edges: edgesProp = edges }) {
-  const hasEdges = edgesProp.length > 0;
+export default function RelationshipFlow({ nodes: nodesProp = nodes, edges: edgesProp = edges }) {
+  const hasChanges = edgesProp.some((e) => e.data?.effects?.length > 0);
 
   return (
     <div style={{ width: "100%", height: 400, position: "relative" }}>
-      <ReactFlow nodes={nodes} edges={edgesProp} edgeTypes={edgeTypes} fitView>
+      <ReactFlow nodes={nodesProp} edges={edgesProp} edgeTypes={edgeTypes} fitView>
         <Background />
         <Controls />
       </ReactFlow>
 
-      {!hasEdges && (
+      {!hasChanges && (
         <div
           style={{
             position: "absolute",

--- a/frontend/src/components/RelationshipFlow.jsx
+++ b/frontend/src/components/RelationshipFlow.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  BaseEdge,
+  EdgeLabelRenderer,
+  getStraightPath,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { DeltaGroup } from "./DeltaDisplay";
+
+// --- delta를 보여주는 커스텀 edge ---
+function DeltaEdge({ id, sourceX, sourceY, targetX, targetY, data }) {
+  const [edgePath, labelX, labelY] = getStraightPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+  });
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} />
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            pointerEvents: "all",
+          }}
+        >
+          <DeltaGroup effects={data.effects} compact />
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}
+
+const edgeTypes = { delta: DeltaEdge };
+
+// --- agent 2명 (mock) ---
+const nodes = [
+  {
+    id: "3",
+    position: { x: 0, y: 100 },
+    data: { label: "Agent 3" },
+  },
+  {
+    id: "7",
+    position: { x: 300, y: 100 },
+    data: { label: "Agent 7" },
+  },
+];
+
+// --- 그 사이 관계 edge (mock delta 포함) ---
+const edges = [
+  {
+    id: "e3-7",
+    source: "3",
+    target: "7",
+    type: "delta",
+    data: {
+      effects: [
+        {
+          effect_id: "sim-20260721-01:42:3:reaction:TRUST_UP:7",
+          target_type: "RELATIONSHIP",
+          source_agent_id: 3,
+          target_agent_id: 7,
+          metric: "trust",
+          delta: 3,
+          before: 21,
+          after_preview: 24,
+          reason: "TALK의 MEDIUM TRUST_UP 반응",
+          rule_id: "REL_SIGNAL_TRUST_UP_MEDIUM",
+        },
+        {
+          effect_id: "sim-20260721-01:42:7:reaction:TENSION_UP:3",
+          target_type: "RELATIONSHIP",
+          source_agent_id: 7,
+          target_agent_id: 3,
+          metric: "tension",
+          delta: 2,
+          before: 20,
+          after_preview: 22,
+          reason: "의식 실패로 긴장 고조",
+        },
+      ],
+    },
+  },
+];
+export default function RelationshipFlow({ edges: edgesProp = edges }) {
+  const hasEdges = edgesProp.length > 0;
+
+  return (
+    <div style={{ width: "100%", height: 400, position: "relative" }}>
+      <ReactFlow nodes={nodes} edges={edgesProp} edgeTypes={edgeTypes} fitView>
+        <Background />
+        <Controls />
+      </ReactFlow>
+
+      {!hasEdges && (
+        <div
+          style={{
+            position: "absolute",
+            top: 12,
+            left: "50%",
+            transform: "translateX(-50%)",
+            fontSize: 12,
+            color: "#9a9da3",
+            background: "#fafbfc",
+            border: "1px solid #e1e3e6",
+            borderRadius: 999,
+            padding: "4px 12px",
+            pointerEvents: "none",
+          }}
+        >
+          이번 tick에는 관계 변화가 없습니다
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## 6. 작업 개요
Policy Engine의 관계·상태 변화(effect_candidates)를 화면에 표시하는 delta 배지 컴포넌트와, React Flow 엣지 위에 이를 부착하는 기능을 구현했다. Slice 2 Task 1~3(reaction signal, Policy Engine, relationships 테이블)이 아직 merge되지 않아, §4.2 계약 구조를 기준으로 한 mock 데이터로 UI만 우선 구현했다.

## 7. 관련 Issue
Closes #48

## 8. 변경 내용
- `DeltaDisplay.jsx`: `DeltaBadge`, `DeltaGroup` 컴포넌트 추가 — Policy Engine §4.2 `effect_candidates` 구조(effect_id, target_type, metric, delta, before, after_preview, reason 등) 기준
- metric별 증감 색상을 valence(긍정/부정 방향) 기반으로 결정하는 로직 추가 (부호 그대로 색을 매기지 않고, tension/rivalry/hunger/fatigue/stress는 증가 시 경고색으로 표시)
- `RelationshipFlow.jsx`: `@xyflow/react` 설치 및 커스텀 edge(`DeltaEdge`)로 두 Agent 사이 관계 delta를 엣지 라벨에 표시
- 관계 변화가 없는 tick(빈 `effects` 배열)에 대한 안내 문구 처리
- `DeltaDisplay.test.jsx`: 렌더링 및 빈 배열 처리 테스트 5건 추가
- `src/test/setup.js`: 테스트 간 `cleanup()` 누락 수정 (기존 설정에 없어 테스트 간 DOM이 누적되는 문제 발견 및 수정)

## 9. 결정 사항 및 이유
- **색상 매핑을 delta 부호가 아닌 metric별 valence로 분리**: tension/rivalry 등은 증가가 부정적 신호라 부호 그대로 초록/빨강을 매기면 오해를 유발하기 때문.
- **`dependency`는 중립(회색) 처리**: 의존도 증가가 긍정적 신호(유대 강화)인지 부정적 신호(불건강한 의존)인지에 대한 기획 확정이 없어, 임의로 색을 매기지 않고 중립으로 표시. 추후 기획 확정 시 반영 예정.
- **target_type 기반으로 REL/STATE 판별**: metric 이름으로 하드코딩하지 않고 §4.2/§10.9에 명시된 `target_type`(`RELATIONSHIP` / `AGENT_STATE`) 필드를 우선 사용하도록 구현.
- **mock 데이터 우선 구현**: Task 1~3 PR이 아직 open 상태라 실제 API 연동이 불가능한 상황. 병목 없이 UI를 먼저 준비하기 위해 §4.2 계약 구조 그대로 하드코딩한 fixture 사용.

## 10. 테스트 / 확인 내용
- [x] 로컬 실행 확인 (`npm run dev`)
- [x] 주요 기능 동작 확인 (배지 렌더링, edge 부착, 빈 결과 문구)
- [x] 에러 케이스 확인 (`effects` undefined/빈 배열)
- [ ] 관련 문서 업데이트 확인 (해당 없음 — 실제 API 연동 전이라 별도 문서 변경 없음)

## 11. AI 사용 여부
- 사용 여부: 사용함
- 사용한 작업: 컴포넌트 skeleton 초기 작성, valence 기반 색상 로직 설계, React Flow 커스텀 엣지 연동 구조, 테스트 코드 작성, `cleanup()` 누락 디버깅
- 사람이 검토한 내용: §4.2/§10.9 실제 스펙과 필드 대조 확인, dependency valence 처리 방향 결정, 로컬 실행 및 테스트 결과 직접 확인, App.jsx 임시 코드 제거

## 12. 리뷰어가 봐야 할 부분

- `dependency` valence를 중립이 아닌 값으로 정할 경우 `METRIC_VALENCE` 한 줄만 수정하면 됨
- mock 데이터 구조가 실제 Policy Engine 최종 응답과 필드명이 다를 경우 (특히 Task 2 PR #42 merge 후) `RelationshipFlow.jsx`의 fixture 부분 교체 필요