### PR TITLE
[Feature] Slice 3 Task 3 — Tick Memory 서비스 경계 구현

### DIFF
--- a/backend/app/services/tick_memory.py
+++ b/backend/app/services/tick_memory.py
@@ -1,0 +1,92 @@
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Protocol
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.repositories.memory_repository import MemoryCreateInput, MemoryRepository, MemoryRow
+from app.simulation.tick_engine import MemoryCandidateItem, MemoryItem
+
+
+class EmbeddingProvider(Protocol):
+    def embed(self, text: str) -> Sequence[float]: ...
+
+
+class TickMemoryService:
+    def __init__(
+        self,
+        repository: MemoryRepository,
+        embedding_provider: EmbeddingProvider,
+    ) -> None:
+        self._repository = repository
+        self._embedding_provider = embedding_provider
+
+    def retrieve(
+        self,
+        session: Session,
+        agent_id: str,
+        current_tick: int,
+        query_text: str,
+    ) -> list[MemoryItem]:
+        repository_agent_id = self._parse_uuid(agent_id, "agent_id")
+        query_embedding = self._embed(query_text)
+        rows = self._repository.retrieve_for_runtime(
+            session,
+            repository_agent_id,
+            current_tick,
+            query_embedding,
+        )
+        return [self._to_item(row) for row in rows]
+
+    def store(
+        self,
+        session: Session,
+        agent_id: str,
+        event_id: str | None,
+        candidate: MemoryCandidateItem,
+        current_tick: int,
+    ) -> str:
+        repository_agent_id = self._parse_uuid(agent_id, "agent_id")
+        repository_event_id = (
+            None if event_id is None else self._parse_uuid(event_id, "event_id")
+        )
+        row = self._repository.create(
+            session,
+            MemoryCreateInput(
+                agent_id=repository_agent_id,
+                event_id=repository_event_id,
+                content=candidate.content,
+                memory_type=candidate.memory_type,
+                importance=candidate.importance,
+                created_tick=current_tick,
+                occurred_at=datetime.now(UTC),
+                embedding=self._embed(candidate.content),
+            ),
+        )
+        self._repository.enforce_cap(session, repository_agent_id, max_active=10)
+        return str(row.id)
+
+    def _embed(self, text: str) -> list[float]:
+        embedding = list(self._embedding_provider.embed(text))
+        if len(embedding) != 1536:
+            raise ValueError("embedding must contain exactly 1536 values")
+        return embedding
+
+    @staticmethod
+    def _parse_uuid(value: str, field_name: str) -> UUID:
+        try:
+            return UUID(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"{field_name} must be a UUID") from None
+
+    @staticmethod
+    def _to_item(row: MemoryRow) -> MemoryItem:
+        return MemoryItem(
+            id=str(row.id),
+            content=row.content,
+            memory_type=row.memory_type,
+            importance=row.importance,
+            created_tick=row.created_tick,
+            event_id=None if row.event_id is None else str(row.event_id),
+        )

