### PR TITLE
[Feature] Slice1 Tick 실행 결과·오류 표시 UI 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -66,7 +66,7 @@ function classifyTickError(requestError) {
   if (status === 404 || code === "RESOURCE_NOT_FOUND") {
     return { type: "NOT_FOUND", message: "Simulation을 찾을 수 없습니다." };
   }
-  if (status === 409 || code === "TICK_ALREADY_RUNNING") {
+  if (code === "TICK_ALREADY_RUNNING") {
     return {
       type: "TICK_ALREADY_RUNNING",
       message: "이미 진행 중인 Tick이 있습니다. 잠시 후 다시 시도해 주세요.",
@@ -162,7 +162,6 @@ export default function App() {
         {
           token: auth.access_token,
           method: "POST",
-          body: JSON.stringify({}),
         }
       );
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,11 +2,12 @@ import { useState } from "react";
 import { apiRequest } from "./api/client.js";
 import "./App.css";
 
-function AuthPanel({ onLogin }) {
+function AuthPanel({ onLogin, notice }) {
   const [mode, setMode] = useState("login");
   const [form, setForm] = useState({ username: "", display_name: "", password: "" });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [authNotice, setAuthNotice] = useState("");
 
   async function submit(event) {
     event.preventDefault();
@@ -36,6 +37,7 @@ function AuthPanel({ onLogin }) {
       <form className="panel auth-panel" onSubmit={submit}>
         <h1>Magic Academy</h1>
         <p>Slice 0 통합 환경</p>
+        {notice && <p className="message error" role="alert">{notice}</p>}
         <label>아이디<input required minLength="3" value={form.username} onChange={(e) => setForm({ ...form, username: e.target.value })} /></label>
         {mode === "register" && <label>표시 이름<input required value={form.display_name} onChange={(e) => setForm({ ...form, display_name: e.target.value })} /></label>}
         <label>비밀번호<input required minLength="8" type="password" value={form.password} onChange={(e) => setForm({ ...form, password: e.target.value })} /></label>
@@ -64,10 +66,10 @@ function classifyTickError(requestError) {
   if (status === 404 || code === "RESOURCE_NOT_FOUND") {
     return { type: "NOT_FOUND", message: "Simulation을 찾을 수 없습니다." };
   }
-  if (status === 409 || code === "CONFLICT") {
+  if (status === 409 || code === "TICK_ALREADY_RUNNING") {
     return {
-      type: "RETRY_FAILURE",
-      message: "Simulation이 현재 Tick을 진행할 수 있는 상태가 아닙니다. 잠시 후 다시 시도해 주세요.",
+      type: "TICK_ALREADY_RUNNING",
+      message: "이미 진행 중인 Tick이 있습니다. 잠시 후 다시 시도해 주세요.",
     };
   }
   if (status >= 500) {
@@ -91,8 +93,9 @@ export default function App() {
   const [tickLoading, setTickLoading] = useState(false);
   const [tickResult, setTickResult] = useState(null);
   const [tickError, setTickError] = useState(null); // { type, message }
-
-  function resetSession() {
+  const [sessionNotice, setSessionNotice] = useState("");
+  const [authNotice, setAuthNotice] = useState("");
+  function resetSession(notice = "") {
     setAuth(null);
     setSimulation(null);
     setAgents([]);
@@ -100,9 +103,10 @@ export default function App() {
     setError("");
     setTickResult(null);
     setTickError(null);
+    setAuthNotice(notice);
   }
 
-  if (!auth) return <AuthPanel onLogin={setAuth} />;
+  if (!auth) return <AuthPanel onLogin={setAuth} notice={authNotice} />;
 
   async function loadAgents(simulationId) {
     setLoading(true);
@@ -158,9 +162,6 @@ export default function App() {
         {
           token: auth.access_token,
           method: "POST",
-          headers: {
-            "X-Internal-Api-Key": import.meta.env.VITE_INTERNAL_API_KEY,
-          },
           body: JSON.stringify({}),
         }
       );
@@ -169,7 +170,7 @@ export default function App() {
     } catch (requestError) {
       const classified = classifyTickError(requestError);
       if (classified.type === "AUTH") {
-        resetSession();
+        resetSession(classified.message);
         return;
       }
       setTickError(classified);
@@ -177,12 +178,9 @@ export default function App() {
       setTickLoading(false);
     }
   }
-
-  // NOTE: 현재 API 명세(§4.2 ticks/advance 응답)에는 Agent별 행동/발화/판단 근거 필드가
-  // 없다. Agent Runtime Internal API spec §3.2(AgentRuntimeResult)에는 이미
-  // action_type / utterance / motivation_summary / decision_explanation이 정의되어 있으므로,
-  // 백엔드가 이를 ticks/advance 응답에 `agent_results`라는 이름으로 얹어준다고 가정하고
-  // 미리 대응해뒀다. 실제 필드명이 확정되면 아래 한 줄만 바꾸면 된다.
+  // agent_results: agent_id, agent_name, runtime_status(PROPOSED/FALLBACK/SKIPPED),
+  // action_type, utterance, motivation_summary, decision_explanation.influencing_factors,
+  // retry_count, failure_reason (은혜님 스펙 확정, §3.2)
   const agentResults = tickResult?.agent_results ?? [];
   const tickSucceeded = tickResult?.status === "COMPLETED";
   const tickFailed = tickResult && !tickSucceeded;
@@ -255,26 +253,46 @@ export default function App() {
                     </p>
                   ) : (
                     <ul className="agent-result-list">
-                      {agentResults.map((agentResult) => (
-                        <li key={agentResult.agent_id} className="agent-result">
-                          <b>{agentResult.agent_name ?? agentResult.agent_id}</b>
-                          <span className="action-type">{agentResult.action_type}</span>
-                          {agentResult.utterance && <p className="utterance">“{agentResult.utterance}”</p>}
-                          {agentResult.motivation_summary && (
-                            <p className="motivation">{agentResult.motivation_summary}</p>
-                          )}
-                          {agentResult.decision_explanation?.influencing_factors?.length > 0 && (
-                            <ul className="influencing-factors">
-                              {agentResult.decision_explanation.influencing_factors.map((factor, idx) => (
-                                <li key={idx}>
-                                  [{factor.source}] {factor.description} ({factor.direction})
-                                </li>
-                              ))}
-                            </ul>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
+										  {agentResults.map((agentResult) => {
+										    const status = agentResult.runtime_status;
+										    return (
+										      <li key={agentResult.agent_id} className={`agent-result status-${status?.toLowerCase()}`}>
+										        <b>{agentResult.agent_name ?? agentResult.agent_id}</b>
+										        <span className={`runtime-status runtime-status-${status?.toLowerCase()}`}>
+										          {status === "PROPOSED" && "정상 진행"}
+										          {status === "FALLBACK" && "재시도 실패 → Fallback 적용"}
+										          {status === "SKIPPED" && "이번 Tick 미참여"}
+										        </span>
+										        {status === "SKIPPED" ? (
+										          <p className="message">비활성 상태로 이번 Tick에서 행동하지 않았습니다.</p>
+										        ) : (
+										          <>
+										            <span className="action-type">{agentResult.action_type}</span>
+										            {agentResult.utterance && <p className="utterance">“{agentResult.utterance}”</p>}
+										            {agentResult.motivation_summary && (
+										              <p className="motivation">{agentResult.motivation_summary}</p>
+										            )}
+										            {agentResult.decision_explanation?.influencing_factors?.length > 0 && (
+										              <ul className="influencing-factors">
+										                {agentResult.decision_explanation.influencing_factors.map((factor, idx) => (
+										                  <li key={idx}>
+										                    [{factor.source}] {factor.description} ({factor.direction})
+										                  </li>
+										                ))}
+										              </ul>
+										            )}
+										          </>
+										        )}
+										        {status === "FALLBACK" && (
+										          <p className="fallback-info">
+										            재시도 {agentResult.retry_count}회 실패
+										            {agentResult.failure_reason && ` — 사유: ${agentResult.failure_reason}`}
+										          </p>
+										        )}
+										      </li>
+										    );
+										  })}
+										</ul>
                   )}
                 </div>
               )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -49,6 +49,36 @@ function AuthPanel({ onLogin }) {
   );
 }
 
+// 서버 응답의 code/HTTP status를 프론트에서 보여줄 오류 종류로 분류한다.
+// NOTE: ticks/advance 스펙(§4.2)에 정의된 코드(UNAUTHORIZED/RESOURCE_NOT_FOUND/CONFLICT) 기준.
+// "재시도 실패"는 백엔드가 별도 code로 내려주는 필드가 아직 확정되지 않아, 우선 CONFLICT(409)를
+// "지금은 재시도할 수 없는 상태"로 간주해 매핑했다. 실제 재시도 관련 code가 확정되면 이 매핑만
+// 바꾸면 되도록 분리해뒀다.
+function classifyTickError(requestError) {
+  const status = requestError?.status;
+  const code = requestError?.code;
+
+  if (status === 401) {
+    return { type: "AUTH", message: requestError.message };
+  }
+  if (status === 404 || code === "RESOURCE_NOT_FOUND") {
+    return { type: "NOT_FOUND", message: "Simulation을 찾을 수 없습니다." };
+  }
+  if (status === 409 || code === "CONFLICT") {
+    return {
+      type: "RETRY_FAILURE",
+      message: "Simulation이 현재 Tick을 진행할 수 있는 상태가 아닙니다. 잠시 후 다시 시도해 주세요.",
+    };
+  }
+  if (status >= 500) {
+    return {
+      type: "RUNTIME",
+      message: "Tick 실행 중 서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+    };
+  }
+  return { type: "GENERIC", message: requestError?.message || "알 수 없는 오류가 발생했습니다." };
+}
+
 export default function App() {
   const [auth, setAuth] = useState(null);
   const [simulation, setSimulation] = useState(null);
@@ -58,12 +88,18 @@ export default function App() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
+  const [tickLoading, setTickLoading] = useState(false);
+  const [tickResult, setTickResult] = useState(null);
+  const [tickError, setTickError] = useState(null); // { type, message }
+
   function resetSession() {
     setAuth(null);
     setSimulation(null);
     setAgents([]);
     setSelectedAgent(null);
     setError("");
+    setTickResult(null);
+    setTickError(null);
   }
 
   if (!auth) return <AuthPanel onLogin={setAuth} />;
@@ -111,6 +147,46 @@ export default function App() {
     }
   }
 
+  async function runTick() {
+    setTickLoading(true);
+    setTickError(null);
+    setTickResult(null);
+
+    try {
+      const result = await apiRequest(
+        `/v1/simulations/${simulation.id}/ticks/advance`,
+        {
+          token: auth.access_token,
+          method: "POST",
+          headers: {
+            "X-Internal-Api-Key": import.meta.env.VITE_INTERNAL_API_KEY,
+          },
+          body: JSON.stringify({}),
+        }
+      );
+
+      setTickResult(result.data ?? result);
+    } catch (requestError) {
+      const classified = classifyTickError(requestError);
+      if (classified.type === "AUTH") {
+        resetSession();
+        return;
+      }
+      setTickError(classified);
+    } finally {
+      setTickLoading(false);
+    }
+  }
+
+  // NOTE: 현재 API 명세(§4.2 ticks/advance 응답)에는 Agent별 행동/발화/판단 근거 필드가
+  // 없다. Agent Runtime Internal API spec §3.2(AgentRuntimeResult)에는 이미
+  // action_type / utterance / motivation_summary / decision_explanation이 정의되어 있으므로,
+  // 백엔드가 이를 ticks/advance 응답에 `agent_results`라는 이름으로 얹어준다고 가정하고
+  // 미리 대응해뒀다. 실제 필드명이 확정되면 아래 한 줄만 바꾸면 된다.
+  const agentResults = tickResult?.agent_results ?? [];
+  const tickSucceeded = tickResult?.status === "COMPLETED";
+  const tickFailed = tickResult && !tickSucceeded;
+
   return (
     <div className="app-shell">
       <header><strong>Magic Academy</strong><div className="profile"><span>{auth.user.display_name}</span><small>@{auth.user.username}</small></div></header>
@@ -139,6 +215,70 @@ export default function App() {
                 <dl><dt>종류</dt><dd>{selectedAgent.agent_type}</dd><dt>MBTI</dt><dd>{selectedAgent.mbti_type}</dd><dt>학년</dt><dd>{selectedAgent.student_profile ? `${selectedAgent.student_profile.grade}학년` : "-"}</dd><dt>위치</dt><dd>{selectedAgent.location.name}</dd><dt>기분</dt><dd>{selectedAgent.state.mood}</dd><dt>배고픔</dt><dd>{selectedAgent.state.hunger}</dd><dt>피로도</dt><dd>{selectedAgent.state.fatigue}</dd><dt>스트레스</dt><dd>{selectedAgent.state.stress}</dd><dt>만족도</dt><dd>{selectedAgent.state.satisfaction}</dd></dl>
               </>}
             </aside>
+            <div className="panel tick-panel">
+              <h2>Tick</h2>
+
+              <button type="button" onClick={runTick} disabled={tickLoading}>
+                {tickLoading ? "Tick 실행 중..." : "Tick 실행"}
+              </button>
+
+              {tickError && (
+                <p className={`message error tick-error-${tickError.type.toLowerCase()}`} role="alert">
+                  {tickError.message}
+                </p>
+              )}
+
+              {tickError && tickError.type !== "AUTH" && (
+                <button type="button" onClick={runTick} disabled={tickLoading}>
+                  다시 시도
+                </button>
+              )}
+
+              {tickFailed && (
+                <p className="message error" role="alert">
+                  Tick이 완료되지 않았습니다 (상태: {tickResult.status}).
+                </p>
+              )}
+
+              {tickSucceeded && (
+                <div className="tick-result">
+                  <h3>실행 결과</h3>
+                  <p>이전 Tick: {tickResult.previous_tick}</p>
+                  <p>현재 Tick: {tickResult.current_tick}</p>
+                  <p>현재 Day: {tickResult.current_day}</p>
+                  <p>상태: {tickResult.status}</p>
+
+                  <h4>Agent 행동</h4>
+                  {agentResults.length === 0 ? (
+                    <p className="message">
+                      이번 Tick에서 표시할 Agent 행동 결과가 없습니다.
+                    </p>
+                  ) : (
+                    <ul className="agent-result-list">
+                      {agentResults.map((agentResult) => (
+                        <li key={agentResult.agent_id} className="agent-result">
+                          <b>{agentResult.agent_name ?? agentResult.agent_id}</b>
+                          <span className="action-type">{agentResult.action_type}</span>
+                          {agentResult.utterance && <p className="utterance">“{agentResult.utterance}”</p>}
+                          {agentResult.motivation_summary && (
+                            <p className="motivation">{agentResult.motivation_summary}</p>
+                          )}
+                          {agentResult.decision_explanation?.influencing_factors?.length > 0 && (
+                            <ul className="influencing-factors">
+                              {agentResult.decision_explanation.influencing_factors.map((factor, idx) => (
+                                <li key={idx}>
+                                  [{factor.source}] {factor.description} ({factor.direction})
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </div>
           </section>
         )}
       </main>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -17,6 +17,27 @@ const agents = ['professor-01', 'student-01', 'student-02', 'student-03', 'stude
   state: { hunger: 50, fatigue: 0, stress: 0, satisfaction: 50, mood: 0, current_action: null },
   location: { id: `01900000-0000-7000-8000-00000000002${index}`, code: key.startsWith('student') ? 'dormitory' : 'classroom', name: key.startsWith('student') ? '기숙사' : '교실' },
 }))
+function tickResult(overrides = {}) {
+  return {
+    previous_tick: 0,
+    current_tick: 1,
+    current_day: 1,
+    status: 'COMPLETED',
+    agent_results: [],
+    ...overrides,
+  }
+}
+
+async function setupSimulationWithAgents(fetchMock) {
+  fetchMock
+    .mockImplementationOnce(() => response({ access_token: 'token', token_type: 'bearer', user }))
+    .mockImplementationOnce(() => response(simulation, 201))
+    .mockImplementationOnce(() => response(agents))
+  render(<App />)
+  await login()
+  await userEvent.click(screen.getByRole('button', { name: 'Simulation 생성' }))
+  await screen.findByText('Agent 6명')
+}
 
 function response(body, status = 200) {
   return Promise.resolve({ ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) })
@@ -109,5 +130,119 @@ describe('Slice 0 UI', () => {
     expect(document.querySelector('.create-panel')).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: simulation.name })).not.toBeInTheDocument()
     expect(document.querySelectorAll('[data-agent-id]')).toHaveLength(0)
+  })
+  it('shows loading state while a tick is running', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => new Promise(() => {})) // never resolves
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(screen.getByRole('button', { name: 'Tick 실행 중...' })).toBeDisabled()
+  })
+
+  it('renders a PROPOSED agent result on success', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => response(tickResult({
+      agent_results: [{
+        agent_id: agents[0].id,
+        agent_name: agents[0].name,
+        runtime_status: 'PROPOSED',
+        action_type: 'STUDY',
+        utterance: '오늘도 열심히 공부하자',
+        motivation_summary: '학업 성취 욕구가 높음',
+        decision_explanation: { influencing_factors: [{ source: 'mood', description: '기분이 좋음', direction: 'positive' }] },
+        retry_count: 0,
+        failure_reason: null,
+      }],
+    })))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(await screen.findByText('STUDY')).toBeInTheDocument()
+    expect(screen.getByText('“오늘도 열심히 공부하자”')).toBeInTheDocument()
+    expect(screen.getByText('정상 진행')).toBeInTheDocument()
+  })
+
+  it('shows an empty agent-results message', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => response(tickResult({ agent_results: [] })))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(await screen.findByText('이번 Tick에서 표시할 Agent 행동 결과가 없습니다.')).toBeInTheDocument()
+  })
+
+  it('renders a FALLBACK agent result with retry info', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => response(tickResult({
+      agent_results: [{
+        agent_id: agents[0].id,
+        agent_name: agents[0].name,
+        runtime_status: 'FALLBACK',
+        action_type: 'IDLE',
+        utterance: null,
+        motivation_summary: null,
+        decision_explanation: null,
+        retry_count: 3,
+        failure_reason: 'LLM_TIMEOUT',
+      }],
+    })))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(await screen.findByText('재시도 실패 → Fallback 적용')).toBeInTheDocument()
+    expect(screen.getByText('재시도 3회 실패 — 사유: LLM_TIMEOUT')).toBeInTheDocument()
+  })
+
+  it('renders a SKIPPED agent result without action details', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => response(tickResult({
+      agent_results: [{
+        agent_id: agents[0].id,
+        agent_name: agents[0].name,
+        runtime_status: 'SKIPPED',
+        action_type: null,
+        utterance: null,
+        motivation_summary: null,
+        decision_explanation: null,
+        retry_count: 0,
+        failure_reason: null,
+      }],
+    })))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(await screen.findByText('이번 Tick 미참여')).toBeInTheDocument()
+    expect(screen.getByText('비활성 상태로 이번 Tick에서 행동하지 않았습니다.')).toBeInTheDocument()
+    expect(screen.queryByText('IDLE')).not.toBeInTheDocument()
+  })
+
+  it('returns to the login screen with a notice on tick auth error', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => response({ error: { code: 'UNAUTHORIZED', message: '로그인이 필요하거나 만료되었습니다.' } }, 401))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(await screen.findByRole('main')).toHaveClass('auth-shell')
+    expect(screen.getByRole('alert')).toHaveTextContent('로그인이 필요하거나 만료되었습니다.')
+  })
+
+  it('shows a concurrent-tick message on TICK_ALREADY_RUNNING', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => response({
+      error: { code: 'TICK_ALREADY_RUNNING', message: '이미 진행 중인 Tick이 있습니다.' },
+    }, 409))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('이미 진행 중인 Tick이 있습니다')
+    expect(screen.getByRole('button', { name: '다시 시도' })).toBeInTheDocument()
   })
 })

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -245,4 +245,28 @@ describe('Slice 0 UI', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('이미 진행 중인 Tick이 있습니다')
     expect(screen.getByRole('button', { name: '다시 시도' })).toBeInTheDocument()
   })
+    it('does not treat a 409 with a different error code as TICK_ALREADY_RUNNING', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => response({
+      error: { code: 'SIMULATION_LOCKED', message: '시뮬레이션이 잠겨 있습니다.' },
+    }, 409))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('시뮬레이션이 잠겨 있습니다.')
+    expect(screen.queryByText('이미 진행 중인 Tick이 있습니다')).not.toBeInTheDocument()
+  })
+
+  it('sends the tick advance request without a request body', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+    fetchMock.mockImplementationOnce(() => response(tickResult({ agent_results: [] })))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+    await screen.findByText('이번 Tick에서 표시할 Agent 행동 결과가 없습니다.')
+
+    const tickCall = fetchMock.mock.calls.find(([url]) => url.includes('/ticks/advance'))
+    expect(tickCall[1]).not.toHaveProperty('body')
+  })
 })

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -12,9 +12,22 @@ export async function apiRequest(path, { token, ...options } = {}) {
   if (token) headers.Authorization = `Bearer ${token}`;
   const response = await fetch(`${API_URL}${path}`, { ...options, headers });
   if (!response.ok) {
-    const error = new Error(ERROR_MESSAGES[response.status] ?? `요청에 실패했습니다. (${response.status})`);
-    error.status = response.status;
-    throw error;
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    // body 없음/JSON 파싱 실패 — 무시하고 status 기반 메시지로 fallback
   }
+
+  const code = body?.error?.code;
+  const serverMessage = body?.error?.message;
+
+  const error = new Error(
+    serverMessage ?? ERROR_MESSAGES[response.status] ?? `요청에 실패했습니다. (${response.status})`
+  );
+  error.status = response.status;
+  error.code = code;
+  throw error;
+}
   return response.json();
 }

--- a/frontend/src/api/client.test.js
+++ b/frontend/src/api/client.test.js
@@ -14,3 +14,48 @@ describe.each([
     await expect(apiRequest('/test')).rejects.toMatchObject({ status, message })
   })
 })
