### PR TITLE
[Feature] Slice 4 Task 2 — 5-Student·조건부 Professor Tick orchestration

### DIFF
--- a/backend/app/services/runtime_target_selection.py
+++ b/backend/app/services/runtime_target_selection.py
@@ -1,7 +1,41 @@
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from uuid import UUID
 
+from app.domain.models import Agent
 from app.simulation.agent_runtime import AgentContext
+
+# User Persona는 별도 Runtime 없이 기존 Student와 동일하게 편성된다 (Slice 4 Task 0 계약).
+STUDENT_AGENT_TYPES = frozenset({"student", "user_persona"})
+PROFESSOR_AGENT_TYPE = "professor"
+
+
+def select_tick_participant_ids(
+    agents: Sequence[Agent],
+    *,
+    event_participant_agent_ids: Iterable[UUID] = (),
+    schedule_requires_professor: bool = False,
+) -> tuple[UUID, ...]:
+    """Tick 실행 대상 Agent.id를 편성한다.
+
+    Student(User Persona 포함)는 항상 포함하고, Professor는 Event 참여자이거나
+    Schedule 조건을 충족할 때만 추가한다. agents 순서를 보존하고 중복 id는 제거한다.
+    """
+    participant_event_id_set = set(event_participant_agent_ids)
+    seen_ids: set[UUID] = set()
+    participant_ids: list[UUID] = []
+    for agent in agents:
+        if agent.id in seen_ids:
+            continue
+        if agent.agent_type in STUDENT_AGENT_TYPES:
+            include = True
+        elif agent.agent_type == PROFESSOR_AGENT_TYPE:
+            include = schedule_requires_professor or agent.id in participant_event_id_set
+        else:
+            include = False
+        if include:
+            seen_ids.add(agent.id)
+            participant_ids.append(agent.id)
+    return tuple(participant_ids)
 
 
 class RuntimeTargetSelector:

--- a/backend/app/services/runtime_target_selection.py
+++ b/backend/app/services/runtime_target_selection.py
@@ -18,24 +18,26 @@ def select_tick_participant_ids(
     """Tick 실행 대상 Agent.id를 편성한다.
 
     Student(User Persona 포함)는 항상 포함하고, Professor는 Event 참여자이거나
-    Schedule 조건을 충족할 때만 추가한다. agents 순서를 보존하고 중복 id는 제거한다.
+    Schedule 조건을 충족할 때만 추가한다. 중복 id는 제거하며, 각 그룹 내
+    상대 순서는 agents 순서를 보존하되 canonical 순서는 Student 전원 →
+    조건부 Professor로 고정한다 (Slice 4 Task 0 계약, Agent 조회 순서인
+    fixture_key 정렬 등에 의존하지 않는다).
     """
     participant_event_id_set = set(event_participant_agent_ids)
     seen_ids: set[UUID] = set()
-    participant_ids: list[UUID] = []
+    student_ids: list[UUID] = []
+    professor_ids: list[UUID] = []
     for agent in agents:
         if agent.id in seen_ids:
             continue
         if agent.agent_type in STUDENT_AGENT_TYPES:
-            include = True
-        elif agent.agent_type == PROFESSOR_AGENT_TYPE:
-            include = schedule_requires_professor or agent.id in participant_event_id_set
-        else:
-            include = False
-        if include:
             seen_ids.add(agent.id)
-            participant_ids.append(agent.id)
-    return tuple(participant_ids)
+            student_ids.append(agent.id)
+        elif agent.agent_type == PROFESSOR_AGENT_TYPE:
+            if schedule_requires_professor or agent.id in participant_event_id_set:
+                seen_ids.add(agent.id)
+                professor_ids.append(agent.id)
+    return tuple(student_ids) + tuple(professor_ids)
 
 
 class RuntimeTargetSelector:

--- a/backend/app/services/simulation_tick.py
+++ b/backend/app/services/simulation_tick.py
@@ -11,6 +11,7 @@ from app.repositories.simulations import (
 )
 from app.services.runtime_input_adapter import RuntimeInputAdapter
 from app.services.runtime_orchestrator import RuntimeBatchExecutionResult
+from app.services.runtime_target_selection import select_tick_participant_ids
 from app.simulation.agent_runtime import Block, ScheduleSummary
 
 
@@ -30,7 +31,8 @@ class SimulationTickService:
         run_id: UUID,
         tick_number: int,
         block: Block,
-        preselected_agent_ids: Sequence[UUID],
+        preselected_agent_ids: Sequence[UUID] | None = None,
+        schedule_requires_professor: bool = False,
         schedule: ScheduleSummary,
         events: Sequence[Event],
         event_participants: Mapping[UUID, Sequence[EventParticipant]],
@@ -48,6 +50,17 @@ class SimulationTickService:
             valid_location_ids=valid_location_ids,
         )
 