--- a/backend/tests/test_tick_memory_service.py
+++ b/backend/tests/test_tick_memory_service.py
@@ -1,0 +1,128 @@
+from datetime import UTC
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+from app.repositories.memory_repository import MemoryRow
+from app.services.tick_memory import TickMemoryService
+from app.simulation.tick_engine import MemoryCandidateItem
+
+
+AGENT_ID = UUID("00000000-0000-0000-0000-000000000001")
+EVENT_ID = UUID("00000000-0000-0000-0000-000000000002")
+MEMORY_ID = UUID("00000000-0000-0000-0000-000000000003")
+EMBEDDING = [0.1] * 1536
+
+
+class FakeEmbeddingProvider:
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    def embed(self, text: str) -> list[float]:
+        self.texts.append(text)
+        return EMBEDDING
+
+
+class FakeMemoryRepository:
+    def __init__(self) -> None:
+        self.retrieve_calls: list[tuple] = []
+        self.created = None
+        self.cap_calls: list[tuple] = []
+
+    def retrieve_for_runtime(self, session, agent_id, current_tick, query_embedding):
+        self.retrieve_calls.append((session, agent_id, current_tick, query_embedding))
+        return [
+            MemoryRow(
+                id=MEMORY_ID,
+                agent_id=AGENT_ID,
+                event_id=EVENT_ID,
+                content="이전 수업 기억",
+                memory_type="observation",
+                importance=70,
+                created_tick=2,
+                occurred_at=MagicMock(),
+                embedding=EMBEDDING,
+            )
+        ]
+
+    def create(self, session, item):
+        self.created = (session, item)
+        return MemoryRow(
+            id=MEMORY_ID,
+            agent_id=item.agent_id,
+            event_id=item.event_id,
+            content=item.content,
+            memory_type=item.memory_type,
+            importance=item.importance,
+            created_tick=item.created_tick,
+            occurred_at=item.occurred_at,
+            embedding=list(item.embedding),
+        )
+
+    def enforce_cap(self, session, agent_id, max_active=10):
+        self.cap_calls.append((session, agent_id, max_active))
+        return 0
+
+
+def test_retrieve_converts_uuid_rows_to_tick_memory_items() -> None:
+    session = MagicMock()
+    repository = FakeMemoryRepository()
+    embedding_provider = FakeEmbeddingProvider()
+    service = TickMemoryService(repository, embedding_provider)
+
+    items = service.retrieve(session, str(AGENT_ID), 3, "class")
+
+    assert embedding_provider.texts == ["class"]
+    assert repository.retrieve_calls == [(session, AGENT_ID, 3, EMBEDDING)]
+    assert items[0].id == str(MEMORY_ID)
+    assert items[0].event_id == str(EVENT_ID)
+    assert items[0].content == "이전 수업 기억"
+
+
+def test_store_converts_tick_candidate_and_applies_cap_without_commit() -> None:
+    session = MagicMock()
+    repository = FakeMemoryRepository()
+    embedding_provider = FakeEmbeddingProvider()
+    service = TickMemoryService(repository, embedding_provider)
+    candidate = MemoryCandidateItem(
+        content="새 주문을 익혔다",
+        memory_type="observation",
+        importance=60,
+    )
+
+    memory_id = service.store(
+        session,
+        str(AGENT_ID),
+        str(EVENT_ID),
+        candidate,
+        current_tick=3,
+    )
+
+    _, created = repository.created
+    assert created.agent_id == AGENT_ID
+    assert created.event_id == EVENT_ID
+    assert created.embedding == EMBEDDING
+    assert created.occurred_at.tzinfo is UTC
+    assert repository.cap_calls == [(session, AGENT_ID, 10)]
+    assert memory_id == str(MEMORY_ID)
+    session.commit.assert_not_called()
+
+
+def test_invalid_agent_id_is_rejected_before_repository_call() -> None:
+    repository = FakeMemoryRepository()
+    service = TickMemoryService(repository, FakeEmbeddingProvider())
+
+    with pytest.raises(ValueError, match="agent_id must be a UUID"):
+        service.retrieve(MagicMock(), "not-a-uuid", 3, "class")
+
+    assert repository.retrieve_calls == []
+
+
+def test_invalid_embedding_dimension_is_rejected() -> None:
+    provider = FakeEmbeddingProvider()
+    provider.embed = MagicMock(return_value=[0.1])
+    service = TickMemoryService(FakeMemoryRepository(), provider)
+
+    with pytest.raises(ValueError, match="1536"):
+        service.retrieve(MagicMock(), str(AGENT_ID), 3, "class")

