### PR TITLE
[Feature] Slice 3 Task 2 — Runtime memory 입출력 계약 구현

### DIFF
--- a/backend/app/simulation/agent_runtime.py
+++ b/backend/app/simulation/agent_runtime.py
@@ -287,6 +287,7 @@ class AgentRuntimeResult(StrictModel):
     agent_id: UUID
     status: RuntimeStatus
     intent: IntentCandidate
+    memory_candidate: MemoryCandidateItem | None = None
     retry_count: int = Field(ge=0)
     failure_reason: str | None
     model: str

--- a/backend/app/simulation/agent_runtime.py
+++ b/backend/app/simulation/agent_runtime.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Literal, Protocol, TypedDict
 from uuid import UUID
@@ -12,6 +13,15 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+
+
+@dataclass
+class MemoryCandidateItem:
+    """Runtime이 반환하는 기억 후보 — id 없음, 저장은 Tick Engine 담당."""
+
+    content: str
+    memory_type: str  # "observation" | "conversation" | "reflection" | "plan"
+    importance: int  # 0–100
 
 
 class StrictModel(BaseModel):

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Coroutine
 from app.simulation.agent_runtime import (
     AgentReaction,
     AgentRuntimeResult,
+    MemoryCandidateItem,
     RelationshipSignal,
     RelationshipSignalType,
     SignalIntensity,
@@ -59,14 +60,6 @@ class MemoryItem:
     importance: int   # 0–100
     created_tick: int
     event_id: str | None
-
-
-@dataclass
-class MemoryCandidateItem:
-    """Runtime이 반환하는 기억 후보 — id 없음, 저장은 Tick Engine 담당."""
-    content: str
-    memory_type: str  # "observation" | "conversation" | "reflection" | "plan"
-    importance: int   # 0–100
 
 
 # ─── Tick 결과 ─────────────────────────────────────────────────────────────────

--- a/backend/tests/test_slice3_memory_contract.py
+++ b/backend/tests/test_slice3_memory_contract.py
@@ -1,0 +1,35 @@
+from dataclasses import fields, is_dataclass
+
+from app.simulation import agent_runtime, tick_engine
+from app.simulation.tick_engine import MemoryCandidateItem
+
+
+def test_memory_item_contract() -> None:
+    assert is_dataclass(tick_engine.MemoryItem)
+    assert [field.name for field in fields(tick_engine.MemoryItem)] == [
+        "id",
+        "content",
+        "memory_type",
+        "importance",
+        "created_tick",
+        "event_id",
+    ]
+
+
+def test_memory_candidate_item_contract_and_legacy_import_path() -> None:
+    assert is_dataclass(agent_runtime.MemoryCandidateItem)
+    assert [field.name for field in fields(agent_runtime.MemoryCandidateItem)] == [
+        "content",
+        "memory_type",
+        "importance",
+    ]
+    assert not hasattr(
+        agent_runtime.MemoryCandidateItem(
+            content="카이와 과제를 함께 정리했다.",
+            memory_type="conversation",
+            importance=4,
+        ),
+        "id",
+    )
+    assert tick_engine.MemoryCandidateItem is agent_runtime.MemoryCandidateItem
+    assert MemoryCandidateItem is agent_runtime.MemoryCandidateItem

--- a/backend/tests/test_slice3_memory_contract.py
+++ b/backend/tests/test_slice3_memory_contract.py
@@ -1,7 +1,54 @@
 from dataclasses import fields, is_dataclass
+from typing import get_type_hints
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
 
 from app.simulation import agent_runtime, tick_engine
 from app.simulation.tick_engine import MemoryCandidateItem
+
+
+AGENT_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+def valid_runtime_result_payload() -> dict[str, object]:
+    return {
+        "run_id": "slice-3-memory-contract",
+        "tick_number": 3,
+        "agent_id": AGENT_ID,
+        "status": "PROPOSED",
+        "intent": {
+            "action_type": "STUDY",
+            "target_agent_id": None,
+            "target_location_id": None,
+            "related_event_id": None,
+            "utterance": None,
+            "motivation_summary": "마법 이론을 복습한다.",
+            "reaction": {
+                "valence": "NEUTRAL",
+                "relationship_signals": [],
+                "state_signals": [],
+            },
+            "decision_explanation": {
+                "alternatives": [
+                    {
+                        "action_type": "STUDY",
+                        "description": "마법 이론을 복습한다.",
+                        "relative_priority": "HIGH",
+                        "selected": True,
+                    }
+                ],
+                "influencing_factors": [],
+            },
+            "memory_candidates": [],
+        },
+        "retry_count": 0,
+        "failure_reason": None,
+        "model": "mock-llm",
+        "prompt_version": "agent-runtime-10.1",
+        "idempotency_key": f"slice-3-memory-contract:3:{AGENT_ID}",
+    }
 
 
 def test_memory_item_contract() -> None:
@@ -33,3 +80,40 @@ def test_memory_candidate_item_contract_and_legacy_import_path() -> None:
     )
     assert tick_engine.MemoryCandidateItem is agent_runtime.MemoryCandidateItem
     assert MemoryCandidateItem is agent_runtime.MemoryCandidateItem
