### PR TITLE
[Feature] Slice 2 Task 1 Tick Engine 신호 계약 타입 적용

### DIFF
--- a/backend/app/simulation/agent_runtime.py
+++ b/backend/app/simulation/agent_runtime.py
@@ -69,7 +69,7 @@ class ReactionValence(StrEnum):
     NEGATIVE = "NEGATIVE"
 
 
-class Intensity(StrEnum):
+class SignalIntensity(StrEnum):
     LOW = "LOW"
     MEDIUM = "MEDIUM"
     HIGH = "HIGH"
@@ -211,13 +211,13 @@ class AgentRuntimeInput(StrictModel):
 
 class RelationshipSignal(StrictModel):
     signal_type: RelationshipSignalType
-    intensity: Intensity
+    intensity: SignalIntensity
     target_agent_id: UUID
 
 
 class StateSignal(StrictModel):
     signal_type: StateSignalType
-    intensity: Intensity
+    intensity: SignalIntensity
 
 
 class AgentReaction(StrictModel):

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -2,6 +2,16 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Coroutine
 
+from app.simulation.agent_runtime import (
+    AgentReaction,
+    AgentRuntimeResult,
+    RelationshipSignal,
+    RelationshipSignalType,
+    SignalIntensity,
+    StateSignal,
+    StateSignalType,
+)
+
 
 class AgentType(str, Enum):
     STUDENT = "student"
@@ -34,7 +44,7 @@ class PolicyInput:
     """Runtime 결과를 Policy로 전달하는 단위"""
     agent_id: str
     event_id: str
-    runtime_result: dict[str, Any]
+    runtime_result: AgentRuntimeResult
 
 
 @dataclass
@@ -42,7 +52,7 @@ class TickResult:
     """Tick 실행 결과"""
     status: str  # "completed" | "failed"
     participant_ids: list[str]
-    runtime_outputs: dict[str, dict[str, Any]]
+    runtime_outputs: dict[str, AgentRuntimeResult]
 
 
 class TickConflictError(Exception):
@@ -60,7 +70,7 @@ class TickRollbackError(Exception):
 # (agents, event, snapshot) → {agent_id: result} batch 방식 1회 호출
 AgentRuntimeFn = Callable[
     [list[TickAgent], TickEvent, WorldSnapshot],
-    Coroutine[Any, Any, dict[str, Any]],
+    Coroutine[Any, Any, dict[str, AgentRuntimeResult]],
 ]
 PolicyFn = Callable[[list[PolicyInput]], Coroutine[Any, Any, None]]
 
@@ -92,7 +102,7 @@ class TickEngine:
             participants = self._select_participants(
                 agents, event, schedule_requires_professor=schedule_requires_professor
             )
-            runtime_outputs: dict[str, Any] = {}
+            runtime_outputs: dict[str, AgentRuntimeResult] = {}
 
             if participants:
                 runtime_outputs = await self._runtime(participants, event, snapshot)

--- a/backend/tests/test_agent_runtime.py
+++ b/backend/tests/test_agent_runtime.py
@@ -13,6 +13,7 @@ from app.simulation.agent_runtime import (
     MockLLMClient,
     RuntimeStatus,
     ScheduleSummary,
+    SignalIntensity,
     validate_intent_candidate,
 )
 
@@ -87,7 +88,7 @@ def test_valid_attend_class_response(runtime_input: AgentRuntimeInput) -> None:
     assert candidate.target_location_id == LOCATION_IDS[0]
     assert candidate.related_event_id == CLASS_EVENT_ID
     assert candidate.reaction.state_signals[0].signal_type.value == "FATIGUE_UP"