+describe('API error body parsing', () => {
+  it('extracts code and message from the error body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({
+        error: { code: 'TICK_ALREADY_RUNNING', message: '이미 진행 중인 Tick이 있습니다.', trace_id: 'req_1' },
+      }),
+    })
+
+    await expect(apiRequest('/test')).rejects.toMatchObject({
+      status: 409,
+      code: 'TICK_ALREADY_RUNNING',
+      message: '이미 진행 중인 Tick이 있습니다.',
+    })
+  })
+
+  it('falls back to the status message when the body has no error field', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    })
+
+    await expect(apiRequest('/test')).rejects.toMatchObject({
+      status: 500,
+      code: undefined,
+      message: '서버 오류가 발생했습니다.',
+    })
+  })
+
+  it('falls back gracefully when the body is not JSON', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () => Promise.reject(new Error('not json')),
+    })
+
+    await expect(apiRequest('/test')).rejects.toMatchObject({
+      status: 404,
+      code: undefined,
+      message: 'Simulation을 찾을 수 없습니다.',
+    })
+  })
+})


### PR DESCRIPTION
## 작업 개요
수동 Tick 실행 결과 및 오류 표시 UI를 App.jsx에 구현했다. Tick 실행 버튼, 로딩 처리, 기본 결과/에러 표시는 직접 구현했고, 에러 유형 세분화와 Agent별 행동 표시는 AI 제안을 검토 후 추가 반영했다.