+        if preselected_agent_ids is None:
+            # Student(User Persona 포함)를 기본 편성하고, Event 참여자이거나
+            # Schedule 조건을 충족하는 Professor만 추가한다 (Slice 4 Task 0 계약).
+            preselected_agent_ids = select_tick_participant_ids(
+                agents,
+                event_participant_agent_ids=self._flatten_event_participant_agent_ids(
+                    event_participants
+                ),
+                schedule_requires_professor=schedule_requires_professor,
+            )
+
         return self._runtime_input_adapter.run(
             run_id=str(run_id),
             tick_number=tick_number,
@@ -60,6 +73,16 @@ class SimulationTickService:
             event_participants=event_participants,
             valid_agent_ids=agent_ids,
             valid_location_ids=valid_location_ids,
+        )
+
+    @staticmethod
+    def _flatten_event_participant_agent_ids(
+        event_participants: Mapping[UUID, Sequence[EventParticipant]],
+    ) -> tuple[UUID, ...]:
+        return tuple(
+            participant.agent_id
+            for participants in event_participants.values()
+            for participant in participants
         )
 
     @staticmethod

--- a/backend/tests/test_simulation_tick_runtime.py
+++ b/backend/tests/test_simulation_tick_runtime.py
@@ -645,3 +645,132 @@ def test_inactive_slice_one_student_is_skipped_without_llm_and_saved(runtime_db)
     assert llm_client.agent_ids == []
     assert sink.call_count == 1
     assert sink.list_results() == [batch.results[0]]