--- a/docs/decisions/001-sync-session-boundary.md
+++ b/docs/decisions/001-sync-session-boundary.md
@@ -1,0 +1,35 @@
+---
+authored_with: Codex
+features_used:
+  - github:github
+  - orca-cli
+date: 2026-08-20
+status: accepted
+---
+
+# 001. Tick Memory의 동기 Session 경계
+
+## 배경
+
+현재 인증, Simulation, Runtime 결과와 Memory Repository는 SQLAlchemy 동기 `Session`을 사용한다. Slice 3 계획의 `AsyncSession` 예시만 적용하면 Memory 경로에 별도 세션 체계가 생기며, 하나의 Tick에서 트랜잭션 책임이 분산된다.
+
+## 결정
+
+Slice 3에서는 기존 동기 `Session`을 유지한다. Repository는 `flush`까지만 수행하고 commit과 rollback은 상위 Tick Coordinator가 담당한다. 비동기 API에서 동기 DB 구간을 실행할 때는 해당 worker 안에서 Session을 생성하고 종료하며, Session을 thread 경계 밖으로 전달하지 않는다.
+
+DB snapshot과 최종 commit의 격리 수준은 `tick-engine.md`의 기존 결정인 `REPEATABLE READ`와 `READ COMMITTED`를 따른다. 전체 `AsyncSession` 전환은 백엔드 DB 계층 전체를 대상으로 별도 결정과 migration 계획을 수립한다.
+
+## 이유
+
+- 기존 Repository와 서비스 계층의 일관성을 유지한다.
+- 일부 Repository만 async로 전환해 생기는 이중 세션과 트랜잭션 혼용을 피한다.
+- 비동기 API의 이벤트 루프 블로킹은 DB 구간을 worker로 분리해 제한할 수 있다.
+
+대안인 MemoryRepository 단독 `AsyncSession` 전환은 변경량은 작지만, Tick 단위 commit 책임과 테스트 fixture를 두 체계로 나누므로 선택하지 않았다. 백엔드 전체 async 전환은 장기 동시성에는 유리하지만 현재 Slice 3 범위를 넘는다.
+
+## 결과
+
+- `TickMemoryService`는 동기 메서드로 UUID 변환과 Repository 호출을 조정한다.
+- Runtime과 Policy Engine은 DB Session을 전달받지 않는다.
+- 실제 Tick endpoint는 동기 DB 구간을 async route에서 직접 실행하지 않아야 한다.
+- 향후 다중 worker Tick 실행은 별도의 PostgreSQL lease와 fencing token 계약을 구현해야 한다.


### PR DESCRIPTION
## 작업 개요

Tick Engine의 문자열 ID 계약과 MemoryRepository의 UUID 계약 사이를 조정하는 `TickMemoryService`를 추가합니다. 현재 백엔드의 동기 SQLAlchemy Session 구조를 유지하면서 Repository와 상위 Tick Coordinator의 트랜잭션 책임을 명확히 합니다.

## 관련 Issue

Refs #76
Refs #72

> Slice 3 전체 부모 Issue이므로 이 PR에서 자동 종료하지 않습니다.

## 변경 내용

- `TickMemoryService` 추가
  - Agent·Event·Memory ID의 UUID/문자열 변환
  - Runtime 조회 query의 embedding 생성 및 1536차원 검증
  - `MemoryRow`를 `MemoryItem`으로 변환
  - Memory 후보 저장 후 Agent별 cap 10 적용
- Repository는 `flush`, 상위 Coordinator는 commit/rollback을 담당하도록 경계 설정
- 동기 Session 유지 결정과 향후 async endpoint 연결 조건을 ADR로 기록
- UUID 변환, 저장, cap, commit 비소유, embedding 검증 테스트 추가

## 결정 사항 및 이유

MemoryRepository만 `AsyncSession`으로 전환하면 기존 인증·Simulation·Runtime 결과 저장 계층과 세션 체계가 분리됩니다. Slice 3에서는 동기 Session을 유지하고, 실제 async Tick endpoint에서는 DB 구간을 worker로 분리하는 방향을 선택했습니다.

Repository는 DB 타입인 UUID를 유지하고, Tick/API 문자열 계약으로의 변환은 애플리케이션 서비스가 담당합니다.

## 테스트 / 확인 내용

- [x] TickMemoryService 단위 테스트 4개
- [x] Backend 전체 테스트 — 213 passed, 38 skipped
- [x] Python compileall
- [x] git diff --check
- [x] 관련 ADR 작성
- [ ] 실제 PostgreSQL MemoryRepository 통합 테스트 — TEST_DATABASE_URL 환경에서 실행 필요

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업:
  - 기존 Session·Memory·Tick 계약 분석
  - TDD 기반 서비스 및 테스트 구현
  - ADR 초안 작성
- 사람이 검토한 내용:
  - 동기 Session 유지 결정
  - UUID 변환 책임
  - commit/rollback 책임 경계
  - 브랜치·커밋·PR 범위

## 리뷰어가 봐야 할 부분

- `TickMemoryService`가 application/infrastructure 경계로 적절한지
- MemoryRepository가 commit을 소유하지 않는 계약
- sync Session 유지 ADR과 향후 async endpoint 연결 조건