### PR TITLE
[Feature] Slice 4 Task 1 — 5-Student Runtime batch 및 User Persona 공통 Runtime

### DIFF
--- a/backend/app/services/runtime_orchestrator.py
+++ b/backend/app/services/runtime_orchestrator.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
@@ -30,6 +31,8 @@ class RuntimeBatchExecutionResult:
 
 
 class RuntimeOrchestrator:
+    MAX_CONCURRENT_RUNTIMES = 6
+
     def __init__(
         self,
         runtime: AgentRuntimeExecutor,
@@ -84,10 +87,10 @@ class RuntimeOrchestrator:
     def run_batch(
         self, runtime_inputs: Sequence[AgentRuntimeInput]
     ) -> RuntimeBatchExecutionResult:
-        results = tuple(
-            self._runtime.run(runtime_input)
-            for runtime_input in runtime_inputs
-        )
+        with ThreadPoolExecutor(
+            max_workers=self.MAX_CONCURRENT_RUNTIMES
+        ) as executor:
+            results = tuple(executor.map(self._runtime.run, runtime_inputs))
         save_result = self._result_sink.save_batch(results)
         return RuntimeBatchExecutionResult(
             results=results,

--- a/backend/tests/test_runtime_orchestrator.py
+++ b/backend/tests/test_runtime_orchestrator.py
@@ -180,7 +180,9 @@ def test_unhandled_runtime_exception_prevents_sink_call_and_propagates() -> None
     sink = SpySink()
     with pytest.raises(RuntimeError, match="unexpected runtime failure"):
         RuntimeOrchestrator(runtime, sink).run_batch(inputs)
-    assert len(runtime.calls) == 2
+    assert {item.agent.agent_id for item in runtime.calls} == {
+        item.agent.agent_id for item in inputs
+    }
     assert sink.calls == []
     assert sink.delegate.list_results() == []
 

--- a/backend/tests/test_slice4_runtime_batch.py
+++ b/backend/tests/test_slice4_runtime_batch.py
@@ -1,5 +1,7 @@
 from copy import deepcopy
-from threading import Lock
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
+from time import sleep
 from uuid import UUID
 
 from app.services.runtime_orchestrator import RuntimeOrchestrator
@@ -103,6 +105,66 @@ class RecordingLLMClient:
         return response
 
 
+class DelayedRuntime:
+    def __init__(self, delays: dict[UUID, float]) -> None:
+        self._runtime = AgentRuntime(RecordingLLMClient())
+        self._delays = delays
+        self._lock = Lock()
+        self.completion_order: list[UUID] = []
+
+    def run(self, runtime_input: AgentRuntimeInput):
+        sleep(self._delays[runtime_input.agent.agent_id])
+        result = self._runtime.run(runtime_input)
+        with self._lock:
+            self.completion_order.append(runtime_input.agent.agent_id)
+        return result
+
+
+class BlockingRuntime:
+    def __init__(self) -> None:
+        self._runtime = AgentRuntime(RecordingLLMClient())
+        self._lock = Lock()
+        self.release = Event()
+        self.six_started = Event()
+        self.active_count = 0
+        self.started_count = 0
+        self.max_active_count = 0
+
+    def run(self, runtime_input: AgentRuntimeInput):
+        with self._lock:
+            self.active_count += 1
+            self.started_count += 1
+            self.max_active_count = max(self.max_active_count, self.active_count)
+            if self.started_count == 6:
+                self.six_started.set()
+        assert self.release.wait(timeout=2)
+        try:
+            return self._runtime.run(runtime_input)
+        finally:
+            with self._lock:
+                self.active_count -= 1
+
+
+def make_additional_student_input(index: int) -> AgentRuntimeInput:
+    agent_id = UUID(f"00000000-0000-0000-0000-{index + 1:012d}")
+    runtime_input = make_student_input(0)
+    return runtime_input.model_copy(
+        update={
+            "agent": runtime_input.agent.model_copy(
+                update={
+                    "agent_id": agent_id,
+                    "fixture_key": f"student-{index + 1:02d}",
+                    "name": f"Student {index + 1}",
+                }
+            ),
+            "valid_agent_ids": [
+                UUID(f"00000000-0000-0000-0000-{item + 1:012d}")
+                for item in range(7)
+            ],
+        }
+    )
+
+
 def test_five_students_run_in_one_batch_with_agent_mapping() -> None:
     runtime_inputs = [make_student_input(index) for index in range(5)]
     client = RecordingLLMClient()
@@ -151,3 +213,38 @@ def test_inactive_student_is_skipped_without_llm_call() -> None:
     assert batch.results[3].status is RuntimeStatus.SKIPPED
     assert STUDENT_IDS[3] not in client.agent_ids
     assert len(client.agent_ids) == 4
+
+
+def test_results_preserve_input_order_when_completion_order_differs() -> None:
+    runtime_inputs = [make_student_input(index) for index in range(5)]
+    runtime = DelayedRuntime(
+        {
+            runtime_input.agent.agent_id: (5 - index) * 0.01
+            for index, runtime_input in enumerate(runtime_inputs)
+        }
+    )
+
+    batch = RuntimeOrchestrator(
+        runtime, InMemoryRuntimeResultSink()
+    ).run_batch(runtime_inputs)
+
+    assert runtime.completion_order != STUDENT_IDS
+    assert [result.agent_id for result in batch.results] == STUDENT_IDS
+
+
+def test_runtime_batch_concurrency_never_exceeds_six() -> None:
+    runtime_inputs = [make_additional_student_input(index) for index in range(7)]
+    runtime = BlockingRuntime()
+    orchestrator = RuntimeOrchestrator(runtime, InMemoryRuntimeResultSink())
+
+    with ThreadPoolExecutor(max_workers=1) as caller:
+        future = caller.submit(orchestrator.run_batch, runtime_inputs)
+        six_started = runtime.six_started.wait(timeout=1)
+        started_before_release = runtime.started_count
+        runtime.release.set()
+        batch = future.result(timeout=3)
+
+    assert six_started
+    assert started_before_release == 6
+    assert runtime.max_active_count == 6
+    assert len(batch.results) == 7

--- a/backend/tests/test_slice4_runtime_batch.py
+++ b/backend/tests/test_slice4_runtime_batch.py
@@ -1,0 +1,153 @@
+from copy import deepcopy
+from threading import Lock
+from uuid import UUID
+
+from app.services.runtime_orchestrator import RuntimeOrchestrator
+from app.services.runtime_results import InMemoryRuntimeResultSink
+from app.simulation.agent_runtime import (
+    AgentRuntime,
+    AgentRuntimeInput,
+    MockLLMClient,
+    RuntimeStatus,
+)
+
+
+STUDENT_IDS = [
+    UUID(f"00000000-0000-0000-0000-{index:012d}") for index in range(1, 6)
+]
+LOCATION_ID = UUID("10000000-0000-0000-0000-000000000001")
+CLASS_EVENT_ID = UUID("20000000-0000-0000-0000-000000000001")
+
+
+def make_student_input(
+    index: int,
+    *,
+    active: bool = True,
+    user_persona: bool = False,
+) -> AgentRuntimeInput:
+    agent_id = STUDENT_IDS[index]
+    return AgentRuntimeInput.model_validate(
+        {
+            "run_id": "slice-4-runtime-batch",
+            "tick_number": 1,
+            "block": "MORNING",
+            "agent": {
+                "agent_id": agent_id,
+                "fixture_key": "user-persona-01"
+                if user_persona
+                else f"student-{index + 1:02d}",
+                "agent_type": "student",
+                "name": f"Student {index + 1}",
+                "mbti": "INFP" if user_persona else "ISTJ",
+                "big_five": {
+                    "openness": 0,
+                    "conscientiousness": 0,
+                    "extraversion": 0,
+                    "agreeableness": 0,
+                    "emotional_stability": 0,
+                },
+                "state": {
+                    "hunger": 0,
+                    "fatigue": 0,
+                    "stress": 0,
+                    "satisfaction": 0,
+                    "mood": 0,
+                },
+                "current_location_id": LOCATION_ID,
+                "active_status": active,
+            },
+            "nearby_agents": [],
+            "relationships": [],
+            "memories": [],
+            "events": [
+                {
+                    "event_id": CLASS_EVENT_ID,
+                    "event_type": "class",
+                    "location_id": LOCATION_ID,
+                    "participant_agent_ids": [agent_id],
+                }
+            ],
+            "schedule": {
+                "event_id": CLASS_EVENT_ID,
+                "schedule_type": "class",
+                "is_mandatory": True,
+                "location_id": LOCATION_ID,
+                "start_tick": 1,
+                "end_tick": 1,
+            },
+            "valid_agent_ids": STUDENT_IDS,
+            "valid_location_ids": [LOCATION_ID],
+        }
+    )
+
+
+class RecordingLLMClient:
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self.agent_ids: list[UUID] = []
+
+    def generate(self, runtime_input: AgentRuntimeInput) -> object:
+        with self._lock:
+            self.agent_ids.append(runtime_input.agent.agent_id)
+        mock_input = runtime_input.model_copy(
+            update={
+                "agent": runtime_input.agent.model_copy(
+                    update={"fixture_key": "student-01"}
+                )
+            }
+        )
+        response = deepcopy(MockLLMClient().generate(mock_input))
+        response["memory_candidates"][0]["content"] = (
+            f"{runtime_input.agent.agent_id}의 수업 기억"
+        )
+        return response
+
+
+def test_five_students_run_in_one_batch_with_agent_mapping() -> None:
+    runtime_inputs = [make_student_input(index) for index in range(5)]
+    client = RecordingLLMClient()
+
+    batch = RuntimeOrchestrator(
+        AgentRuntime(client), InMemoryRuntimeResultSink()
+    ).run_batch(runtime_inputs)
+
+    assert len(batch.results) == 5
+    assert set(client.agent_ids) == set(STUDENT_IDS)
+    assert [result.agent_id for result in batch.results] == STUDENT_IDS
+    assert [
+        result.intent.memory_candidates[0].content for result in batch.results
+    ] == [f"{agent_id}의 수업 기억" for agent_id in STUDENT_IDS]
+
+
+def test_user_persona_uses_same_student_runtime() -> None:
+    runtime_inputs = [
+        make_student_input(index, user_persona=index == 2) for index in range(5)
+    ]
+    client = RecordingLLMClient()
+
+    batch = RuntimeOrchestrator(
+        AgentRuntime(client), InMemoryRuntimeResultSink()
+    ).run_batch(runtime_inputs)
+
+    persona_input = runtime_inputs[2]
+    persona_result = batch.results[2]
+    assert persona_input.agent.fixture_key == "user-persona-01"
+    assert persona_input.agent.agent_type == "student"
+    assert persona_result.agent_id == persona_input.agent.agent_id
+    assert persona_result.status is RuntimeStatus.PROPOSED
+    assert persona_input.agent.agent_id in client.agent_ids
+
+
+def test_inactive_student_is_skipped_without_llm_call() -> None:
+    runtime_inputs = [
+        make_student_input(index, active=index != 3) for index in range(5)
+    ]
+    client = RecordingLLMClient()
+
+    batch = RuntimeOrchestrator(
+        AgentRuntime(client), InMemoryRuntimeResultSink()
+    ).run_batch(runtime_inputs)
+
+    assert batch.results[3].status is RuntimeStatus.SKIPPED
+    assert STUDENT_IDS[3] not in client.agent_ids
+    assert len(client.agent_ids) == 4


### PR DESCRIPTION
## 작업 개요

Slice 4의 Student 5명 Runtime batch 실행을 구현했습니다.

기존 순차 실행 방식의 `RuntimeOrchestrator.run_batch()`를 최대 동시 실행 수 6의 병렬 실행 방식으로 확장하고, 병렬 실행 완료 순서와 관계없이 입력 Agent 순서대로 결과가 반환되도록 처리했습니다.

## 관련 Issue

Closes #110 

## 변경 내용

- `ThreadPoolExecutor` 기반 Runtime batch 병렬 실행
- 최대 동시 실행 수 6 적용
- `executor.map()`을 사용한 입력 순서 기반 결과 반환
- Student 5명 batch 실행 및 Agent ID 매핑 테스트 추가
- User Persona가 일반 Student Runtime을 사용하는 계약 검증
- 비활성 Student `SKIPPED` 및 LLM 미호출 검증
- Runtime 오류 시 예외 전파 및 sink 미호출 검증
- 기존 단일 Agent Runtime 회귀 테스트 수행

## 결정 사항 및 이유

병렬 실행 결과가 완료 순서에 따라 달라지면 Agent ID와 결과의 매핑이 불안정해질 수 있으므로, `executor.map()`을 사용해 기존 입력 순서를 유지했습니다.

Runtime 결과는 모든 Agent 실행이 성공한 후 기존 sink의 단일 batch 저장 경로로 전달하여, 부분 저장 없이 기존 예외 전파 계약을 유지했습니다.

User Persona 전용 Runtime은 추가하지 않고 일반 Student와 동일한 Runtime 경로를 사용하도록 테스트했습니다.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [x] 관련 문서 업데이트 확인

## AI 사용 여부

사용 여부: 사용함
사용한 작업:
- 기존 Runtime 구조 분석
- 테스트 시나리오 작성
- 병렬 Runtime batch 구현
- 회귀 테스트 수행
- 로컬 커밋 분리
사람이 검토한 내용:
- Task 1 작업 범위 준수 여부
- 입력·결과 순서 보장 방식
- 동시 실행 상한
- 비활성 Agent 처리
- sink 저장 및 예외 전파 계약
- Slice 3 Memory 의존성

## 리뷰어가 봐야 할 부분

- `ThreadPoolExecutor`의 lifecycle과 최대 동시 실행 수 6이 적절한지
- `executor.map()`을 이용한 결과 순서 보장 방식이 기존 계약과 맞는지
- Runtime 하나가 실패했을 때 sink가 호출되지 않는지
- User Persona 전용 Runtime 없이 기존 Student Runtime을 사용하는지
- 기존 IntentCandidate.memory_candidates가 Agent별 batch 결과에 보존되는지


## 추가 메모

- 최신 Slice 4 base d55c7fddc3da551a05b1e22f886277faac849dcb 위로 rebase했습니다.
- PR #107에서 제안됐던 AgentRuntimeResult.memory_candidate 단수 계약은 기존 IntentCandidate.memory_candidates와 중복되어 채택되지 않았습니다.
- 본 PR은 기존 IntentCandidate.memory_candidates 리스트 계약을 유지하며, test_slice4_runtime_batch.py에서 Agent별 Memory 후보가 batch 결과에 보존되는 것을 검증합니다.