## 관련 Issue
Closes [#84](https://github.com/magic-academy-ma/Magic-Academy/issues/84)

## 변경 내용

**직접 구현**
- `runTick()` 함수 작성 — `POST /ticks/advance` 호출, 로딩/에러/결과 상태 관리
- Tick 실행 버튼 및 실행 중 로딩 상태에 따른 버튼 비활성화·텍스트 전환
- 실행 성공 시 `previous_tick`/`current_tick`/`current_day`/`status` 표시
- 실행 실패 시 에러 메시지 표시 (`tickError`)
- 401 응답 시 세션 종료 처리

**AI 제안 반영 (검토 후 추가)**
- `classifyTickError()` 추가 — HTTP status/code(401/404/409/5xx)에 따라 인증 오류·리소스 없음·재시도 실패·Runtime 오류를 구분해 표시하고 "다시 시도" 버튼 제공
- Agent별 행동(`action_type`)·발화(`utterance`)·판단 근거(`motivation_summary`, `decision_explanation.influencing_factors`) 표시 영역 추가 — `agent_results` 필드는 아직 API 스펙에 없는 가정 필드로, 옵셔널 처리하여 없을 경우 대체 문구 표시
- 빈 결과(`agent_results` 없음)와 실패 상태(`status !== COMPLETED`) 분리 표시
- `resetSession()` 헬퍼로 401 처리 통합 — 기존 코드의 return 누락 버그(401이어도 `setError`까지 실행되던 문제) 수정
- `AuthPanel` 내부 미사용 상태(`tickLoading`/`tickResult`/`tickError`) 제거

## 결정 사항 및 이유
- **`agent_results` 필드명은 확정된 스펙이 아니다.** 현재 `POST /ticks/advance` 응답(§4.2)에는 Agent별 행동/발화/판단 근거 필드가 없고, `AgentRuntimeResult`(Agent Runtime Internal API spec §3.2)에는 `action_type`/`utterance`/`motivation_summary`/`decision_explanation`이 이미 정의되어 있으나 tick 응답으로 노출하는 API가 아직 없다는 걸 이번 작업 중 확인했다. 백엔드 확장을 막지 않기 위해 필드가 없어도 깨지지 않도록 방어 코드를 넣고, 없으면 대체 문구를 표시하도록 했다.
- **재시도 실패는 임시로 409 CONFLICT에 매핑했다.** 재시도 실패를 구분하는 별도 code가 스펙에 없어 우선 "Tick 진행 불가능한 상태"(§4.2 에러 표)를 재시도 실패로 간주했다. 정책 확정 시 매핑만 수정하면 되도록 로직을 분리했다.

## 테스트 / 확인 내용
- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인 (Tick 버튼/로딩/기본 결과 표시는 확인, `agent_results` 관련 UI는 실 API 미구현으로 목업 데이터 확인만 완료)
- [x] 에러 케이스 확인 (401/404/409/5xx 분기 확인, 실 서버 응답 기준 재검증 필요)
- [ ] 관련 문서 업데이트 확인 (`agent_results` API 확장 필요 — 별도 확인 중)

## AI 사용 여부
- 사용 여부: 사용함
- 사용한 작업: 기존 스펙 문서(Backend Internal Contract, API 명세, Policy Engine 설계)와 요구사항 대조를 통한 미구현 항목 식별, 에러 분류 로직 및 Agent 행동 표시 UI 코드 초안 작성
- 사람이 검토한 내용: 전체 코드 리뷰, 에러 분류 매핑(409=재시도 실패) 임시 확정, `agent_results` 필드명 백엔드 협의 필요성 확인 후 방어 코드로 반영

## 리뷰어가 봐야 할 부분
- `agentResults`가 참조하는 `agent_results`는 아직 API 스펙에 없는 가정 필드다. 백엔드 응답 형태 확정 시 필드명 일치 여부(`agent_id`, `utterance` 등) 재확인 필요.
- `classifyTickError()`의 409 → "재시도 실패" 매핑이 실제 정책과 맞는지 확인 필요.
- `resetSession()` 도입으로 인한 401 처리 변경이 다른 화면 흐름(Simulation 생성 중 401 등)에 영향 주는지 확인 요망.