+
+
+# ── Slice 4 Task 2: preselected_agent_ids 자동 편성 ───────────────────────────
+
+
+def _runtime_agent_ids_by_fixture_key(db, simulation_id) -> dict[str, UUID]:
+    rows = db.execute(
+        select(Agent.fixture_key, Agent.id).where(Agent.simulation_id == simulation_id)
+    ).all()
+    return {fixture_key: agent_id for fixture_key, agent_id in rows}
+
+
+def test_default_selection_runs_five_students_without_professor(runtime_db) -> None:
+    """preselected_agent_ids를 생략하면 Student 5명만 자동 편성된다."""
+    db, simulation, _, _, _ = runtime_db
+    location_id = db.scalar(
+        select(Location.id).where(
+            Location.simulation_id == simulation.id,
+            Location.code == "classroom",
+        )
+    )
+    event = make_event(simulation.id, location_id)
+    ids_by_fixture_key = _runtime_agent_ids_by_fixture_key(db, simulation.id)
+    adapter = SpyAdapter()
+
+    run_phase(
+        SimulationTickService(adapter),
+        db,
+        simulation,
+        event,
+        [],
+        make_schedule(location_id),
+        preselected_agent_ids=None,
+    )
+
+    assert adapter.calls[0]["preselected_agent_ids"] == tuple(
+        ids_by_fixture_key[f"student-{index:02d}"] for index in range(1, 6)
+    )
+
+
+def test_default_selection_adds_professor_when_event_participant(runtime_db) -> None:
+    """Professor가 Event 참여자면 자동 편성 결과에 6명이 포함된다."""
+    db, simulation, _, _, _ = runtime_db
+    location_id = db.scalar(
+        select(Location.id).where(
+            Location.simulation_id == simulation.id,
+            Location.code == "classroom",
+        )
+    )
+    event = make_event(simulation.id, location_id)
+    ids_by_fixture_key = _runtime_agent_ids_by_fixture_key(db, simulation.id)
+    professor_id = ids_by_fixture_key["professor-01"]
+    participant = EventParticipant(
+        id=uuid4(), event_id=event.id, agent_id=professor_id, result={}
+    )
+    adapter = SpyAdapter()
+
+    run_phase(
+        SimulationTickService(adapter),
+        db,
+        simulation,
+        event,
+        [participant],
+        make_schedule(location_id),
+        preselected_agent_ids=None,
+    )
+
+    assert adapter.calls[0]["preselected_agent_ids"] == (
+        professor_id,
+        *(ids_by_fixture_key[f"student-{index:02d}"] for index in range(1, 6)),
+    )
+
+
+def test_default_selection_adds_professor_when_schedule_requires(runtime_db) -> None:
+    """schedule_requires_professor=True면 Event 미참여 Professor도 자동 편성에 포함된다."""
+    db, simulation, _, _, _ = runtime_db
+    location_id = db.scalar(
+        select(Location.id).where(
+            Location.simulation_id == simulation.id,
+            Location.code == "classroom",
+        )
+    )
+    event = make_event(simulation.id, location_id)
+    ids_by_fixture_key = _runtime_agent_ids_by_fixture_key(db, simulation.id)
+    adapter = SpyAdapter()
+
+    run_phase(
+        SimulationTickService(adapter),
+        db,
+        simulation,
+        event,
+        [],
+        make_schedule(location_id),
+        preselected_agent_ids=None,
+        schedule_requires_professor=True,
+    )
+
+    assert adapter.calls[0]["preselected_agent_ids"] == (
+        ids_by_fixture_key["professor-01"],
+        *(ids_by_fixture_key[f"student-{index:02d}"] for index in range(1, 6)),
+    )
+
+
+def test_explicit_preselected_agent_ids_bypasses_automatic_selection(runtime_db) -> None:
+    """preselected_agent_ids를 명시하면 자동 편성 대신 그대로 사용된다."""
+    db, simulation, _, _, _ = runtime_db
+    location_id = db.scalar(
+        select(Location.id).where(
+            Location.simulation_id == simulation.id,
+            Location.code == "classroom",
+        )
+    )
+    event = make_event(simulation.id, location_id)
+    ids_by_fixture_key = _runtime_agent_ids_by_fixture_key(db, simulation.id)
+    only_student = ids_by_fixture_key["student-02"]
+    adapter = SpyAdapter()
+
+    run_phase(
+        SimulationTickService(adapter),
+        db,
+        simulation,
+        event,
+        [],
+        make_schedule(location_id),
+        preselected_agent_ids=[only_student],
+        schedule_requires_professor=True,
+    )
+
+    assert adapter.calls[0]["preselected_agent_ids"] == [only_student]

--- a/backend/tests/test_simulation_tick_runtime.py
+++ b/backend/tests/test_simulation_tick_runtime.py
@@ -713,8 +713,8 @@ def test_default_selection_adds_professor_when_event_participant(runtime_db) -> 
     )
 
     assert adapter.calls[0]["preselected_agent_ids"] == (
-        professor_id,
         *(ids_by_fixture_key[f"student-{index:02d}"] for index in range(1, 6)),
+        professor_id,
     )
 
 
@@ -743,8 +743,8 @@ def test_default_selection_adds_professor_when_schedule_requires(runtime_db) -> 
     )
 
     assert adapter.calls[0]["preselected_agent_ids"] == (
-        ids_by_fixture_key["professor-01"],
         *(ids_by_fixture_key[f"student-{index:02d}"] for index in range(1, 6)),
+        ids_by_fixture_key["professor-01"],
     )
 
 

