### PR TITLE
[Feature] Slice 6 Task 1 설정 저장·Snapshot·시점 복원

### DIFF
--- a/backend/alembic/versions/20260821_0006_add_slice6_snapshots.py
+++ b/backend/alembic/versions/20260821_0006_add_slice6_snapshots.py
@@ -56,17 +56,9 @@ def upgrade() -> None:
         sa.CheckConstraint("config_version >= 1", name="ck_simulation_snapshots_config_version"),
     )
     op.create_index("idx_simulation_snapshots_timeline", "simulation_snapshots", ["simulation_id", "tick_number"])
-    op.add_column("simulations", sa.Column("origin_simulation_id", postgresql.UUID(as_uuid=True)))
-    op.add_column("simulations", sa.Column("origin_snapshot_id", postgresql.UUID(as_uuid=True)))
-    op.create_foreign_key("fk_simulations_origin_simulation", "simulations", "simulations", ["origin_simulation_id"], ["id"], ondelete="RESTRICT")
-    op.create_foreign_key("fk_simulations_origin_snapshot", "simulations", "simulation_snapshots", ["origin_snapshot_id"], ["id"], ondelete="RESTRICT")
 
 
 def downgrade() -> None:
-    op.drop_constraint("fk_simulations_origin_snapshot", "simulations", type_="foreignkey")
-    op.drop_constraint("fk_simulations_origin_simulation", "simulations", type_="foreignkey")
-    op.drop_column("simulations", "origin_snapshot_id")
-    op.drop_column("simulations", "origin_simulation_id")
     op.drop_index("idx_simulation_snapshots_timeline", table_name="simulation_snapshots")
     op.drop_table("simulation_snapshots")
     op.drop_table("simulation_configs")

