### PR TITLE
[Chore] CodeRabbit develop 자동 리뷰 활성화

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: ko-KR
+
+reviews:
+  profile: assertive
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - develop
+
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  path_instructions:
+    - path: "**/*"
+      instructions: |
+        모든 리뷰는 반드시 한국어로 작성한다.
+
+        Magic Academy 팀 코드 컨벤션을 기준으로 검토한다.
+
+        리뷰 코멘트는 아래 태그 중 하나로 시작한다.
+        [Must] 반드시 수정해야 하는 문제
+        [Question] 구현 이유나 확인이 필요한 부분
+        [Suggest] 개선 제안
+        [Nit] 사소한 수정
+        [Good] 잘 구현된 부분
+
+        공통 검토 기준:
+        - 변수명과 함수명만 보고 역할을 이해할 수 있는지 확인한다.
+        - 불필요한 축약어를 사용하지 않았는지 확인한다.
+        - 하나의 함수가 하나의 역할만 수행하는지 확인한다.
+        - 중복 로직이 있는지 확인한다.
+        - 매직 넘버가 상수로 분리되어 있는지 확인한다.
+        - console.log 또는 디버깅 코드가 남아 있는지 확인한다.
+        - 사용하지 않는 코드가 남아 있는지 확인한다.
+        - 폴더와 파일 위치가 프로젝트 구조에 적절한지 확인한다.
+        - 보안 문제, 예외 처리 누락, 테스트 누락 가능성을 확인한다.
+
+    - path: ".github/workflows/**/*"
+      instructions: |
+        GitHub Actions Workflow를 검토한다.
+        - 브랜치 컨벤션에 없는 타입이 트리거에 포함되지 않았는지 확인한다.
+        - main 또는 develop에 직접 push하도록 유도하지 않는지 확인한다.
+        - permissions가 필요한 최소 권한만 사용하는지 확인한다.
+        - YAML 문법과 들여쓰기를 확인한다.
+        - 파일 끝에 newline이 있는지 확인한다.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,6 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      - main
       - develop
 
   high_level_summary: true


### PR DESCRIPTION
## 작업 개요

`develop` 대상 PR에서도 CodeRabbit 자동 리뷰가 동작하도록 저장소 설정 파일을 추가합니다.

## 관련 Issue

Closes #125

## 변경 내용

- `develop`에 `.coderabbit.yaml` 추가
- 자동 리뷰 대상 브랜치에 `main`, `develop` 등록
- 기존 한국어 리뷰 규칙과 path instructions 유지

## 결정 사항 및 이유

저장소 기본 브랜치가 `main`인 상태에서 Slice 작업 PR은 대부분 `develop`을 대상으로 생성됩니다. `base_branches`에 `develop`을 명시해 두 브랜치 모두 자동 리뷰 대상이 되도록 했습니다.

## 테스트 / 확인 내용

- [x] `git diff --check` 통과
- [x] CodeRabbit YAML 스키마 기준 설정 구조 확인
- [ ] PR에서 CodeRabbit 수동 전체 리뷰 응답 확인

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: CodeRabbit 설정 원인 분석 및 YAML 설정 작성
- 사람이 검토한 내용: 자동 리뷰 대상 브랜치와 기존 팀 리뷰 규칙

## 리뷰어가 봐야 할 부분

- `reviews.auto_review.base_branches`에 `develop`을 포함한 범위
- 기존 한국어 리뷰 지침이 유지되는지