--- a/backend/tests/test_slice4_tick_orchestration.py
+++ b/backend/tests/test_slice4_tick_orchestration.py
@@ -1,0 +1,149 @@
+"""Slice 4 Task 2 — 5-Student·조건부 Professor Tick orchestration.
+
+Runtime·Persistence 통합(Task 1, Task 3)이 base에 병합되기 전에도 검증 가능한
+Student/Professor 실행 대상 편성 로직을 다룬다. 통합 인수 테스트는
+test_slice4_acceptance.py(Task 5)에서 다룬다.
+"""
+
+from uuid import UUID
+
+import pytest
+
+from app.domain.models import Agent
+from app.services.runtime_target_selection import select_tick_participant_ids
+
+SIMULATION_ID = UUID("40000000-0000-0000-0000-000000000001")
+STUDENT_IDS = [UUID(f"00000000-0000-0000-0000-{index:012d}") for index in range(1, 6)]
+USER_PERSONA_ID = STUDENT_IDS[0]
+PROFESSOR_ID = UUID("00000000-0000-0000-0000-000000000010")
+CLASS_EVENT_ID = UUID("20000000-0000-0000-0000-000000000001")
+
+
+def make_agent(agent_id: UUID, agent_type: str) -> Agent:
+    return Agent(
+        id=agent_id,
+        simulation_id=SIMULATION_ID,
+        fixture_key=str(agent_id),
+        fixture_version="test",
+        agent_type=agent_type,
+        name=str(agent_id),
+        mbti_type="ISTJ",
+    )
+
+
+def make_students(*, user_persona_id: UUID | None = None) -> list[Agent]:
+    return [
+        make_agent(
+            agent_id,
+            "user_persona" if agent_id == user_persona_id else "student",
+        )
+        for agent_id in STUDENT_IDS
+    ]
+
+
+def make_professor(agent_id: UUID = PROFESSOR_ID) -> Agent:
+    return make_agent(agent_id, "professor")
+
+
+class TestDefaultStudentFiveOrchestration:
+    def test_student_five_only_by_default(self) -> None:
+        """일반 Tick에서는 Student 5명만 실행 대상이 된다."""
+        agents = make_students() + [make_professor()]
+
+        selected = select_tick_participant_ids(agents)
+
+        assert selected == tuple(STUDENT_IDS)
+
+    def test_user_persona_included_as_ordinary_student(self) -> None:
+        """User Persona는 별도 Runtime 없이 기존 Student와 동일하게 편성된다."""
+        agents = make_students(user_persona_id=USER_PERSONA_ID) + [make_professor()]
+
+        selected = select_tick_participant_ids(agents)
+
+        assert selected == tuple(STUDENT_IDS)
+
+
+class TestConditionalProfessorOrchestration:
+    def test_professor_added_when_event_participant(self) -> None:
+        """Professor가 Event 참여자면 6명이 실행 대상이 된다."""
+        agents = make_students() + [make_professor()]
+
+        selected = select_tick_participant_ids(
+            agents, event_participant_agent_ids=[PROFESSOR_ID]
+        )
+
+        assert selected == (*STUDENT_IDS, PROFESSOR_ID)
+
+    def test_professor_added_when_schedule_requires(self) -> None:
+        """Schedule 조건 충족 시 Event 미참여 Professor도 추가된다."""
+        agents = make_students() + [make_professor()]
+
+        selected = select_tick_participant_ids(
+            agents, schedule_requires_professor=True
+        )
+
+        assert selected == (*STUDENT_IDS, PROFESSOR_ID)
+
+    def test_professor_not_added_without_condition(self) -> None:
+        """Event 참여자도 아니고 Schedule 조건도 없으면 Professor는 제외된다."""
+        agents = make_students() + [make_professor()]
+
+        selected = select_tick_participant_ids(agents)
+
+        assert PROFESSOR_ID not in selected
+        assert len(selected) == 5
+
+
+class TestSelectionInvariants:
+    def test_duplicate_agent_id_is_deduplicated(self) -> None:
+        """같은 Agent.id가 중복 전달돼도 결과는 한 번만 포함한다."""
+        agents = make_students() + make_students()
+
+        selected = select_tick_participant_ids(agents)
+
+        assert selected == tuple(STUDENT_IDS)
+
+    def test_selection_order_follows_agent_snapshot_order(self) -> None:
+        """반환 순서는 Agent 목록 순서를 그대로 보존한다."""
+        reversed_students = list(reversed(make_students()))
+        agents = reversed_students + [make_professor()]
+
+        selected = select_tick_participant_ids(
+            agents, schedule_requires_professor=True
+        )
+
+        assert selected == (*reversed(STUDENT_IDS), PROFESSOR_ID)
+
+    def test_non_runtime_agent_type_is_excluded(self) -> None:
+        """student/professor/user_persona 이외 agent_type은 실행 대상에서 제외된다."""
+        agents = make_students() + [make_agent(PROFESSOR_ID, "unknown")]
+
+        selected = select_tick_participant_ids(
+            agents,
+            event_participant_agent_ids=[PROFESSOR_ID],
+            schedule_requires_professor=True,
+        )
+
+        assert selected == tuple(STUDENT_IDS)
+
+    def test_empty_agents_returns_empty_selection(self) -> None:
+        assert select_tick_participant_ids([]) == ()
+
+
+# ── SimulationTickService 연동 뼈대 ────────────────────────────────────────
+# 실제 DB(Agent/Event/EventParticipant) 연동 시나리오는 Task 1·3 결과를 반영해
+# test_simulation_tick_runtime.py에서 검증한다. 아래는 통합 지점만 표시하는 뼈대다.
+
+
+@pytest.mark.skip(
+    reason="Task 1(Runtime batch)·Task 3(저장·rollback) 병합 후 실제 Runtime 연결"
+)
+def test_tick_calls_runtime_batch_exactly_once_per_tick() -> None:
+    """Tick당 Runtime batch가 정확히 1회 호출된다."""
+
+
+@pytest.mark.skip(
+    reason="Task 1(Runtime batch)·Task 3(저장·rollback) 병합 후 실제 Runtime 연결"
+)
+def test_all_agents_receive_identical_world_snapshot() -> None:
+    """5/6명 모든 Agent가 동일한 World Snapshot을 전달받는다."""