--- a/backend/alembic/versions/20260821_0006_add_slice6_snapshots.py
+++ b/backend/alembic/versions/20260821_0006_add_slice6_snapshots.py
@@ -1,0 +1,72 @@
+"""add Slice 6 versioned settings and immutable snapshots
+
+Revision ID: 20260821_0006
+Revises: 20260814_0005
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20260821_0006"
+down_revision = "20260814_0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "simulation_configs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("simulation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("event_frequency", sa.String(10), nullable=False),
+        sa.Column("event_impact", sa.String(10), nullable=False),
+        sa.Column("magic_enabled", sa.Boolean(), nullable=False),
+        sa.Column("policy_version", sa.String(100)),
+        sa.Column("resolver_version", sa.String(100)),
+        sa.Column("user_persona_settings", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["simulation_id"], ["simulations.id"], ondelete="RESTRICT"),
+        sa.UniqueConstraint("simulation_id", "version", name="uq_simulation_configs_version"),
+        sa.CheckConstraint("version >= 1", name="ck_simulation_configs_version"),
+        sa.CheckConstraint("event_frequency IN ('low', 'medium', 'high')", name="ck_simulation_configs_event_frequency"),
+        sa.CheckConstraint("event_impact IN ('low', 'medium', 'high')", name="ck_simulation_configs_event_impact"),
+    )
+    op.create_table(
+        "simulation_snapshots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("simulation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tick_number", sa.BigInteger(), nullable=False),
+        sa.Column("config_version", sa.Integer(), nullable=False),
+        sa.Column("payload", postgresql.JSONB(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["simulation_id"], ["simulations.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(
+            ["simulation_id", "config_version"],
+            ["simulation_configs.simulation_id", "simulation_configs.version"],
+            name="fk_simulation_snapshots_config",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint("simulation_id", "tick_number", name="uq_simulation_snapshots_tick"),
+        sa.CheckConstraint("tick_number >= 0", name="ck_simulation_snapshots_tick"),
+        sa.CheckConstraint("config_version >= 1", name="ck_simulation_snapshots_config_version"),
+    )
+    op.create_index("idx_simulation_snapshots_timeline", "simulation_snapshots", ["simulation_id", "tick_number"])
+    op.add_column("simulations", sa.Column("origin_simulation_id", postgresql.UUID(as_uuid=True)))
+    op.add_column("simulations", sa.Column("origin_snapshot_id", postgresql.UUID(as_uuid=True)))
+    op.create_foreign_key("fk_simulations_origin_simulation", "simulations", "simulations", ["origin_simulation_id"], ["id"], ondelete="RESTRICT")
+    op.create_foreign_key("fk_simulations_origin_snapshot", "simulations", "simulation_snapshots", ["origin_snapshot_id"], ["id"], ondelete="RESTRICT")
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_simulations_origin_snapshot", "simulations", type_="foreignkey")
+    op.drop_constraint("fk_simulations_origin_simulation", "simulations", type_="foreignkey")
+    op.drop_column("simulations", "origin_snapshot_id")
+    op.drop_column("simulations", "origin_simulation_id")
+    op.drop_index("idx_simulation_snapshots_timeline", table_name="simulation_snapshots")
+    op.drop_table("simulation_snapshots")
+    op.drop_table("simulation_configs")

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -69,6 +69,77 @@ class Simulation(TimestampMixin, Base):
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    origin_simulation_id: Mapped[PythonUUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "simulations.id",
+            name="fk_simulations_origin_simulation",
+            ondelete="RESTRICT",
+        ),
+    )
+    origin_snapshot_id: Mapped[PythonUUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "simulation_snapshots.id",
+            name="fk_simulations_origin_snapshot",
+            ondelete="RESTRICT",
+            use_alter=True,
+        ),
+    )
+
+
+class SimulationConfig(TimestampMixin, Base):
+    __tablename__ = "simulation_configs"
+    __table_args__ = (
+        UniqueConstraint("simulation_id", "version", name="uq_simulation_configs_version"),
+        CheckConstraint("version >= 1", name="ck_simulation_configs_version"),
+        CheckConstraint(
+            "event_frequency IN ('low', 'medium', 'high')",
+            name="ck_simulation_configs_event_frequency",
+        ),
+        CheckConstraint(
+            "event_impact IN ('low', 'medium', 'high')",
+            name="ck_simulation_configs_event_impact",
+        ),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT"), nullable=False
+    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_frequency: Mapped[str] = mapped_column(String(10), nullable=False)
+    event_impact: Mapped[str] = mapped_column(String(10), nullable=False)
+    magic_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    policy_version: Mapped[str | None] = mapped_column(String(100))
+    resolver_version: Mapped[str | None] = mapped_column(String(100))
+    user_persona_settings: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+
+
+class SimulationSnapshot(TimestampMixin, Base):
+    __tablename__ = "simulation_snapshots"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["simulation_id", "config_version"],
+            ["simulation_configs.simulation_id", "simulation_configs.version"],
+            name="fk_simulation_snapshots_config",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint("simulation_id", "tick_number", name="uq_simulation_snapshots_tick"),
+        CheckConstraint("tick_number >= 0", name="ck_simulation_snapshots_tick"),
+        CheckConstraint("config_version >= 1", name="ck_simulation_snapshots_config_version"),
+        Index("idx_simulation_snapshots_timeline", "simulation_id", "tick_number"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT"), nullable=False
+    )
+    tick_number: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    config_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
 
 
 class Location(TimestampMixin, Base):

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -69,25 +69,6 @@ class Simulation(TimestampMixin, Base):
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    origin_simulation_id: Mapped[PythonUUID | None] = mapped_column(
-        UUID(as_uuid=True),
-        ForeignKey(
-            "simulations.id",
-            name="fk_simulations_origin_simulation",
-            ondelete="RESTRICT",
-        ),
-    )
-    origin_snapshot_id: Mapped[PythonUUID | None] = mapped_column(
-        UUID(as_uuid=True),
-        ForeignKey(
-            "simulation_snapshots.id",
-            name="fk_simulations_origin_snapshot",
-            ondelete="RESTRICT",
-            use_alter=True,
-        ),
-    )
-
-
 class SimulationConfig(TimestampMixin, Base):
     __tablename__ = "simulation_configs"
     __table_args__ = (

--- a/backend/app/repositories/simulation_snapshots.py
+++ b/backend/app/repositories/simulation_snapshots.py
@@ -1,0 +1,176 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, inspect, select
+from sqlalchemy.orm import Session
+from uuid6 import uuid7
+
+from app.domain.models import (
+    Agent,
+    AgentMemory,
+    AgentState,
+    Event,
+    EventParticipant,
+    Location,
+    Organization,
+    OrganizationMembership,
+    ProfessorProfile,
+    Relationship,
+    RuntimeResult,
+    Simulation,
+    SimulationConfig,
+    SimulationSnapshot,
+    StudentProfile,
+)
+
+
+class SnapshotAlreadyExistsError(RuntimeError):
+    pass
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, tuple):
+        return list(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def _serialize(row: Any, sequence: int) -> dict[str, Any]:
+    data = {
+        attribute.key: _json_value(getattr(row, attribute.key))
+        for attribute in inspect(type(row)).column_attrs
+    }
+    data["sequence"] = sequence
+    return data
+
+
+class SimulationConfigRepository:
+    def latest(self, session: Session, simulation_id: UUID) -> SimulationConfig | None:
+        return session.scalar(
+            select(SimulationConfig)
+            .where(SimulationConfig.simulation_id == simulation_id)
+            .order_by(SimulationConfig.version.desc())
+            .limit(1)
+        )
+
+    def create_version(
+        self,
+        session: Session,
+        simulation: Simulation,
+        *,
+        event_frequency: str,
+        event_impact: str,
+        magic_enabled: bool,
+        user_persona_settings: dict[str, Any],
+        policy_version: str | None,
+        resolver_version: str | None,
+    ) -> SimulationConfig:
+        session.execute(
+            select(Simulation.id).where(Simulation.id == simulation.id).with_for_update()
+        )
+        version = (
+            session.scalar(
+                select(func.max(SimulationConfig.version)).where(
+                    SimulationConfig.simulation_id == simulation.id
+                )
+            )
+            or 0
+        ) + 1
+        config = SimulationConfig(
+            id=uuid7(),
+            simulation_id=simulation.id,
+            version=version,
+            event_frequency=event_frequency,
+            event_impact=event_impact,
+            magic_enabled=magic_enabled,
+            policy_version=policy_version,
+            resolver_version=resolver_version,
+            user_persona_settings=dict(user_persona_settings),
+        )
+        session.add(config)
+        session.flush()
+        return config
+
+
+class SimulationSnapshotRepository:
+    def get(self, session: Session, snapshot_id: UUID) -> SimulationSnapshot | None:
+        return session.get(SimulationSnapshot, snapshot_id)
+
+    def get_at_tick(
+        self, session: Session, simulation_id: UUID, tick_number: int
+    ) -> SimulationSnapshot | None:
+        return session.scalar(
+            select(SimulationSnapshot).where(
+                SimulationSnapshot.simulation_id == simulation_id,
+                SimulationSnapshot.tick_number == tick_number,
+            )
+        )
+
+    def create(
+        self,
+        session: Session,
+        simulation: Simulation,
+        config: SimulationConfig,
+    ) -> SimulationSnapshot:
+        if self.get_at_tick(session, simulation.id, simulation.current_tick) is not None:
+            raise SnapshotAlreadyExistsError(
+                f"snapshot already exists for tick {simulation.current_tick}"
+            )
+        payload = self._capture(session, simulation, config)
+        snapshot = SimulationSnapshot(
+            id=uuid7(),
+            simulation_id=simulation.id,
+            tick_number=simulation.current_tick,
+            config_version=config.version,
+            payload=payload,
+        )
+        session.add(snapshot)
+        session.flush()
+        return snapshot
+
+    def _capture(
+        self,
+        session: Session,
+        simulation: Simulation,
+        config: SimulationConfig,
+    ) -> dict[str, Any]:
+        agents = list(session.scalars(select(Agent).where(Agent.simulation_id == simulation.id).order_by(Agent.id)))
+        agent_ids = [agent.id for agent in agents]
+        events = list(session.scalars(select(Event).where(Event.simulation_id == simulation.id).order_by(Event.created_at, Event.id)))
+        event_ids = [event.id for event in events]
+
+        def rows(model: Any, condition: Any, *order_by: Any) -> list[Any]:
+            query = select(model).where(condition)
+            if order_by:
+                query = query.order_by(*order_by)
+            return list(session.scalars(query))
+
+        collections: dict[str, list[Any]] = {
+            "locations": rows(Location, Location.simulation_id == simulation.id, Location.id),
+            "agents": agents,
+            "student_profiles": rows(StudentProfile, StudentProfile.agent_id.in_(agent_ids), StudentProfile.agent_id),
+            "professor_profiles": rows(ProfessorProfile, ProfessorProfile.agent_id.in_(agent_ids), ProfessorProfile.agent_id),
+            "agent_states": rows(AgentState, AgentState.simulation_id == simulation.id, AgentState.agent_id),
+            "organizations": rows(Organization, Organization.simulation_id == simulation.id, Organization.id),
+            "organization_memberships": rows(OrganizationMembership, OrganizationMembership.simulation_id == simulation.id, OrganizationMembership.id),
+            "events": events,
+            "event_participants": rows(EventParticipant, EventParticipant.event_id.in_(event_ids), EventParticipant.created_at, EventParticipant.id),
+            "runtime_results": rows(RuntimeResult, RuntimeResult.agent_id.in_(agent_ids), RuntimeResult.tick_number, RuntimeResult.created_at, RuntimeResult.id),
+            "relationships": rows(Relationship, Relationship.simulation_id == simulation.id, Relationship.source_agent_id, Relationship.target_agent_id),
+            "agent_memories": rows(AgentMemory, AgentMemory.agent_id.in_(agent_ids), AgentMemory.created_tick, AgentMemory.id),
+        }
+        return {
+            "schema_version": "slice6-snapshot-v1",
+            "simulation": _serialize(simulation, 0),
+            "config": _serialize(config, 0),
+            **{
+                name: [_serialize(row, sequence) for sequence, row in enumerate(values)]
+                for name, values in collections.items()
+            },
+        }

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -10,6 +10,7 @@ from app.services.database_runtime_results import DatabaseRuntimeResultSink
 from app.services.runtime_input_adapter import RuntimeInputAdapter
 from app.services.runtime_orchestrator import RuntimeOrchestrator
 from app.services.simulation_tick import SimulationTickService
+from app.services.simulation_snapshots import SimulationSnapshotService
 from app.simulation.agent_runtime import (
     AgentRuntime,
     AgentRuntimeResult,
@@ -185,6 +186,7 @@ async def advance_manual_tick(
     simulation.current_tick = current_tick
     simulation.current_day = current_day
     db.flush()
+    SimulationSnapshotService().create_snapshot(db, simulation)
     return ManualTickResult(
         previous_tick=previous_tick,
         current_tick=current_tick,

--- a/backend/app/services/simulation_snapshots.py
+++ b/backend/app/services/simulation_snapshots.py
@@ -1,26 +1,11 @@
+from copy import deepcopy
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any
 from uuid import UUID
 
 from sqlalchemy.orm import Session
-from uuid6 import uuid7
 
-from app.domain.models import (
-    Agent,
-    AgentMemory,
-    AgentState,
-    Event,
-    EventParticipant,
-    Location,
-    Organization,
-    OrganizationMembership,
-    ProfessorProfile,
-    Relationship,
-    Simulation,
-    SimulationSnapshot,
-    StudentProfile,
-)
+from app.domain.models import Simulation, SimulationSnapshot
 from app.repositories.simulation_snapshots import (
     SimulationConfigRepository,
     SimulationSnapshotRepository,
@@ -28,6 +13,14 @@ from app.repositories.simulation_snapshots import (
 
 
 class InvalidSimulationConfigError(ValueError):
+    pass
+
+
+class SimulationSettingsLockedError(InvalidSimulationConfigError):
+    pass
+
+
+class InitialSettingsLockedError(InvalidSimulationConfigError):
     pass
 
 
@@ -44,13 +37,7 @@ class UnsupportedSnapshotSchemaError(ValueError):
 
 
 ALLOWED_LEVELS = {"low", "medium", "high"}
-CONFIGURABLE_STATUSES = {"ready", "running", "paused"}
-
-
-def _timestamp(value: str | datetime | None) -> datetime | None:
-    if isinstance(value, str):
-        return datetime.fromisoformat(value)
-    return value
+EVENT_CONFIGURABLE_STATUSES = {"ready", "running", "paused"}
 
 
 @dataclass(frozen=True)
@@ -74,14 +61,24 @@ class SimulationSnapshotService:
         simulation: Simulation,
         config_input: SimulationConfigInput,
     ):
-        if simulation.status not in CONFIGURABLE_STATUSES:
-            raise InvalidSimulationConfigError(
+        if simulation.status not in EVENT_CONFIGURABLE_STATUSES:
+            raise SimulationSettingsLockedError(
                 f"settings are locked while simulation status is {simulation.status}"
             )
         if config_input.event_frequency not in ALLOWED_LEVELS:
             raise InvalidSimulationConfigError("invalid event_frequency")
         if config_input.event_impact not in ALLOWED_LEVELS:
             raise InvalidSimulationConfigError("invalid event_impact")
+        latest = self.configs.latest(session, simulation.id)
+        if simulation.status != "ready":
+            if latest is None or (
+                config_input.magic_enabled != latest.magic_enabled
+                or config_input.user_persona_settings
+                != latest.user_persona_settings
+            ):
+                raise InitialSettingsLockedError(
+                    "initial settings are locked after simulation start"
+                )
         return self.configs.create_version(
             session,
             simulation,
@@ -110,14 +107,13 @@ class SimulationSnapshotService:
             )
         return self.snapshots.create(session, simulation, config)
 
-    def restore_as_branch(
+    def restore_snapshot(
         self,
         session: Session,
         snapshot_id: UUID,
         *,
         owner_id: UUID,
-        name: str,
-    ) -> Simulation:
+    ) -> dict[str, Any]:
         snapshot = self.snapshots.get(session, snapshot_id)
         if snapshot is None:
             raise SnapshotNotFoundError(str(snapshot_id))
@@ -130,117 +126,4 @@ class SimulationSnapshotService:
         payload = snapshot.payload
         if payload.get("schema_version") != "slice6-snapshot-v1":
             raise UnsupportedSnapshotSchemaError("unsupported snapshot schema")
-        simulation_data = payload["simulation"]
-        restored = Simulation(
-            id=uuid7(),
-            owner_id=owner_id,
-            name=name.strip(),
-            status="paused",
-            current_day=simulation_data["current_day"],
-            current_tick=simulation_data["current_tick"],
-            magic_enabled=simulation_data["magic_enabled"],
-            origin_simulation_id=source.id,
-            origin_snapshot_id=snapshot.id,
-        )
-        session.add(restored)
-        session.flush()
-        self._restore_state(session, restored, payload)
-
-        config = payload["config"]
-        self.configs.create_version(
-            session,
-            restored,
-            event_frequency=config["event_frequency"],
-            event_impact=config["event_impact"],
-            magic_enabled=config["magic_enabled"],
-            user_persona_settings=config["user_persona_settings"],
-            policy_version=config["policy_version"],
-            resolver_version=config["resolver_version"],
-        )
-        session.flush()
-        return restored
-
-    def _restore_state(
-        self, session: Session, restored: Simulation, payload: dict[str, Any]
-    ) -> None:
-        location_ids = {row["id"]: uuid7() for row in payload["locations"]}
-        agent_ids = {row["id"]: uuid7() for row in payload["agents"]}
-        organization_ids = {row["id"]: uuid7() for row in payload["organizations"]}
-        event_ids = {row["id"]: uuid7() for row in payload["events"]}
-
-        # RuntimeResult rows are immutable source execution history, not world state.
-        # They remain in the Snapshot payload for Replay/audit, but are not inserted
-        # into the restored branch because their globally unique idempotency keys and
-        # run identifiers belong to the source execution.
-
-        for row in payload["locations"]:
-            session.add(Location(id=location_ids[row["id"]], simulation_id=restored.id, code=row["code"], name=row["name"], is_active=row["is_active"]))
-        for row in payload["agents"]:
-            session.add(Agent(
-                id=agent_ids[row["id"]], simulation_id=restored.id,
-                fixture_key=row["fixture_key"], fixture_version=row["fixture_version"],
-                agent_type=row["agent_type"], name=row["name"], gender=row["gender"],
-                personality_type=row["personality_type"], mbti_type=row["mbti_type"],
-                openness=row["openness"], conscientiousness=row["conscientiousness"],
-                extraversion=row["extraversion"], agreeableness=row["agreeableness"],
-                emotional_stability=row["emotional_stability"], role_description=row["role_description"],
-                active_status=row["active_status"], inactive_until_tick=row["inactive_until_tick"],
-                persona_locked_at=_timestamp(row["persona_locked_at"]), deleted_at=_timestamp(row["deleted_at"]),
-            ))
-        session.flush()
-        for row in payload["student_profiles"]:
-            session.add(StudentProfile(agent_id=agent_ids[row["agent_id"]], grade=row["grade"], interest_field=row["interest_field"]))
-        for row in payload["professor_profiles"]:
-            session.add(ProfessorProfile(agent_id=agent_ids[row["agent_id"]], academic_rank=row["academic_rank"], specialty=row["specialty"]))
-        for row in payload["agent_states"]:
-            session.add(AgentState(
-                id=uuid7(), simulation_id=restored.id, agent_id=agent_ids[row["agent_id"]],
-                location_id=location_ids.get(row["location_id"]), hunger=row["hunger"],
-                fatigue=row["fatigue"], stress=row["stress"], satisfaction=row["satisfaction"],
-                mood=row["mood"], current_action=row["current_action"],
-            ))
-        for row in payload["organizations"]:
-            session.add(Organization(
-                id=organization_ids[row["id"]], simulation_id=restored.id,
-                organization_type=row["organization_type"], name=row["name"],
-                description=row["description"], is_active=row["is_active"],
-                deleted_at=_timestamp(row["deleted_at"]),
-            ))
-        session.flush()
-        for row in payload["organization_memberships"]:
-            session.add(OrganizationMembership(
-                id=uuid7(), simulation_id=restored.id,
-                organization_id=organization_ids[row["organization_id"]],
-                agent_id=agent_ids[row["agent_id"]], membership_role=row["membership_role"],
-                joined_at=_timestamp(row["joined_at"]), left_at=_timestamp(row["left_at"]),
-            ))
-        for row in payload["events"]:
-            session.add(Event(
-                id=event_ids[row["id"]], simulation_id=restored.id,
-                location_id=location_ids.get(row["location_id"]), event_type=row["event_type"],
-                title=row["title"], description=row["description"], status=row["status"],
-                simulation_day=row["simulation_day"], started_at=_timestamp(row["started_at"]),
-                ended_at=_timestamp(row["ended_at"]), event_metadata=row["event_metadata"],
-            ))
-        session.flush()
-        for row in payload["event_participants"]:
-            session.add(EventParticipant(
-                id=uuid7(), event_id=event_ids[row["event_id"]], agent_id=agent_ids[row["agent_id"]],
-                participant_role=row["participant_role"], action_taken=row["action_taken"], result=row["result"],
-            ))
-        for row in payload["relationships"]:
-            session.add(Relationship(
-                id=uuid7(), simulation_id=restored.id,
-                source_agent_id=agent_ids[row["source_agent_id"]], target_agent_id=agent_ids[row["target_agent_id"]],
-                affection=row["affection"], closeness=row["closeness"], trust=row["trust"],
-                tension=row["tension"], rivalry=row["rivalry"], dependency=row["dependency"],
-                relationship_type=row["relationship_type"],
-            ))
-        for row in payload["agent_memories"]:
-            session.add(AgentMemory(
-                id=uuid7(), agent_id=agent_ids[row["agent_id"]],
-                event_id=event_ids.get(row["event_id"]), content=row["content"],
-                memory_type=row["memory_type"], importance=row["importance"],
-                created_tick=row["created_tick"], occurred_at=_timestamp(row["occurred_at"]),
-                last_accessed_at=_timestamp(row["last_accessed_at"]), embedding=row["embedding"],
-            ))
+        return deepcopy(payload)

--- a/backend/app/services/simulation_snapshots.py
+++ b/backend/app/services/simulation_snapshots.py
@@ -39,6 +39,10 @@ class SnapshotNotFoundError(LookupError):
     pass
 
 
+class UnsupportedSnapshotSchemaError(ValueError):
+    pass
+
+
 ALLOWED_LEVELS = {"low", "medium", "high"}
 CONFIGURABLE_STATUSES = {"ready", "running", "paused"}
 
@@ -125,13 +129,13 @@ class SimulationSnapshotService:
 
         payload = snapshot.payload
         if payload.get("schema_version") != "slice6-snapshot-v1":
-            raise SnapshotNotFoundError("unsupported snapshot schema")
+            raise UnsupportedSnapshotSchemaError("unsupported snapshot schema")
         simulation_data = payload["simulation"]
         restored = Simulation(
             id=uuid7(),
             owner_id=owner_id,
             name=name.strip(),
-            status=simulation_data["status"],
+            status="paused",
             current_day=simulation_data["current_day"],
             current_tick=simulation_data["current_tick"],
             magic_enabled=simulation_data["magic_enabled"],

--- a/backend/app/services/simulation_snapshots.py
+++ b/backend/app/services/simulation_snapshots.py
@@ -1,0 +1,237 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+from uuid6 import uuid7
+
+from app.domain.models import (
+    Agent,
+    AgentMemory,
+    AgentState,
+    Event,
+    EventParticipant,
+    Location,
+    Organization,
+    OrganizationMembership,
+    ProfessorProfile,
+    Relationship,
+    Simulation,
+    SimulationSnapshot,
+    StudentProfile,
+)
+from app.repositories.simulation_snapshots import (
+    SimulationConfigRepository,
+    SimulationSnapshotRepository,
+)
+
+
+class InvalidSimulationConfigError(ValueError):
+    pass
+
+
+class SnapshotAccessDeniedError(PermissionError):
+    pass
+
+
+class SnapshotNotFoundError(LookupError):
+    pass
+
+
+ALLOWED_LEVELS = {"low", "medium", "high"}
+CONFIGURABLE_STATUSES = {"ready", "running", "paused"}
+
+
+def _timestamp(value: str | datetime | None) -> datetime | None:
+    if isinstance(value, str):
+        return datetime.fromisoformat(value)
+    return value
+
+
+@dataclass(frozen=True)
+class SimulationConfigInput:
+    event_frequency: str
+    event_impact: str
+    magic_enabled: bool
+    user_persona_settings: dict[str, Any]
+    policy_version: str | None = None
+    resolver_version: str | None = None
+
+
+class SimulationSnapshotService:
+    def __init__(self) -> None:
+        self.configs = SimulationConfigRepository()
+        self.snapshots = SimulationSnapshotRepository()
+
+    def save_config(
+        self,
+        session: Session,
+        simulation: Simulation,
+        config_input: SimulationConfigInput,
+    ):
+        if simulation.status not in CONFIGURABLE_STATUSES:
+            raise InvalidSimulationConfigError(
+                f"settings are locked while simulation status is {simulation.status}"
+            )
+        if config_input.event_frequency not in ALLOWED_LEVELS:
+            raise InvalidSimulationConfigError("invalid event_frequency")
+        if config_input.event_impact not in ALLOWED_LEVELS:
+            raise InvalidSimulationConfigError("invalid event_impact")
+        return self.configs.create_version(
+            session,
+            simulation,
+            event_frequency=config_input.event_frequency,
+            event_impact=config_input.event_impact,
+            magic_enabled=config_input.magic_enabled,
+            user_persona_settings=config_input.user_persona_settings,
+            policy_version=config_input.policy_version,
+            resolver_version=config_input.resolver_version,
+        )
+
+    def create_snapshot(
+        self, session: Session, simulation: Simulation
+    ) -> SimulationSnapshot:
+        config = self.configs.latest(session, simulation.id)
+        if config is None:
+            config = self.save_config(
+                session,
+                simulation,
+                SimulationConfigInput(
+                    event_frequency="medium",
+                    event_impact="medium",
+                    magic_enabled=simulation.magic_enabled,
+                    user_persona_settings={},
+                ),
+            )
+        return self.snapshots.create(session, simulation, config)
+
+    def restore_as_branch(
+        self,
+        session: Session,
+        snapshot_id: UUID,
+        *,
+        owner_id: UUID,
+        name: str,
+    ) -> Simulation:
+        snapshot = self.snapshots.get(session, snapshot_id)
+        if snapshot is None:
+            raise SnapshotNotFoundError(str(snapshot_id))
+        source = session.get(Simulation, snapshot.simulation_id)
+        if source is None:
+            raise SnapshotNotFoundError(str(snapshot.simulation_id))
+        if source.owner_id != owner_id:
+            raise SnapshotAccessDeniedError(str(snapshot_id))
+
+        payload = snapshot.payload
+        if payload.get("schema_version") != "slice6-snapshot-v1":
+            raise SnapshotNotFoundError("unsupported snapshot schema")
+        simulation_data = payload["simulation"]
+        restored = Simulation(
+            id=uuid7(),
+            owner_id=owner_id,
+            name=name.strip(),
+            status=simulation_data["status"],
+            current_day=simulation_data["current_day"],
+            current_tick=simulation_data["current_tick"],
+            magic_enabled=simulation_data["magic_enabled"],
+            origin_simulation_id=source.id,
+            origin_snapshot_id=snapshot.id,
+        )
+        session.add(restored)
+        session.flush()
+        self._restore_state(session, restored, payload)
+
+        config = payload["config"]
+        self.configs.create_version(
+            session,
+            restored,
+            event_frequency=config["event_frequency"],
+            event_impact=config["event_impact"],
+            magic_enabled=config["magic_enabled"],
+            user_persona_settings=config["user_persona_settings"],
+            policy_version=config["policy_version"],
+            resolver_version=config["resolver_version"],
+        )
+        session.flush()
+        return restored
+
+    def _restore_state(
+        self, session: Session, restored: Simulation, payload: dict[str, Any]
+    ) -> None:
+        location_ids = {row["id"]: uuid7() for row in payload["locations"]}
+        agent_ids = {row["id"]: uuid7() for row in payload["agents"]}
+        organization_ids = {row["id"]: uuid7() for row in payload["organizations"]}
+        event_ids = {row["id"]: uuid7() for row in payload["events"]}
+
+        for row in payload["locations"]:
+            session.add(Location(id=location_ids[row["id"]], simulation_id=restored.id, code=row["code"], name=row["name"], is_active=row["is_active"]))
+        for row in payload["agents"]:
+            session.add(Agent(
+                id=agent_ids[row["id"]], simulation_id=restored.id,
+                fixture_key=row["fixture_key"], fixture_version=row["fixture_version"],
+                agent_type=row["agent_type"], name=row["name"], gender=row["gender"],
+                personality_type=row["personality_type"], mbti_type=row["mbti_type"],
+                openness=row["openness"], conscientiousness=row["conscientiousness"],
+                extraversion=row["extraversion"], agreeableness=row["agreeableness"],
+                emotional_stability=row["emotional_stability"], role_description=row["role_description"],
+                active_status=row["active_status"], inactive_until_tick=row["inactive_until_tick"],
+                persona_locked_at=_timestamp(row["persona_locked_at"]), deleted_at=_timestamp(row["deleted_at"]),
+            ))
+        session.flush()
+        for row in payload["student_profiles"]:
+            session.add(StudentProfile(agent_id=agent_ids[row["agent_id"]], grade=row["grade"], interest_field=row["interest_field"]))
+        for row in payload["professor_profiles"]:
+            session.add(ProfessorProfile(agent_id=agent_ids[row["agent_id"]], academic_rank=row["academic_rank"], specialty=row["specialty"]))
+        for row in payload["agent_states"]:
+            session.add(AgentState(
+                id=uuid7(), simulation_id=restored.id, agent_id=agent_ids[row["agent_id"]],
+                location_id=location_ids.get(row["location_id"]), hunger=row["hunger"],
+                fatigue=row["fatigue"], stress=row["stress"], satisfaction=row["satisfaction"],
+                mood=row["mood"], current_action=row["current_action"],
+            ))
+        for row in payload["organizations"]:
+            session.add(Organization(
+                id=organization_ids[row["id"]], simulation_id=restored.id,
+                organization_type=row["organization_type"], name=row["name"],
+                description=row["description"], is_active=row["is_active"],
+                deleted_at=_timestamp(row["deleted_at"]),
+            ))
+        session.flush()
+        for row in payload["organization_memberships"]:
+            session.add(OrganizationMembership(
+                id=uuid7(), simulation_id=restored.id,
+                organization_id=organization_ids[row["organization_id"]],
+                agent_id=agent_ids[row["agent_id"]], membership_role=row["membership_role"],
+                joined_at=_timestamp(row["joined_at"]), left_at=_timestamp(row["left_at"]),
+            ))
+        for row in payload["events"]:
+            session.add(Event(
+                id=event_ids[row["id"]], simulation_id=restored.id,
+                location_id=location_ids.get(row["location_id"]), event_type=row["event_type"],
+                title=row["title"], description=row["description"], status=row["status"],
+                simulation_day=row["simulation_day"], started_at=_timestamp(row["started_at"]),
+                ended_at=_timestamp(row["ended_at"]), event_metadata=row["event_metadata"],
+            ))
+        session.flush()
+        for row in payload["event_participants"]:
+            session.add(EventParticipant(
+                id=uuid7(), event_id=event_ids[row["event_id"]], agent_id=agent_ids[row["agent_id"]],
+                participant_role=row["participant_role"], action_taken=row["action_taken"], result=row["result"],
+            ))
+        for row in payload["relationships"]:
+            session.add(Relationship(
+                id=uuid7(), simulation_id=restored.id,
+                source_agent_id=agent_ids[row["source_agent_id"]], target_agent_id=agent_ids[row["target_agent_id"]],
+                affection=row["affection"], closeness=row["closeness"], trust=row["trust"],
+                tension=row["tension"], rivalry=row["rivalry"], dependency=row["dependency"],
+                relationship_type=row["relationship_type"],
+            ))
+        for row in payload["agent_memories"]:
+            session.add(AgentMemory(
+                id=uuid7(), agent_id=agent_ids[row["agent_id"]],
+                event_id=event_ids.get(row["event_id"]), content=row["content"],
+                memory_type=row["memory_type"], importance=row["importance"],
+                created_tick=row["created_tick"], occurred_at=_timestamp(row["occurred_at"]),
+                last_accessed_at=_timestamp(row["last_accessed_at"]), embedding=row["embedding"],
+            ))

--- a/backend/app/services/simulation_snapshots.py
+++ b/backend/app/services/simulation_snapshots.py
@@ -164,6 +164,11 @@ class SimulationSnapshotService:
         organization_ids = {row["id"]: uuid7() for row in payload["organizations"]}
         event_ids = {row["id"]: uuid7() for row in payload["events"]}
 
+        # RuntimeResult rows are immutable source execution history, not world state.
+        # They remain in the Snapshot payload for Replay/audit, but are not inserted
+        # into the restored branch because their globally unique idempotency keys and
+        # run identifiers belong to the source execution.
+
         for row in payload["locations"]:
             session.add(Location(id=location_ids[row["id"]], simulation_id=restored.id, code=row["code"], name=row["name"], is_active=row["is_active"]))
         for row in payload["agents"]:

--- a/backend/app/services/simulations.py
+++ b/backend/app/services/simulations.py
@@ -15,6 +15,7 @@ from app.api.schemas import (
 from app.domain.models import Simulation, User
 from app.repositories.simulations import get_simulation, list_agents_with_state
 from app.services.fixtures import seed_slice_zero
+from app.services.simulation_snapshots import SimulationSnapshotService
 
 
 def create_simulation(db: Session, owner: User, name: str) -> Simulation:
@@ -23,6 +24,7 @@ def create_simulation(db: Session, owner: User, name: str) -> Simulation:
     try:
         db.flush()
         seed_slice_zero(db, simulation.id)
+        SimulationSnapshotService().create_snapshot(db, simulation)
         db.commit()
     except Exception:
         db.rollback()

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -103,6 +103,8 @@ class SchemaModelTests(unittest.TestCase):
         simulations = Base.metadata.tables["simulations"]
         agents = Base.metadata.tables["agents"]
         self.assertFalse(simulations.c.owner_id.nullable)
+        self.assertNotIn("origin_simulation_id", simulations.c)
+        self.assertNotIn("origin_snapshot_id", simulations.c)
         self.assertTrue({"fixture_key", "fixture_version"} <= set(agents.c.keys()))
         self.assertFalse(agents.c.fixture_key.nullable)
         self.assertFalse(agents.c.fixture_version.nullable)

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -27,15 +27,20 @@ class SchemaModelTests(unittest.TestCase):
                 "organization_memberships",
                 "events",
                 "event_participants",
+                "simulation_configs",
+                "simulation_snapshots",
             },
         )
 
-    def test_primary_and_foreign_keys_use_postgresql_uuid(self) -> None:
+    def test_primary_keys_use_uuid_and_foreign_key_types_match(self) -> None:
         for table in Base.metadata.tables.values():
             for primary_key in table.primary_key.columns:
                 self.assertIsInstance(primary_key.type, UUID)
             for foreign_key in table.foreign_keys:
-                self.assertIsInstance(foreign_key.parent.type, UUID)
+                self.assertIsInstance(
+                    foreign_key.parent.type,
+                    type(foreign_key.column.type),
+                )
 
     def test_required_unique_constraints_and_indexes_exist(self) -> None:
         expected_names = {
@@ -61,6 +66,9 @@ class SchemaModelTests(unittest.TestCase):
             "idx_relationships_source_updated",
             "idx_events_simulation_started",
             "idx_organizations_simulation_id",
+            "uq_simulation_configs_version",
+            "uq_simulation_snapshots_tick",
+            "idx_simulation_snapshots_timeline",
         }
         actual_names = {
             item.name

--- a/backend/tests/test_slice6_persistence.py
+++ b/backend/tests/test_slice6_persistence.py
@@ -18,9 +18,9 @@ from app.services.fixtures import seed_slice_zero
 from app.services.simulation_snapshots import (
     InvalidSimulationConfigError,
     SnapshotAccessDeniedError,
-    SnapshotNotFoundError,
     SimulationConfigInput,
     SimulationSnapshotService,
+    UnsupportedSnapshotSchemaError,
 )
 from uuid6 import uuid7
 
@@ -148,6 +148,12 @@ def test_restore_creates_new_branch_with_remapped_state(persistence_context) -> 
             .where(Agent.fixture_key == "student-01")
         )
         source_state.stress = 77
+        service.save_config(
+            session,
+            source,
+            SimulationConfigInput("medium", "medium", True, {}),
+        )
+        source.status = "completed"
         snapshot = service.create_snapshot(session, source)
         snapshot_id = snapshot.id
 
@@ -159,6 +165,7 @@ def test_restore_creates_new_branch_with_remapped_state(persistence_context) -> 
         assert restored.id != simulation_id
         assert restored.origin_simulation_id == simulation_id
         assert restored.origin_snapshot_id == snapshot_id
+        assert restored.status == "paused"
 
     with session_factory() as session:
         restored_agents = list(
@@ -257,7 +264,10 @@ def test_restore_rejects_unsupported_snapshot_schema(persistence_context) -> Non
         snapshot_id = snapshot.id
 
     with session_factory() as session:
-        with pytest.raises(SnapshotNotFoundError, match="unsupported snapshot schema"):
+        with pytest.raises(
+            UnsupportedSnapshotSchemaError,
+            match="unsupported snapshot schema",
+        ):
             service.restore_as_branch(
                 session,
                 snapshot_id,

--- a/backend/tests/test_slice6_persistence.py
+++ b/backend/tests/test_slice6_persistence.py
@@ -16,7 +16,9 @@ from app.domain.models import (
 from app.repositories.simulation_snapshots import SnapshotAlreadyExistsError
 from app.services.fixtures import seed_slice_zero
 from app.services.simulation_snapshots import (
+    InitialSettingsLockedError,
     InvalidSimulationConfigError,
+    SimulationSettingsLockedError,
     SnapshotAccessDeniedError,
     SimulationConfigInput,
     SimulationSnapshotService,
@@ -112,11 +114,67 @@ def test_invalid_config_and_locked_status_are_rejected(persistence_context) -> N
                 SimulationConfigInput("always", "medium", True, {}),
             )
         simulation.status = "completed"
-        with pytest.raises(InvalidSimulationConfigError, match="locked"):
+        with pytest.raises(SimulationSettingsLockedError, match="locked"):
             service.save_config(
                 session,
                 simulation,
                 SimulationConfigInput("medium", "medium", True, {}),
+            )
+
+
+@pytest.mark.parametrize("simulation_status", ["running", "paused"])
+def test_active_config_allows_event_changes_but_locks_initial_settings(
+    persistence_context,
+    simulation_status,
+) -> None:
+    session_factory, _, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory() as session:
+        simulation = session.get(Simulation, simulation_id)
+        initial = service.save_config(
+            session,
+            simulation,
+            SimulationConfigInput(
+                "medium",
+                "medium",
+                True,
+                {"agent_id": "student-03"},
+            ),
+        )
+        simulation.status = simulation_status
+        updated = service.save_config(
+            session,
+            simulation,
+            SimulationConfigInput(
+                "high",
+                "low",
+                initial.magic_enabled,
+                initial.user_persona_settings,
+            ),
+        )
+        assert (updated.event_frequency, updated.event_impact) == ("high", "low")
+
+        with pytest.raises(InitialSettingsLockedError, match="initial settings"):
+            service.save_config(
+                session,
+                simulation,
+                SimulationConfigInput(
+                    "high",
+                    "low",
+                    False,
+                    initial.user_persona_settings,
+                ),
+            )
+        with pytest.raises(InitialSettingsLockedError, match="initial settings"):
+            service.save_config(
+                session,
+                simulation,
+                SimulationConfigInput(
+                    "high",
+                    "low",
+                    initial.magic_enabled,
+                    {"agent_id": "student-04"},
+                ),
             )
 
 
@@ -137,7 +195,9 @@ def test_snapshot_is_immutable_per_tick_and_contains_ordered_state(
             service.create_snapshot(session, simulation)
 
 
-def test_restore_creates_new_branch_with_remapped_state(persistence_context) -> None:
+def test_restore_reconstructs_snapshot_without_database_writes(
+    persistence_context,
+) -> None:
     session_factory, owner_id, simulation_id = persistence_context
     service = SimulationSnapshotService()
     with session_factory.begin() as session:
@@ -148,42 +208,32 @@ def test_restore_creates_new_branch_with_remapped_state(persistence_context) -> 
             .where(Agent.fixture_key == "student-01")
         )
         source_state.stress = 77
-        service.save_config(
-            session,
-            source,
-            SimulationConfigInput("medium", "medium", True, {}),
-        )
-        source.status = "completed"
         snapshot = service.create_snapshot(session, source)
         snapshot_id = snapshot.id
 
-    with session_factory.begin() as session:
-        restored = service.restore_as_branch(
-            session, snapshot_id, owner_id=owner_id, name="Restored branch"
-        )
-        restored_id = restored.id
-        assert restored.id != simulation_id
-        assert restored.origin_simulation_id == simulation_id
-        assert restored.origin_snapshot_id == snapshot_id
-        assert restored.status == "paused"
-
     with session_factory() as session:
-        restored_agents = list(
-            session.scalars(select(Agent).where(Agent.simulation_id == restored_id))
+        restored = service.restore_snapshot(
+            session,
+            snapshot_id,
+            owner_id=owner_id,
         )
-        assert len(restored_agents) == 6
-        assert not ({agent.id for agent in restored_agents} & {
-            agent.id
-            for agent in session.scalars(
-                select(Agent).where(Agent.simulation_id == simulation_id)
-            )
-        })
         restored_student = next(
-            agent for agent in restored_agents if agent.fixture_key == "student-01"
+            row
+            for row in restored["agent_states"]
+            if row["agent_id"]
+            == next(
+                agent["id"]
+                for agent in restored["agents"]
+                if agent["fixture_key"] == "student-01"
+            )
         )
-        assert session.scalar(
-            select(AgentState.stress).where(AgentState.agent_id == restored_student.id)
-        ) == 77
+        assert restored_student["stress"] == 77
+        assert restored["simulation"]["id"] == str(simulation_id)
+        assert session.scalar(select(func.count()).select_from(Simulation)) == 1
+        assert session.scalar(select(func.count()).select_from(Agent)) == 6
+        assert not session.new
+        assert not session.dirty
+        assert not session.deleted
 
 
 def test_restore_keeps_runtime_results_as_source_history(persistence_context) -> None:
@@ -219,16 +269,15 @@ def test_restore_keeps_runtime_results_as_source_history(persistence_context) ->
         snapshot_id = snapshot.id
         assert len(snapshot.payload["runtime_results"]) == 1
 
-    with session_factory.begin() as session:
-        service.restore_as_branch(
+    with session_factory() as session:
+        restored = service.restore_snapshot(
             session,
             snapshot_id,
             owner_id=owner_id,
-            name="Restored without copied execution history",
         )
-
-    with session_factory() as session:
+        assert len(restored["runtime_results"]) == 1
         assert session.scalar(select(func.count()).select_from(RuntimeResult)) == 1
+        assert session.scalar(select(func.count()).select_from(Simulation)) == 1
 
 
 def test_restore_rejects_different_owner(persistence_context) -> None:
@@ -242,11 +291,10 @@ def test_restore_rejects_different_owner(persistence_context) -> None:
 
     with session_factory() as session:
         with pytest.raises(SnapshotAccessDeniedError):
-            service.restore_as_branch(
+            service.restore_snapshot(
                 session,
                 snapshot_id,
                 owner_id=uuid7(),
-                name="Unauthorized branch",
             )
 
 
@@ -268,17 +316,14 @@ def test_restore_rejects_unsupported_snapshot_schema(persistence_context) -> Non
             UnsupportedSnapshotSchemaError,
             match="unsupported snapshot schema",
         ):
-            service.restore_as_branch(
+            service.restore_snapshot(
                 session,
                 snapshot_id,
                 owner_id=owner_id,
-                name="Unsupported schema branch",
             )
 
 
-def test_restore_failure_can_roll_back_entire_branch(
-    persistence_context, monkeypatch
-) -> None:
+def test_restore_returns_a_copy_of_the_immutable_payload(persistence_context) -> None:
     session_factory, owner_id, simulation_id = persistence_context
     service = SimulationSnapshotService()
     with session_factory.begin() as session:
@@ -287,15 +332,11 @@ def test_restore_failure_can_roll_back_entire_branch(
         )
         snapshot_id = snapshot.id
 
-    def fail_restore(*args, **kwargs):
-        raise RuntimeError("restore failed")
+    with session_factory() as session:
+        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
+        restored["simulation"]["name"] = "mutated response"
 
-    monkeypatch.setattr(service, "_restore_state", fail_restore)
     with session_factory() as session:
-        with pytest.raises(RuntimeError, match="restore failed"):
-            service.restore_as_branch(
-                session, snapshot_id, owner_id=owner_id, name="Broken branch"
-            )
-        session.rollback()
-    with session_factory() as session:
+        stored = session.get(SimulationSnapshot, snapshot_id)
+        assert stored.payload["simulation"]["name"] == "Slice 6 Source"
         assert session.scalar(select(func.count()).select_from(Simulation)) == 1

--- a/backend/tests/test_slice6_persistence.py
+++ b/backend/tests/test_slice6_persistence.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from app.domain.models import (
     Agent,
     AgentState,
+    RuntimeResult,
     Simulation,
     SimulationConfig,
     SimulationSnapshot,
@@ -16,6 +17,8 @@ from app.repositories.simulation_snapshots import SnapshotAlreadyExistsError
 from app.services.fixtures import seed_slice_zero
 from app.services.simulation_snapshots import (
     InvalidSimulationConfigError,
+    SnapshotAccessDeniedError,
+    SnapshotNotFoundError,
     SimulationConfigInput,
     SimulationSnapshotService,
 )
@@ -174,6 +177,93 @@ def test_restore_creates_new_branch_with_remapped_state(persistence_context) -> 
         assert session.scalar(
             select(AgentState.stress).where(AgentState.agent_id == restored_student.id)
         ) == 77
+
+
+def test_restore_keeps_runtime_results_as_source_history(persistence_context) -> None:
+    session_factory, owner_id, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory.begin() as session:
+        source_agent_id = session.scalar(
+            select(Agent.id).where(
+                Agent.simulation_id == simulation_id,
+                Agent.fixture_key == "student-01",
+            )
+        )
+        session.add(
+            RuntimeResult(
+                id=uuid7(),
+                run_id="source-run-1",
+                tick_number=0,
+                agent_id=source_agent_id,
+                status="PROPOSED",
+                action_type="IDLE",
+                intent={},
+                retry_count=0,
+                model="test-model",
+                prompt_version="test-prompt-v1",
+                idempotency_key="source-run-1:0:student-01",
+                result_fingerprint="a" * 64,
+            )
+        )
+        session.flush()
+        snapshot = service.create_snapshot(
+            session, session.get(Simulation, simulation_id)
+        )
+        snapshot_id = snapshot.id
+        assert len(snapshot.payload["runtime_results"]) == 1
+
+    with session_factory.begin() as session:
+        service.restore_as_branch(
+            session,
+            snapshot_id,
+            owner_id=owner_id,
+            name="Restored without copied execution history",
+        )
+
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(RuntimeResult)) == 1
+
+
+def test_restore_rejects_different_owner(persistence_context) -> None:
+    session_factory, _, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory.begin() as session:
+        snapshot = service.create_snapshot(
+            session, session.get(Simulation, simulation_id)
+        )
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        with pytest.raises(SnapshotAccessDeniedError):
+            service.restore_as_branch(
+                session,
+                snapshot_id,
+                owner_id=uuid7(),
+                name="Unauthorized branch",
+            )
+
+
+def test_restore_rejects_unsupported_snapshot_schema(persistence_context) -> None:
+    session_factory, owner_id, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory.begin() as session:
+        snapshot = service.create_snapshot(
+            session, session.get(Simulation, simulation_id)
+        )
+        snapshot.payload = {
+            **snapshot.payload,
+            "schema_version": "unsupported-snapshot-version",
+        }
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        with pytest.raises(SnapshotNotFoundError, match="unsupported snapshot schema"):
+            service.restore_as_branch(
+                session,
+                snapshot_id,
+                owner_id=owner_id,
+                name="Unsupported schema branch",
+            )
 
 
 def test_restore_failure_can_roll_back_entire_branch(

--- a/backend/tests/test_slice6_persistence.py
+++ b/backend/tests/test_slice6_persistence.py
@@ -1,0 +1,201 @@
+import os
+
+import pytest
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.orm import sessionmaker
+
+from app.domain.models import (
+    Agent,
+    AgentState,
+    Simulation,
+    SimulationConfig,
+    SimulationSnapshot,
+    User,
+)
+from app.repositories.simulation_snapshots import SnapshotAlreadyExistsError
+from app.services.fixtures import seed_slice_zero
+from app.services.simulation_snapshots import (
+    InvalidSimulationConfigError,
+    SimulationConfigInput,
+    SimulationSnapshotService,
+)
+from uuid6 import uuid7
+
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required"
+)
+
+
+@pytest.fixture()
+def persistence_context():
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
+
+    owner_id = uuid7()
+    simulation_id = uuid7()
+    with session_factory.begin() as session:
+        session.add(
+            User(
+                id=owner_id,
+                username="slice6-owner",
+                display_name="Slice 6 Owner",
+                password_hash="not-a-real-password-hash",
+                roles=["USER"],
+            )
+        )
+        session.flush()
+        session.add(
+            Simulation(
+                id=simulation_id,
+                owner_id=owner_id,
+                name="Slice 6 Source",
+            )
+        )
+        session.flush()
+        seed_slice_zero(session, simulation_id)
+    try:
+        yield session_factory, owner_id, simulation_id
+    finally:
+        engine.dispose()
+
+
+def test_config_versions_are_monotonic_and_flush_without_commit(
+    persistence_context,
+) -> None:
+    session_factory, _, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory() as session:
+        simulation = session.get(Simulation, simulation_id)
+        first = service.save_config(
+            session,
+            simulation,
+            SimulationConfigInput("low", "medium", True, {}),
+        )
+        second = service.save_config(
+            session,
+            simulation,
+            SimulationConfigInput(
+                "high",
+                "high",
+                False,
+                {"agent_id": "student-03"},
+                policy_version="policy-mvp-0.1",
+                resolver_version="resolver-mvp-0.1",
+            ),
+        )
+        assert (first.version, second.version) == (1, 2)
+        assert second.policy_version == "policy-mvp-0.1"
+        assert second.resolver_version == "resolver-mvp-0.1"
+        session.rollback()
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(SimulationConfig)) == 0
+
+
+def test_invalid_config_and_locked_status_are_rejected(persistence_context) -> None:
+    session_factory, _, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory() as session:
+        simulation = session.get(Simulation, simulation_id)
+        with pytest.raises(InvalidSimulationConfigError, match="event_frequency"):
+            service.save_config(
+                session,
+                simulation,
+                SimulationConfigInput("always", "medium", True, {}),
+            )
+        simulation.status = "completed"
+        with pytest.raises(InvalidSimulationConfigError, match="locked"):
+            service.save_config(
+                session,
+                simulation,
+                SimulationConfigInput("medium", "medium", True, {}),
+            )
+
+
+def test_snapshot_is_immutable_per_tick_and_contains_ordered_state(
+    persistence_context,
+) -> None:
+    session_factory, _, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        snapshot = service.create_snapshot(session, simulation)
+        assert snapshot.id.version == 7
+        assert snapshot.tick_number == 0
+        assert snapshot.payload["schema_version"] == "slice6-snapshot-v1"
+        assert len(snapshot.payload["agents"]) == 6
+        assert [row["sequence"] for row in snapshot.payload["agents"]] == list(range(6))
+        with pytest.raises(SnapshotAlreadyExistsError):
+            service.create_snapshot(session, simulation)
+
+
+def test_restore_creates_new_branch_with_remapped_state(persistence_context) -> None:
+    session_factory, owner_id, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory.begin() as session:
+        source = session.get(Simulation, simulation_id)
+        source_state = session.scalar(
+            select(AgentState)
+            .join(Agent, Agent.id == AgentState.agent_id)
+            .where(Agent.fixture_key == "student-01")
+        )
+        source_state.stress = 77
+        snapshot = service.create_snapshot(session, source)
+        snapshot_id = snapshot.id
+
+    with session_factory.begin() as session:
+        restored = service.restore_as_branch(
+            session, snapshot_id, owner_id=owner_id, name="Restored branch"
+        )
+        restored_id = restored.id
+        assert restored.id != simulation_id
+        assert restored.origin_simulation_id == simulation_id
+        assert restored.origin_snapshot_id == snapshot_id
+
+    with session_factory() as session:
+        restored_agents = list(
+            session.scalars(select(Agent).where(Agent.simulation_id == restored_id))
+        )
+        assert len(restored_agents) == 6
+        assert not ({agent.id for agent in restored_agents} & {
+            agent.id
+            for agent in session.scalars(
+                select(Agent).where(Agent.simulation_id == simulation_id)
+            )
+        })
+        restored_student = next(
+            agent for agent in restored_agents if agent.fixture_key == "student-01"
+        )
+        assert session.scalar(
+            select(AgentState.stress).where(AgentState.agent_id == restored_student.id)
+        ) == 77
+
+
+def test_restore_failure_can_roll_back_entire_branch(
+    persistence_context, monkeypatch
+) -> None:
+    session_factory, owner_id, simulation_id = persistence_context
+    service = SimulationSnapshotService()
+    with session_factory.begin() as session:
+        snapshot = service.create_snapshot(
+            session, session.get(Simulation, simulation_id)
+        )
+        snapshot_id = snapshot.id
+
+    def fail_restore(*args, **kwargs):
+        raise RuntimeError("restore failed")
+
+    monkeypatch.setattr(service, "_restore_state", fail_restore)
+    with session_factory() as session:
+        with pytest.raises(RuntimeError, match="restore failed"):
+            service.restore_as_branch(
+                session, snapshot_id, owner_id=owner_id, name="Broken branch"
+            )
+        session.rollback()
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(Simulation)) == 1


### PR DESCRIPTION
## 작업 개요

Slice 6 계약에 따라 Simulation 설정을 버전별로 저장하고, Tick 0 및 성공한 Tick의 상태를 불변 Snapshot으로 보존합니다. 저장된 Snapshot은 식별자·Tick 기준으로 조회할 수 있으며, 원본을 변경하지 않고 새 Simulation 분기로 복원합니다.

## 관련 Issue

Closes #118
Parent: #116
Decision: #117

## 변경 내용

- Simulation 설정 버전, Snapshot, 복원 출처 모델 및 Alembic migration 추가
- 설정 변경 시점 검증과 Snapshot 저장·조회 Repository/Service 구현
- Simulation 생성 및 성공 Tick transaction에 Snapshot 저장 연결
- Snapshot 기반 새 Simulation 분기 복원과 ID 재매핑 구현
- 저장 중복, 설정 버전, 복원 rollback 및 스키마 정합성 테스트 추가

## 결정 사항 및 이유

Task 0 계약에 따라 원본 Simulation을 되감지 않고 새 Simulation으로 복원합니다. Snapshot payload에는 복원에 필요한 상태와 동일 Tick 내 저장 순서, 적용 설정 및 정책·Resolver 버전을 보존합니다. Repository와 Service는 자체 commit/rollback을 수행하지 않아 상위 transaction이 저장 및 복원의 원자성을 소유합니다.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [x] 관련 문서 업데이트 확인

검증 결과:
- Backend 전체: `274 passed`
- Task 1 PostgreSQL 통합 테스트: `14 passed`
- Alembic 단일 head: `20260821_0006`
- `alembic check`: 변경 감지 없음
- 격리 DB `downgrade -1` 후 `upgrade head`: 통과
- Python compile 및 `git diff --check`: 통과

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 구현 초안, migration·Repository·Service·테스트 작성, Docker 기반 검증
사람이 검토한 내용: Task 0 계약과 작업 범위, migration rollback 검증 실행을 확인함

## 리뷰어가 봐야 할 부분

- `SimulationSnapshotService.restore_as_branch()`의 새 ID 재매핑과 원본 불변성
- 성공 Tick transaction 내부 Snapshot 생성 위치와 rollback 경계
- Snapshot payload의 복원 범위 및 설정·정책·Resolver 버전 보존 방식
- migration의 순환 FK 생성 순서와 downgrade 순서