+
+
+def test_runtime_result_memory_candidate_defaults_to_none() -> None:
+    result = agent_runtime.AgentRuntimeResult.model_validate(
+        valid_runtime_result_payload()
+    )
+
+    assert result.memory_candidate is None
+    assert (
+        get_type_hints(agent_runtime.AgentRuntimeResult)["memory_candidate"]
+        == MemoryCandidateItem | None
+    )
+
+
+def test_runtime_result_preserves_memory_candidate() -> None:
+    payload = valid_runtime_result_payload()
+    payload["memory_candidate"] = MemoryCandidateItem(
+        content="마법 이론을 복습했다.",
+        memory_type="observation",
+        importance=6,
+    )
+
+    result = agent_runtime.AgentRuntimeResult.model_validate(payload)
+
+    assert result.memory_candidate == MemoryCandidateItem(
+        content="마법 이론을 복습했다.",
+        memory_type="observation",
+        importance=6,
+    )
+
+
+def test_runtime_result_rejects_unexpected_extra_field() -> None:
+    payload = valid_runtime_result_payload()
+    payload["unexpected"] = "value"
+
+    with pytest.raises(ValidationError, match="unexpected"):
+        agent_runtime.AgentRuntimeResult.model_validate(payload)


### PR DESCRIPTION
## 작업 개요

Slice 3의 Runtime memory 입출력 계약을 실제 AgentRuntimeResult에 반영했습니다.
MemoryCandidateItem의 정의 위치를 통합하고, 기존 Tick Engine import 경로와 Runtime payload의 하위 호환성을 유지했습니다.

## 관련 Issue

Closes #71 

## 변경 내용

- MemoryCandidateItem 정의를 agent_runtime.py로 이동
- AgentRuntimeResult에 memory_candidate: MemoryCandidateItem | None = None 필드 추가
- tick_engine.py에서 기존 import 경로를 유지하도록 MemoryCandidateItem re-export
- Runtime memory 계약과 Pydantic 검증을 확인하는 테스트 추가

## 결정 사항 및 이유

AgentRuntimeResult가 정의된 agent_runtime.py에 MemoryCandidateItem을 함께 배치해 Runtime 계약의 정의 위치를 통합했습니다.
tick_engine.py는 agent_runtime.py의 타입을 import하고 있으므로, 반대 방향의 import를 추가하면 순환 참조가 발생할 수 있습니다. 이를 방지하기 위해 MemoryCandidateItem을 agent_runtime.py에 정의하고 tick_engine.py에서 import 및 re-export하도록 구성했습니다.
또한 memory_candidate의 기본값을 None으로 지정해 기존 Runtime payload가 변경 없이 계속 검증되도록 했습니다.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [x] 관련 문서 업데이트 확인

## AI 사용 여부

사용 여부: 사용함 
사용한 작업: 구현 범위 분석, 테스트 케이스 작성, 코드 변경 및 회귀 테스트 실행
사람이 검토한 내용: Issue 계약 반영 여부, 변경 범위, 테스트 결과 및 커밋 내역

## 리뷰어가 봐야 할 부분

- MemoryCandidateItem의 정의 위치가 Runtime 계약 기준으로 적절한지
- tick_engine.py의 기존 import 경로가 정상적으로 유지되는지
- 기존 Runtime payload가 memory_candidate 없이도 정상 검증되는지
- policy/types.py의 임시 중복 AgentRuntimeResult는 이번 Issue 범위에서 수정하지 않았습니다.