--- a/backend/tests/test_slice4_tick_orchestration.py
+++ b/backend/tests/test_slice4_tick_orchestration.py
@@ -104,7 +104,7 @@ class TestSelectionInvariants:
         assert selected == tuple(STUDENT_IDS)
 
     def test_selection_order_follows_agent_snapshot_order(self) -> None:
-        """반환 순서는 Agent 목록 순서를 그대로 보존한다."""
+        """Student 간 상대 순서는 Agent 목록 순서를 그대로 보존한다."""
         reversed_students = list(reversed(make_students()))
         agents = reversed_students + [make_professor()]
 
@@ -113,6 +113,18 @@ class TestSelectionInvariants:
         )
 
         assert selected == (*reversed(STUDENT_IDS), PROFESSOR_ID)
+
+    def test_professor_placed_after_students_regardless_of_snapshot_order(self) -> None:
+        """Agent 조회 순서(fixture_key 오름차순 등)로 Professor가 Student보다 먼저
+        와도, 최종 편성 순서는 Student 전원 → Professor로 고정된다
+        (Slice 4 Task 0 계약: canonical 순서는 fixture_key 정렬에 의존하지 않는다)."""
+        agents = [make_professor()] + make_students()
+
+        selected = select_tick_participant_ids(
+            agents, schedule_requires_professor=True
+        )
+
+        assert selected == (*STUDENT_IDS, PROFESSOR_ID)
 
     def test_non_runtime_agent_type_is_excluded(self) -> None:
         """student/professor/user_persona 이외 agent_type은 실행 대상에서 제외된다."""


### PR DESCRIPTION
## 작업 개요

Tick Engine이 Student 5명(User Persona 포함)을 기본 실행 대상으로 편성하고,
Event 참여자 또는 Schedule 조건에 따라 Professor를 추가하는 선정 로직과
`SimulationTickService` 연동 구조를 구현한다.