-    assert candidate.reaction.state_signals[0].intensity.value == "LOW"
+    assert candidate.reaction.state_signals[0].intensity is SignalIntensity.LOW
 
 
 def test_typed_relationship_signal_accepts_valid_other_agent(
@@ -106,7 +107,7 @@ def test_typed_relationship_signal_accepts_valid_other_agent(
 
     signal = candidate.reaction.relationship_signals[0]
     assert signal.signal_type.value == "TRUST_UP"
-    assert signal.intensity.value == "HIGH"
+    assert signal.intensity is SignalIntensity.HIGH
     assert signal.target_agent_id == STUDENT_IDS[1]
 
 

--- a/backend/tests/test_signal_contract.py
+++ b/backend/tests/test_signal_contract.py
@@ -1,0 +1,82 @@
+from typing import get_type_hints
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from app.simulation.tick_engine import (
+    AgentReaction,
+    AgentRuntimeResult,
+    PolicyInput,
+    RelationshipSignal,
+    RelationshipSignalType,
+    SignalIntensity,
+    StateSignal,
+    StateSignalType,
+)
+
+
+AGENT_ID = UUID("00000000-0000-0000-0000-000000000001")
+TARGET_AGENT_ID = UUID("00000000-0000-0000-0000-000000000002")
+
+
+def test_signal_enum_contract_is_frozen() -> None:
+    assert {item.value for item in SignalIntensity} == {"LOW", "MEDIUM", "HIGH"}
+    assert {item.value for item in RelationshipSignalType} == {
+        "TRUST_UP",
+        "TRUST_DOWN",
+        "AFFECTION_UP",
+        "AFFECTION_DOWN",
+        "CLOSENESS_UP",
+        "CLOSENESS_DOWN",
+        "TENSION_UP",
+        "TENSION_DOWN",
+        "RIVALRY_UP",
+        "RIVALRY_DOWN",
+        "DEPENDENCY_UP",
+        "DEPENDENCY_DOWN",
+    }
+    assert {item.value for item in StateSignalType} == {
+        "HUNGER_UP",
+        "HUNGER_DOWN",
+        "FATIGUE_UP",
+        "FATIGUE_DOWN",
+        "STRESS_UP",
+        "STRESS_DOWN",
+        "SATISFACTION_UP",
+        "SATISFACTION_DOWN",
+        "MOOD_UP",
+        "MOOD_DOWN",
+    }
+
+
+def test_signal_models_have_per_signal_intensity_and_required_target() -> None:
+    relationship_signal = RelationshipSignal(
+        signal_type="TRUST_UP",
+        intensity="HIGH",
+        target_agent_id=TARGET_AGENT_ID,
+    )
+    state_signal = StateSignal(signal_type="FATIGUE_UP", intensity="LOW")
+
+    assert relationship_signal.intensity is SignalIntensity.HIGH
+    assert relationship_signal.target_agent_id == TARGET_AGENT_ID
+    assert state_signal.intensity is SignalIntensity.LOW
+
+    with pytest.raises(ValidationError, match="target_agent_id"):
+        RelationshipSignal(signal_type="TRUST_UP", intensity="LOW")
+
+
+def test_agent_reaction_defaults_to_empty_signal_lists() -> None:
+    reaction = AgentReaction(valence="NEUTRAL")
+
+    assert reaction.relationship_signals == []
+    assert reaction.state_signals == []
+
+
+def test_agent_reaction_rejects_legacy_numeric_delta() -> None:
+    with pytest.raises(ValidationError, match="relationship_delta"):
+        AgentReaction(valence="POSITIVE", relationship_delta={"trust": 5})
+
+
+def test_policy_input_uses_agent_runtime_result_contract() -> None:
+    assert get_type_hints(PolicyInput)["runtime_result"] is AgentRuntimeResult

--- a/backend/tests/test_slice1_acceptance.py
+++ b/backend/tests/test_slice1_acceptance.py
@@ -11,6 +11,7 @@ Slice 1 인수 조건 — 은혜님 파트 (Tick·Event 흐름)
 """
 import pytest
 
+from app.simulation.agent_runtime import AgentRuntimeResult
 from app.simulation.tick_engine import (
     AgentType,
     PolicyInput,
@@ -25,20 +26,76 @@ from app.simulation.tick_engine import (
 )
 
 
+AGENT_IDS = {
+    "s-1": "00000000-0000-0000-0000-000000000001",
+    "s-2": "00000000-0000-0000-0000-000000000002",
+    "p-1": "00000000-0000-0000-0000-000000000003",
+    "s-active": "00000000-0000-0000-0000-000000000004",
+    "s-inactive": "00000000-0000-0000-0000-000000000005",
+}
+
+
+def agent_id(alias: str) -> str:
+    return AGENT_IDS[alias]
+
+
 def student(sid: str, *, is_active: bool = True) -> TickAgent:
-    return TickAgent(id=sid, agent_type=AgentType.STUDENT, is_active=is_active)
+    return TickAgent(id=agent_id(sid), agent_type=AgentType.STUDENT, is_active=is_active)
 
 
 def professor(pid: str, *, is_active: bool = True) -> TickAgent:
-    return TickAgent(id=pid, agent_type=AgentType.PROFESSOR, is_active=is_active)
+    return TickAgent(id=agent_id(pid), agent_type=AgentType.PROFESSOR, is_active=is_active)
 
 
 def class_event(*participant_ids: str) -> TickEvent:
-    return TickEvent(id="evt-1", event_type="class", participant_ids=set(participant_ids))
+    return TickEvent(
+        id="evt-1",
+        event_type="class",
+        participant_ids={agent_id(item) for item in participant_ids},
+    )
 
 
 def snapshot() -> WorldSnapshot:
     return WorldSnapshot(simulation_id="sim-1", current_tick=1, data={})
+
+
+def make_runtime_result(
+    agent: TickAgent, *, status: str = "PROPOSED"
+) -> AgentRuntimeResult:
+    return AgentRuntimeResult.model_validate(
+        {
+            "run_id": "slice-1-run",
+            "tick_number": 1,
+            "agent_id": agent.id,
+            "status": status,
+            "intent": {
+                "action_type": "STUDY",
+                "target_agent_id": None,
+                "target_location_id": None,
+                "related_event_id": None,
+                "utterance": None,
+                "motivation_summary": "수업 내용을 복습한다.",
+                "reaction": {"valence": "NEUTRAL"},
+                "decision_explanation": {
+                    "alternatives": [
+                        {
+                            "action_type": "STUDY",
+                            "description": "복습한다.",
+                            "relative_priority": "HIGH",
+                            "selected": True,
+                        }
+                    ],
+                    "influencing_factors": [],
+                },
+                "memory_candidates": [],
+            },
+            "retry_count": 0,
+            "failure_reason": None,
+            "model": "mock-llm",
+            "prompt_version": "slice-1-test",
+            "idempotency_key": f"slice-1-run:1:{agent.id}",
+        }
+    )
 
 
 # ── Runtime 결과 → Policy 전달 ────────────────────────────────────────────────
@@ -47,9 +104,12 @@ def snapshot() -> WorldSnapshot:
 async def test_runtime_result_passed_to_policy():
     """Runtime 결과가 PolicyInput에 담겨 Policy 콜백으로 전달된다"""
     policy_inputs: list[PolicyInput] = []
+    expected_result: AgentRuntimeResult | None = None
 
     async def runtime(agents, event, snap):
-        return {a.id: {"intent": "study", "reaction": {"trust": +5}} for a in agents}
+        nonlocal expected_result
+        expected_result = make_runtime_result(agents[0])
+        return {agents[0].id: expected_result}
 
     async def policy(inputs: list[PolicyInput]) -> None:
         policy_inputs.extend(inputs)
@@ -62,8 +122,8 @@ async def test_runtime_result_passed_to_policy():
     )
 
     assert len(policy_inputs) == 1
-    assert policy_inputs[0].agent_id == "s-1"
-    assert policy_inputs[0].runtime_result == {"intent": "study", "reaction": {"trust": +5}}
+    assert policy_inputs[0].agent_id == agent_id("s-1")
+    assert policy_inputs[0].runtime_result is expected_result
 
 
 async def test_all_participants_results_passed_to_policy():
@@ -71,7 +131,7 @@ async def test_all_participants_results_passed_to_policy():
     received: list[PolicyInput] = []
 
     async def runtime(agents, event, snap):
-        return {a.id: {"intent": "attend"} for a in agents}
+        return {agent.id: make_runtime_result(agent) for agent in agents}
 
     async def policy(inputs: list[PolicyInput]) -> None:
         received.extend(inputs)
@@ -84,7 +144,10 @@ async def test_all_participants_results_passed_to_policy():
     )
 
     assert len(received) == 2
-    assert {p.agent_id for p in received} == {"s-1", "p-1"}
+    assert {p.agent_id for p in received} == {
+        agent_id("s-1"),
+        agent_id("p-1"),
+    }
 
 
 async def test_policy_receives_event_context():
@@ -92,7 +155,7 @@ async def test_policy_receives_event_context():
     received: list[PolicyInput] = []
 
     async def runtime(agents, event, snap):
-        return {a.id: {"intent": "study"} for a in agents}
+        return {agent.id: make_runtime_result(agent) for agent in agents}
 
     async def policy(inputs: list[PolicyInput]) -> None:
         received.extend(inputs)
@@ -114,7 +177,7 @@ async def test_tick_result_contains_participant_ids():
     """TickResult에 Runtime batch에 전달된 Agent ID 목록이 담긴다"""
 
     async def runtime(agents, event, snap):
-        return {a.id: {"intent": "study"} for a in agents}
+        return {agent.id: make_runtime_result(agent) for agent in agents}
 
     # Student는 모두 포함, Professor는 Event 미참여 시 제외
     agents = [student("s-1"), professor("p-1")]
@@ -124,15 +187,15 @@ async def test_tick_result_contains_participant_ids():
         agents=agents, event=event, snapshot=snapshot()
     )
 
-    assert "s-1" in result.participant_ids
-    assert "p-1" not in result.participant_ids
+    assert agent_id("s-1") in result.participant_ids
+    assert agent_id("p-1") not in result.participant_ids
 
 
 async def test_tick_result_contains_runtime_outputs():
     """TickResult에 각 Agent의 Runtime 결과가 담긴다"""
 
     async def runtime(agents, event, snap):
-        return {a.id: {"intent": f"action-{a.id}"} for a in agents}
+        return {agent.id: make_runtime_result(agent) for agent in agents}
 
     agents = [student("s-1"), student("s-2")]
     event = class_event("s-1", "s-2")
@@ -141,8 +204,8 @@ async def test_tick_result_contains_runtime_outputs():
         agents=agents, event=event, snapshot=snapshot()
     )
 
-    assert result.runtime_outputs["s-1"] == {"intent": "action-s-1"}
-    assert result.runtime_outputs["s-2"] == {"intent": "action-s-2"}
+    assert result.runtime_outputs[agent_id("s-1")].agent_id.hex.endswith("0001")
+    assert result.runtime_outputs[agent_id("s-2")].agent_id.hex.endswith("0002")
 
 
 async def test_inactive_agent_in_runtime_batch_with_skipped_result():
@@ -152,13 +215,13 @@ async def test_inactive_agent_in_runtime_batch_with_skipped_result():
 
     async def runtime(agents, event, snap):
         result = {}
-        for a in agents:
-            if not a.is_active:
-                result[a.id] = {"status": "SKIPPED"}
+        for agent in agents:
+            if not agent.is_active:
+                result[agent.id] = make_runtime_result(agent, status="SKIPPED")
             else:
                 nonlocal llm_call_count
                 llm_call_count += 1
-                result[a.id] = {"intent": "study"}
+                result[agent.id] = make_runtime_result(agent)
         return result
 
     active = student("s-active")
@@ -170,10 +233,10 @@ async def test_inactive_agent_in_runtime_batch_with_skipped_result():
     )
 
     # 비활성 Agent도 participant_ids에 포함
-    assert "s-inactive" in result.participant_ids
-    assert "s-active" in result.participant_ids
+    assert agent_id("s-inactive") in result.participant_ids
+    assert agent_id("s-active") in result.participant_ids
     # SKIPPED 결과가 runtime_outputs에 포함
-    assert result.runtime_outputs["s-inactive"] == {"status": "SKIPPED"}
+    assert result.runtime_outputs[agent_id("s-inactive")].status.value == "SKIPPED"
     # LLM 호출은 활성 Agent에만
     assert llm_call_count == 1
 
@@ -185,7 +248,7 @@ async def test_tick_state_transitions_on_success():
     """Tick 완료 후 TickResult status가 completed다"""
 
     async def runtime(agents, event, snap):
-        return {a.id: {"intent": "study"} for a in agents}
+        return {agent.id: make_runtime_result(agent) for agent in agents}
 
     s1 = student("s-1")
     event = class_event("s-1")


### PR DESCRIPTION
## 작업 개요

Slice 2 Task 1 범위로 Agent Runtime의 reaction signal 계약 타입을 추가하고, Tick Engine이 타입이 지정된 Runtime 결과를 사용하도록 변경했습니다.

공식 Slice 2 베이스에 반영된 Slice 1의 batch Runtime 호출 및 실행 대상 선정 동작을 유지하면서 signal 계약과 Slice 1 테스트를 정합화했습니다.


## 관련 Issue

Closes #45 

## 변경 내용

- `RelationshipSignal`, `StateSignal`, `SignalIntensity` 계약 추가
- `AgentReaction`, `AgentRuntimeResult` 계약 추가
- `PolicyInput.runtime_result`를 `dict`에서 `AgentRuntimeResult`로 변경
- Runtime callback 반환 타입과 `TickResult.runtime_outputs` 타입 정합화
- Tick Engine에서 signal 및 Runtime 계약 타입 import/re-export
- Slice 1 인수 테스트를 실제 Pydantic `AgentRuntimeResult` 기반으로 변경
- signal enum, 개별 intensity, 필수 target, 기본 빈 signal 목록 검증 테스트 추가
- legacy `delta` 입력 거부 계약 테스트 추가

## 결정 사항 및 이유

- signal 및 Runtime 결과 타입은 `agent_runtime.py`를 단일 계약 정의 위치로 사용했습니다.
- Tick Engine에서는 해당 타입을 import/re-export하여 외부 사용 경로를 유지하고, 중복 dataclass 정의를 방지했습니다.
- `PolicyInput.runtime_result`에 구체적인 Pydantic 모델을 사용하여 Runtime과 Policy Engine 사이의 입력 계약을 명확하게 검증하도록 했습니다.
- 공식 Slice 2 베이스의 batch Runtime 호출, Student 전체 및 조건부 Professor 실행, 비활성 Agent의 `SKIPPED` 처리 규칙은 그대로 유지했습니다.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [x] 관련 문서 업데이트 확인

## AI 사용 여부

사용 여부: 사용함 
사용한 작업: 
- 기존 WIP 변경을 공식 Slice 2 베이스로 이관하는 과정 지원
- 충돌 파일 분석 및 해결
- signal 계약과 Runtime 타입 정합성 검토
- 테스트 실행 및 회귀 결과 확인
사람이 검토한 내용:
- Task 1 요구사항과 실제 변경 범위
- 공식 베이스의 Slice 1 동작 보존 여부
- 변경 파일 및 충돌 해결 결과
- 테스트 결과와 커밋 대상 파일

## 리뷰어가 봐야 할 부분

- `agent_runtime.py`를 signal/runtime 계약의 단일 정의 위치로 사용한 구조
- `PolicyInput.runtime_result`가 `AgentRuntimeResult`로 올바르게 교체되었는지
- Tick Engine의 callback 및 `runtime_outputs` 타입 정합성
- 기존 Slice 1 batch 실행과 비활성 Agent `SKIPPED` 동작이 유지되는지
- legacy `delta` 입력을 허용하지 않는 계약이 적절한지