최신 Slice 4 base(Task 1 Runtime batch 포함) 위에서 다음 범위를 다룬다:

- 실행 대상 selection 로직 (Student/User Persona 기본 편성 + Professor 조건부 편성)
- `SimulationTickService.run_runtime_phase` 오케스트레이션 구조(자동 편성 연결)
- 관련 fixture 및 테스트 뼈대

Task 3(저장·rollback, #112) 결과를 반영한 최종 통합은 해당 작업이 base에
병합된 후 진행한다.

## 관련 Issue

Relates to #111, #108 (Parent), #109 (Task 0 계약)

## 변경 내용

- `backend/app/services/runtime_target_selection.py`: `select_tick_participant_ids()` 추가
  - Student·User Persona는 항상 포함 (별도 Runtime 없이 Student와 동일 취급, Task 0 계약)
  - Professor는 Event 참여자이거나 `schedule_requires_professor=True`일 때만 포함
  - 중복 Agent.id 제거, canonical 순서인 Student 5명 → 조건부 Professor 보장
- `backend/app/services/simulation_tick.py`: `run_runtime_phase`에 `schedule_requires_professor` 옵션 추가
  - `preselected_agent_ids`를 생략하면 위 선정 로직으로 자동 편성
  - `preselected_agent_ids`를 명시하면 기존과 동일하게 그 값을 그대로 사용
- `backend/tests/test_slice4_tick_orchestration.py` (신규): 선정 로직 단위 테스트
  - Student 5명만 기본 편성, Professor 조건부 추가(Event 참여/Schedule), 중복 제거, 순서 보존, User Persona를 Student와 동일 취급
- `backend/tests/test_simulation_tick_runtime.py`: 자동 편성 연동 테스트 4건 추가 (실제 PostgreSQL 필요, `TEST_DATABASE_URL` 게이트)

`backend/app/simulation/tick_engine.py`는 변경하지 않았다 — 이미 Student 항상 포함,
Professor 조건부 편성 로직(Event 참여 또는 `schedule_requires_professor`)을 만족하고
있어 회귀 위험 없이 그대로 유지한다.

## 결정 사항 및 이유

- **User Persona 편성 취급**: Task 0 계약(별도 Agent 타입·Runtime 추가 안 함)에 따라
  선정 로직에서는 `user_persona`를 `student`와 동일하게 처리한다. DB의 `agent_type`
  구분은 Task 3(저장·식별) 영역이며 이번 선정 로직에는 영향 없다.
- **결과 순서**: 확정된 canonical 계약에 따라 Student 5명을 먼저 배치하고,
  조건을 만족하는 Professor를 마지막에 추가한다. 순서는 완료 순서와 무관하게 결정적이다.
- **하위 호환**: 기존 `preselected_agent_ids` 필수 파라미터를 optional로 바꾸되 값을
  명시하면 자동 편성을 우회하도록 해 기존 테스트·호출부 동작을 유지한다.

## 테스트

실제 PostgreSQL(pgvector/PostgreSQL 16)에 마이그레이션을 적용하고 실행했다.

```bash
cd backend
python -m pytest -q tests/test_simulation_tick_runtime.py \
  tests/test_slice4_tick_orchestration.py
python -m pytest -q -rs
```

- 관련 테스트: 31 passed, 2 skipped
- 전체 backend 테스트: 288 passed, 2 skipped
- skip 2건은 Task 3 병합 후 실제 Runtime 연결을 위한 기존 placeholder

## AI 사용

GitHub Copilot CLI와 Codex로 구현 및 리뷰 반영. 이슈 #108/#109/#111 요구사항과
리뷰 피드백을 검토해 선정 로직·오케스트레이션 연동 코드를 작성했고, 실제
PostgreSQL 컨테이너로 회귀 여부를 검증했다.

## 확인 필요

- Task 3(#112) 병합 후 실제 저장·rollback 경로 통합 예정
- 위 결정 사항 중 이견 있으면 #109 또는 본 이슈에 코멘트 부탁드립니다
