### PR TITLE
[Feature] Slice 4 Task 3 — User Persona 저장·잠금 및 실행 기록

### DIFF
--- a/backend/alembic/versions/20260824_0006_add_persona_and_runtime_execution.py
+++ b/backend/alembic/versions/20260824_0006_add_persona_and_runtime_execution.py
@@ -1,0 +1,122 @@
+"""add user persona configuration and runtime execution metadata
+
+Revision ID: 20260824_0006
+Revises: 20260814_0005
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260824_0006"
+down_revision = "20260814_0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_persona_configs",
+        sa.Column("simulation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("mbti_type", sa.String(length=4), nullable=False),
+        sa.Column("personality_rule_version", sa.String(length=50), nullable=False),
+        sa.Column("openness", sa.SmallInteger(), nullable=False),
+        sa.Column("conscientiousness", sa.SmallInteger(), nullable=False),
+        sa.Column("extraversion", sa.SmallInteger(), nullable=False),
+        sa.Column("agreeableness", sa.SmallInteger(), nullable=False),
+        sa.Column("emotional_stability", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["simulation_id"],
+            ["simulations.id"],
+            name="fk_user_persona_configs_simulation_id_simulations",
+            onupdate="RESTRICT",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["simulation_id", "agent_id"],
+            ["agents.simulation_id", "agents.id"],
+            name="fk_user_persona_configs_agent",
+            onupdate="RESTRICT",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("simulation_id"),
+        *[
+            sa.CheckConstraint(
+                f"{trait} BETWEEN -50 AND 50 AND {trait} % 5 = 0",
+                name=f"ck_user_persona_configs_{trait}",
+            )
+            for trait in (
+                "openness",
+                "conscientiousness",
+                "extraversion",
+                "agreeableness",
+                "emotional_stability",
+            )
+        ],
+    )
+    op.create_table(
+        "runtime_executions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("simulation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("run_id", sa.String(length=100), nullable=False),
+        sa.Column("tick_number", sa.BigInteger(), nullable=False),
+        sa.Column("seed", sa.BigInteger(), nullable=False),
+        sa.Column("model", sa.String(length=100), nullable=False),
+        sa.Column("prompt_version", sa.String(length=100), nullable=False),
+        sa.Column("policy_version", sa.String(length=100), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint("seed >= 0", name="ck_runtime_executions_seed"),
+        sa.CheckConstraint(
+            "tick_number >= 0", name="ck_runtime_executions_tick_number"
+        ),
+        sa.ForeignKeyConstraint(
+            ["simulation_id"],
+            ["simulations.id"],
+            onupdate="RESTRICT",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("run_id", name="uq_runtime_executions_run_id"),
+        sa.UniqueConstraint(
+            "simulation_id",
+            "tick_number",
+            name="uq_runtime_executions_simulation_tick",
+        ),
+    )
+    op.create_index(
+        "idx_runtime_executions_simulation_tick",
+        "runtime_executions",
+        ["simulation_id", sa.text("tick_number DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_runtime_executions_simulation_tick", table_name="runtime_executions"
+    )
+    op.drop_table("runtime_executions")
+    op.drop_table("user_persona_configs")

--- a/backend/alembic/versions/20260824_0007_allow_missing_policy_version.py
+++ b/backend/alembic/versions/20260824_0007_allow_missing_policy_version.py
@@ -1,0 +1,36 @@
+"""allow runtime execution metadata without an applied policy
+
+Revision ID: 20260824_0007
+Revises: 20260824_0006
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260824_0007"
+down_revision = "20260824_0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "runtime_executions",
+        "policy_version",
+        existing_type=sa.String(length=100),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE runtime_executions "
+        "SET policy_version = 'policy-unapplied' "
+        "WHERE policy_version IS NULL"
+    )
+    op.alter_column(
+        "runtime_executions",
+        "policy_version",
+        existing_type=sa.String(length=100),
+        nullable=False,
+    )

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -3,8 +3,10 @@ from fastapi import APIRouter
 from app.api.auth import router as auth_router
 from app.api.simulations import router as simulations_router
 from app.api.ticks import router as ticks_router
+from app.api.user_persona import router as user_persona_router
 
 api_router = APIRouter()
 api_router.include_router(auth_router)
 api_router.include_router(simulations_router)
 api_router.include_router(ticks_router)
+api_router.include_router(user_persona_router)

--- a/backend/app/api/user_persona.py
+++ b/backend/app/api/user_persona.py
@@ -1,0 +1,142 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import require_user_role
+from app.domain.models import Agent, User, UserPersonaConfig
+from app.services.simulations import require_owned_simulation
+from app.services.user_persona import (
+    InvalidPersonaAgentError,
+    InvalidPersonalityConfigurationError,
+    PersonaChangeConflictError,
+    PersonaInput,
+    PersonaRequiredError,
+    UserPersonaService,
+    personality_config,
+)
+
+
+router = APIRouter(prefix="/simulations/{simulation_id}", tags=["user-persona"])
+
+
+class UserPersonaRequest(BaseModel):
+    agent_id: UUID
+    mbti_type: str
+    personality_rule_version: str
+    openness: int
+    conscientiousness: int
+    extraversion: int
+    agreeableness: int
+    emotional_stability: int
+
+
+def error(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"code": code, "message": message, "details": None},
+    )
+
+
+def persona_response(db: Session, config: UserPersonaConfig) -> dict:
+    agent = db.get(Agent, config.agent_id)
+    locked_at = agent.persona_locked_at if agent is not None else None
+    return {
+        "agent_id": str(config.agent_id),
+        "simulation_id": str(config.simulation_id),
+        "agent_type": "USER_PERSONA",
+        "mbti_type": config.mbti_type,
+        "openness": config.openness,
+        "conscientiousness": config.conscientiousness,
+        "extraversion": config.extraversion,
+        "agreeableness": config.agreeableness,
+        "emotional_stability": config.emotional_stability,
+        "personality_rule_version": config.personality_rule_version,
+        "status": "APPLIED",
+        "locked": locked_at is not None,
+        "persona_locked_at": locked_at.isoformat() if locked_at else None,
+    }
+
+
+@router.get("/user-persona/config")
+def get_config(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> dict:
+    require_owned_simulation(db, simulation_id, current_user)
+    return {"data": personality_config()}
+
+
+@router.get("/user-persona")
+def get_persona(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+):
+    require_owned_simulation(db, simulation_id, current_user)
+    config = UserPersonaService().get_persona(db, simulation_id)
+    if config is None:
+        return error(404, "RESOURCE_NOT_FOUND", "User Persona is not configured")
+    return {"data": persona_response(db, config)}
+
+
+@router.post("/user-persona")
+def set_persona(
+    simulation_id: UUID,
+    request: UserPersonaRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+):
+    require_owned_simulation(db, simulation_id, current_user)
+    try:
+        config = UserPersonaService().set_persona(
+            db, simulation_id, PersonaInput(**request.model_dump())
+        )
+        db.commit()
+        db.refresh(config)
+    except InvalidPersonalityConfigurationError as exc:
+        db.rollback()
+        return error(400, "INVALID_PERSONALITY_CONFIGURATION", str(exc))
+    except InvalidPersonaAgentError as exc:
+        db.rollback()
+        return error(400, "INVALID_PERSONA_AGENT", str(exc))
+    except PersonaChangeConflictError as exc:
+        db.rollback()
+        return error(409, "CONFLICT", str(exc))
+    except Exception:
+        db.rollback()
+        raise
+    return {"data": persona_response(db, config)}
+
+
+@router.post("/start")
+def start_simulation(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+):
+    require_owned_simulation(db, simulation_id, current_user)
+    try:
+        simulation = UserPersonaService().start(db, simulation_id)
+        db.commit()
+        db.refresh(simulation)
+    except PersonaRequiredError as exc:
+        db.rollback()
+        return error(400, "PERSONA_REQUIRED", str(exc))
+    except (PersonaChangeConflictError, InvalidPersonaAgentError) as exc:
+        db.rollback()
+        return error(409, "CONFLICT", str(exc))
+    except Exception:
+        db.rollback()
+        raise
+    return {
+        "data": {
+            "id": str(simulation.id),
+            "status": simulation.status,
+            "started_at": simulation.started_at.isoformat(),
+        }
+    }

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -127,6 +127,53 @@ class Agent(TimestampMixin, Base):
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
+class UserPersonaConfig(TimestampMixin, Base):
+    __tablename__ = "user_persona_configs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["simulation_id", "agent_id"],
+            ["agents.simulation_id", "agents.id"],
+            ondelete="RESTRICT",
+            onupdate="RESTRICT",
+            name="fk_user_persona_configs_agent",
+        ),
+        CheckConstraint(
+            "openness BETWEEN -50 AND 50 AND openness % 5 = 0",
+            name="ck_user_persona_configs_openness",
+        ),
+        CheckConstraint(
+            "conscientiousness BETWEEN -50 AND 50 AND conscientiousness % 5 = 0",
+            name="ck_user_persona_configs_conscientiousness",
+        ),
+        CheckConstraint(
+            "extraversion BETWEEN -50 AND 50 AND extraversion % 5 = 0",
+            name="ck_user_persona_configs_extraversion",
+        ),
+        CheckConstraint(
+            "agreeableness BETWEEN -50 AND 50 AND agreeableness % 5 = 0",
+            name="ck_user_persona_configs_agreeableness",
+        ),
+        CheckConstraint(
+            "emotional_stability BETWEEN -50 AND 50 AND emotional_stability % 5 = 0",
+            name="ck_user_persona_configs_emotional_stability",
+        ),
+    )
+
+    simulation_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        primary_key=True,
+    )
+    agent_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    mbti_type: Mapped[str] = mapped_column(String(4), nullable=False)
+    personality_rule_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    openness: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    conscientiousness: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    extraversion: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    agreeableness: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    emotional_stability: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+
+
 class StudentProfile(Base):
     __tablename__ = "student_profiles"
     __table_args__ = (CheckConstraint("grade BETWEEN 1 AND 4", name="ck_student_profiles_grade"),)
@@ -286,6 +333,40 @@ class RuntimeResult(TimestampMixin, Base):
     prompt_version: Mapped[str] = mapped_column(String(100), nullable=False)
     idempotency_key: Mapped[str] = mapped_column(String(255), nullable=False)
     result_fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+
+
+class RuntimeExecution(TimestampMixin, Base):
+    __tablename__ = "runtime_executions"
+    __table_args__ = (
+        UniqueConstraint("run_id", name="uq_runtime_executions_run_id"),
+        UniqueConstraint(
+            "simulation_id",
+            "tick_number",
+            name="uq_runtime_executions_simulation_tick",
+        ),
+        CheckConstraint(
+            "tick_number >= 0", name="ck_runtime_executions_tick_number"
+        ),
+        CheckConstraint("seed >= 0", name="ck_runtime_executions_seed"),
+        Index(
+            "idx_runtime_executions_simulation_tick",
+            "simulation_id",
+            text("tick_number DESC"),
+        ),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        nullable=False,
+    )
+    run_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    tick_number: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    seed: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String(100), nullable=False)
+    policy_version: Mapped[str] = mapped_column(String(100), nullable=False)
 
 
 class Relationship(TimestampMixin, Base):

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -366,7 +366,7 @@ class RuntimeExecution(TimestampMixin, Base):
     seed: Mapped[int] = mapped_column(BigInteger, nullable=False)
     model: Mapped[str] = mapped_column(String(100), nullable=False)
     prompt_version: Mapped[str] = mapped_column(String(100), nullable=False)
-    policy_version: Mapped[str] = mapped_column(String(100), nullable=False)
+    policy_version: Mapped[str | None] = mapped_column(String(100))
 
 
 class Relationship(TimestampMixin, Base):

--- a/backend/app/repositories/runtime_executions.py
+++ b/backend/app/repositories/runtime_executions.py
@@ -1,0 +1,16 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.models import RuntimeExecution
+
+
+def get_by_run_id(session: Session, run_id: str) -> RuntimeExecution | None:
+    return session.scalar(
+        select(RuntimeExecution).where(RuntimeExecution.run_id == run_id)
+    )
+
+
+def add(session: Session, execution: RuntimeExecution) -> RuntimeExecution:
+    session.add(execution)
+    session.flush()
+    return execution

--- a/backend/app/repositories/user_personas.py
+++ b/backend/app/repositories/user_personas.py
@@ -1,0 +1,53 @@
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.models import Agent, Simulation, StudentProfile, UserPersonaConfig
+
+
+def get_simulation_for_update(
+    session: Session, simulation_id: UUID
+) -> Simulation | None:
+    return session.scalar(
+        select(Simulation)
+        .where(Simulation.id == simulation_id, Simulation.deleted_at.is_(None))
+        .with_for_update()
+    )
+
+
+def get_student(
+    session: Session, simulation_id: UUID, agent_id: UUID
+) -> Agent | None:
+    return session.scalar(
+        select(Agent)
+        .join(StudentProfile, StudentProfile.agent_id == Agent.id)
+        .where(
+            Agent.id == agent_id,
+            Agent.simulation_id == simulation_id,
+            Agent.agent_type == "student",
+            Agent.deleted_at.is_(None),
+        )
+    )
+
+
+def get_config(
+    session: Session, simulation_id: UUID
+) -> UserPersonaConfig | None:
+    return session.get(UserPersonaConfig, simulation_id)
+
+
+def upsert_config(
+    session: Session,
+    simulation_id: UUID,
+    values: dict,
+) -> UserPersonaConfig:
+    config = session.get(UserPersonaConfig, simulation_id)
+    if config is None:
+        config = UserPersonaConfig(simulation_id=simulation_id, **values)
+        session.add(config)
+    else:
+        for name, value in values.items():
+            setattr(config, name, value)
+    session.flush()
+    return config

--- a/backend/app/services/execution_metadata.py
+++ b/backend/app/services/execution_metadata.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+from uuid6 import uuid7
+
+from app.domain.models import RuntimeExecution
+from app.repositories import runtime_executions
+
+
+@dataclass(frozen=True)
+class ExecutionMetadataInput:
+    simulation_id: UUID
+    run_id: str
+    tick_number: int
+    seed: int
+    model: str
+    prompt_version: str
+    policy_version: str
+
+
+class ExecutionMetadataConflictError(ValueError):
+    pass
+
+
+def record_execution_metadata(
+    session: Session, metadata: ExecutionMetadataInput
+) -> RuntimeExecution:
+    existing = runtime_executions.get_by_run_id(session, metadata.run_id)
+    if existing is not None:
+        expected = (
+            metadata.simulation_id,
+            metadata.tick_number,
+            metadata.seed,
+            metadata.model,
+            metadata.prompt_version,
+            metadata.policy_version,
+        )
+        actual = (
+            existing.simulation_id,
+            existing.tick_number,
+            existing.seed,
+            existing.model,
+            existing.prompt_version,
+            existing.policy_version,
+        )
+        if actual != expected:
+            raise ExecutionMetadataConflictError(metadata.run_id)
+        return existing
+    return runtime_executions.add(
+        session,
+        RuntimeExecution(
+            id=uuid7(),
+            simulation_id=metadata.simulation_id,
+            run_id=metadata.run_id,
+            tick_number=metadata.tick_number,
+            seed=metadata.seed,
+            model=metadata.model,
+            prompt_version=metadata.prompt_version,
+            policy_version=metadata.policy_version,
+        ),
+    )

--- a/backend/app/services/execution_metadata.py
+++ b/backend/app/services/execution_metadata.py
@@ -16,7 +16,7 @@ class ExecutionMetadataInput:
     seed: int
     model: str
     prompt_version: str
-    policy_version: str
+    policy_version: str | None
 
 
 class ExecutionMetadataConflictError(ValueError):

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import secrets
 from uuid import UUID
 
 from sqlalchemy import select, text
@@ -7,6 +8,10 @@ from uuid6 import uuid7
 
 from app.domain.models import Agent, Event, EventParticipant, Simulation
 from app.services.database_runtime_results import DatabaseRuntimeResultSink
+from app.services.execution_metadata import (
+    ExecutionMetadataInput,
+    record_execution_metadata,
+)
 from app.services.runtime_input_adapter import RuntimeInputAdapter
 from app.services.runtime_orchestrator import RuntimeOrchestrator
 from app.services.simulation_tick import SimulationTickService
@@ -58,6 +63,7 @@ async def advance_manual_tick(
     *,
     runtime: AgentRuntime,
     policy: PolicyFn | None = None,
+    seed: int | None = None,
 ) -> ManualTickResult:
     locked = db.scalar(
         select(
@@ -74,6 +80,7 @@ async def advance_manual_tick(
     current_tick = previous_tick + 1
     current_day, block = tick_position(current_tick)
     run_id = uuid7()
+    execution_seed = seed if seed is not None else secrets.randbits(63)
 
     event = db.scalar(
         select(Event)
@@ -182,6 +189,19 @@ async def advance_manual_tick(
     )
     if tick_result.status != "completed" or batch is None:
         raise RuntimeError("TickEngine completed without a Runtime batch")
+    first_result = batch.results[0]
+    record_execution_metadata(
+        db,
+        ExecutionMetadataInput(
+            simulation_id=simulation.id,
+            run_id=str(run_id),
+            tick_number=current_tick,
+            seed=execution_seed,
+            model=first_result.model,
+            prompt_version=first_result.prompt_version,
+            policy_version="policy-mvp-0.1",
+        ),
+    )
     simulation.current_tick = current_tick
     simulation.current_day = current_day
     db.flush()

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -63,8 +63,11 @@ async def advance_manual_tick(
     *,
     runtime: AgentRuntime,
     policy: PolicyFn | None = None,
+    policy_version: str | None = None,
     seed: int | None = None,
 ) -> ManualTickResult:
+    if (policy is None) != (policy_version is None):
+        raise ValueError("policy and policy_version must be provided together")
     locked = db.scalar(
         select(
             text(
@@ -201,7 +204,7 @@ async def advance_manual_tick(
             seed=execution_seed,
             model=first_result.model,
             prompt_version=first_result.prompt_version,
-            policy_version="policy-mvp-0.1",
+            policy_version=policy_version,
         ),
     )
     simulation.current_tick = current_tick

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -150,6 +150,7 @@ async def advance_manual_tick(
             simulation_id=simulation.id,
             run_id=run_id,
             tick_number=current_tick,
+            seed=execution_seed,
             block=block,
             preselected_agent_ids=[UUID(agent.id) for agent in selected_agents],
             schedule=schedule,
@@ -174,6 +175,7 @@ async def advance_manual_tick(
     snapshot = WorldSnapshot(
         simulation_id=str(simulation.id),
         current_tick=previous_tick,
+        data={"execution_seed": execution_seed},
     )
     tick_result = await TickEngine(
         runtime=run_runtime_batch,

--- a/backend/app/services/runtime_input_adapter.py
+++ b/backend/app/services/runtime_input_adapter.py
@@ -97,6 +97,7 @@ class RuntimeInputAdapter:
         *,
         run_id: str,
         tick_number: int,
+        seed: int = 0,
         block: Block,
         agents: Sequence[Agent],
         preselected_agent_ids: Sequence[UUID],
@@ -119,6 +120,7 @@ class RuntimeInputAdapter:
         return self._orchestrator.run_preselected(
             run_id=run_id,
             tick_number=tick_number,
+            seed=seed,
             block=block,
             agent_candidates=agent_candidates,
             preselected_agent_ids=preselected_agent_ids,

--- a/backend/app/services/runtime_orchestrator.py
+++ b/backend/app/services/runtime_orchestrator.py
@@ -49,6 +49,7 @@ class RuntimeOrchestrator:
         *,
         run_id: str,
         tick_number: int,
+        seed: int = 0,
         block: Block,
         agent_candidates: Sequence[AgentContext],
         preselected_agent_ids: Sequence[UUID],
@@ -65,6 +66,7 @@ class RuntimeOrchestrator:
             self._context_assembler.assemble(
                 run_id=run_id,
                 tick_number=tick_number,
+                seed=seed,
                 block=block,
                 agent_id=agent.agent_id,
                 fixture_key=agent.fixture_key,

--- a/backend/app/services/simulation_tick.py
+++ b/backend/app/services/simulation_tick.py
@@ -30,6 +30,7 @@ class SimulationTickService:
         simulation_id: UUID,
         run_id: UUID,
         tick_number: int,
+        seed: int = 0,
         block: Block,
         preselected_agent_ids: Sequence[UUID] | None = None,
         schedule_requires_professor: bool = False,
@@ -64,6 +65,7 @@ class SimulationTickService:
         return self._runtime_input_adapter.run(
             run_id=str(run_id),
             tick_number=tick_number,
+            seed=seed,
             block=block,
             agents=agents,
             preselected_agent_ids=preselected_agent_ids,

--- a/backend/app/services/user_persona.py
+++ b/backend/app/services/user_persona.py
@@ -1,0 +1,167 @@
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.domain.models import Simulation, UserPersonaConfig
+from app.repositories import user_personas
+
+
+RULE_VERSION = "mbti-big-five-v0.1"
+TRAITS = (
+    "openness",
+    "conscientiousness",
+    "extraversion",
+    "agreeableness",
+    "emotional_stability",
+)
+MBTI_RULES = {
+    "ISTJ": {
+        "openness": {"min": -45, "default": -25, "max": 5},
+        "conscientiousness": {"min": -15, "default": 25, "max": 45},
+        "extraversion": {"min": -45, "default": -25, "max": 5},
+        "agreeableness": {"min": -45, "default": -20, "max": 15},
+        "emotional_stability": {"min": -50, "default": 0, "max": 50},
+    },
+    "INFP": {
+        "openness": {"min": -5, "default": 25, "max": 45},
+        "conscientiousness": {"min": -45, "default": -25, "max": 15},
+        "extraversion": {"min": -45, "default": -25, "max": 5},
+        "agreeableness": {"min": -15, "default": 20, "max": 45},
+        "emotional_stability": {"min": -50, "default": 0, "max": 50},
+    },
+    "ENTJ": {
+        "openness": {"min": -5, "default": 25, "max": 45},
+        "conscientiousness": {"min": -15, "default": 25, "max": 45},
+        "extraversion": {"min": -5, "default": 25, "max": 45},
+        "agreeableness": {"min": -45, "default": -20, "max": 15},
+        "emotional_stability": {"min": -50, "default": 0, "max": 50},
+    },
+    "ESTP": {
+        "openness": {"min": -45, "default": -25, "max": 5},
+        "conscientiousness": {"min": -45, "default": -25, "max": 15},
+        "extraversion": {"min": -5, "default": 25, "max": 45},
+        "agreeableness": {"min": -45, "default": -20, "max": 15},
+        "emotional_stability": {"min": -50, "default": 0, "max": 50},
+    },
+    "ESFJ": {
+        "openness": {"min": -45, "default": -25, "max": 5},
+        "conscientiousness": {"min": -15, "default": 25, "max": 45},
+        "extraversion": {"min": -5, "default": 25, "max": 45},
+        "agreeableness": {"min": -15, "default": 20, "max": 45},
+        "emotional_stability": {"min": -50, "default": 0, "max": 50},
+    },
+}
+
+
+class PersonaError(ValueError):
+    pass
+
+
+class InvalidPersonaAgentError(PersonaError):
+    pass
+
+
+class InvalidPersonalityConfigurationError(PersonaError):
+    pass
+
+
+class PersonaChangeConflictError(PersonaError):
+    pass
+
+
+class PersonaRequiredError(PersonaError):
+    pass
+
+
+@dataclass(frozen=True)
+class PersonaInput:
+    agent_id: UUID
+    mbti_type: str
+    personality_rule_version: str
+    openness: int
+    conscientiousness: int
+    extraversion: int
+    agreeableness: int
+    emotional_stability: int
+
+
+def personality_config() -> dict:
+    return {
+        "rule_version": RULE_VERSION,
+        "global_min": -50,
+        "global_max": 50,
+        "step": 5,
+        "mbti_rules": MBTI_RULES,
+    }
+
+
+class UserPersonaService:
+    def set_persona(
+        self,
+        session: Session,
+        simulation_id: UUID,
+        persona: PersonaInput,
+    ) -> UserPersonaConfig:
+        simulation = self._require_ready_simulation(session, simulation_id)
+        if simulation.started_at is not None or simulation.status != "ready":
+            raise PersonaChangeConflictError("Persona is locked after Simulation start")
+        if user_personas.get_student(session, simulation_id, persona.agent_id) is None:
+            raise InvalidPersonaAgentError("Persona must select a Student in this Simulation")
+        self._validate(persona)
+        values = asdict(persona)
+        values.pop("agent_id")
+        return user_personas.upsert_config(
+            session,
+            simulation_id,
+            {"agent_id": persona.agent_id, **values},
+        )
+
+    def get_persona(
+        self, session: Session, simulation_id: UUID
+    ) -> UserPersonaConfig | None:
+        return user_personas.get_config(session, simulation_id)
+
+    def start(self, session: Session, simulation_id: UUID) -> Simulation:
+        simulation = self._require_ready_simulation(session, simulation_id)
+        if simulation.started_at is not None or simulation.status != "ready":
+            raise PersonaChangeConflictError("Simulation is already started")
+        config = user_personas.get_config(session, simulation_id)
+        if config is None:
+            raise PersonaRequiredError("User Persona must be configured before start")
+        agent = user_personas.get_student(session, simulation_id, config.agent_id)
+        if agent is None:
+            raise InvalidPersonaAgentError("Configured Persona Student is unavailable")
+        locked_at = datetime.now(timezone.utc)
+        for name in ("mbti_type", *TRAITS):
+            setattr(agent, name, getattr(config, name))
+        agent.persona_locked_at = locked_at
+        simulation.status = "running"
+        simulation.started_at = locked_at
+        session.flush()
+        return simulation
+
+    @staticmethod
+    def _require_ready_simulation(
+        session: Session, simulation_id: UUID
+    ) -> Simulation:
+        simulation = user_personas.get_simulation_for_update(session, simulation_id)
+        if simulation is None:
+            raise PersonaRequiredError("Simulation not found")
+        return simulation
+
+    @staticmethod
+    def _validate(persona: PersonaInput) -> None:
+        if persona.personality_rule_version != RULE_VERSION:
+            raise InvalidPersonalityConfigurationError("Unsupported rule version")
+        rules = MBTI_RULES.get(persona.mbti_type)
+        if rules is None:
+            raise InvalidPersonalityConfigurationError("Unsupported MBTI type")
+        for trait in TRAITS:
+            value = getattr(persona, trait)
+            bounds = rules[trait]
+            if value % 5 != 0 or not bounds["min"] <= value <= bounds["max"]:
+                raise InvalidPersonalityConfigurationError(
+                    f"{trait} must follow the {persona.mbti_type} rule"
+                )

--- a/backend/app/simulation/agent_context_assembler.py
+++ b/backend/app/simulation/agent_context_assembler.py
@@ -20,6 +20,7 @@ class AgentContextAssembler:
         *,
         run_id: str,
         tick_number: int,
+        seed: int = 0,
         block: Block,
         agent_id: UUID,
         fixture_key: str,
@@ -38,6 +39,7 @@ class AgentContextAssembler:
         return AgentRuntimeInput(
             run_id=run_id,
             tick_number=tick_number,
+            seed=seed,
             block=block,
             agent=AgentContext(
                 agent_id=agent_id,

--- a/backend/app/simulation/agent_runtime.py
+++ b/backend/app/simulation/agent_runtime.py
@@ -186,6 +186,7 @@ class ScheduleSummary(StrictModel):
 class AgentRuntimeInput(StrictModel):
     run_id: str
     tick_number: int = Field(ge=0)
+    seed: int = Field(default=0, ge=0)
     block: Block
     agent: AgentContext
     nearby_agents: list[dict[str, Any]]

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -23,6 +23,8 @@ class SchemaModelTests(unittest.TestCase):
                 "agent_memories",
                 "relationships",
                 "runtime_results",
+                "runtime_executions",
+                "user_persona_configs",
                 "organizations",
                 "organization_memberships",
                 "events",
@@ -49,6 +51,9 @@ class SchemaModelTests(unittest.TestCase):
             "uq_relationships_pair",
             "uq_runtime_results_idempotency_key",
             "uq_runtime_results_run_tick_agent",
+            "uq_runtime_executions_run_id",
+            "uq_runtime_executions_simulation_tick",
+            "idx_runtime_executions_simulation_tick",
             "uq_organizations_simulation_type_name",
             "uq_organizations_simulation_id_id",
             "uq_organization_memberships_active",
@@ -76,6 +81,7 @@ class SchemaModelTests(unittest.TestCase):
             "relationships": {"agents"},
             "organization_memberships": {"agents", "organizations"},
             "events": {"locations"},
+            "user_persona_configs": {"agents"},
         }
         for table_name, target_names in expected_targets.items():
             table = Base.metadata.tables[table_name]

--- a/backend/tests/test_slice1_e2e.py
+++ b/backend/tests/test_slice1_e2e.py
@@ -263,6 +263,72 @@ def test_consecutive_ticks_use_distinct_batch_run_ids(client):
     )
 
 
+def test_same_seed_reaches_runtime_and_matches_execution_metadata(client):
+    from app.domain.models import RuntimeExecution, Simulation
+    from app.services.manual_tick import advance_manual_tick
+    from app.simulation.agent_runtime import AgentRuntime, MockLLMClient
+
+    class DeterministicSeedLLM(MockLLMClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.received_seeds = []
+
+        def generate(self, runtime_input):
+            self.received_seeds.append(runtime_input.seed)
+            response = super().generate(runtime_input)
+            response["motivation_summary"] = f"seed-result-{runtime_input.seed % 7}"
+            return response
+
+    test_client, session_factory = client
+    first_id, headers = register_login_create(test_client)
+    second = test_client.post(
+        "/v1/simulations", headers=headers, json={"name": "Same Seed Run"}
+    )
+    assert second.status_code == 201
+    simulation_ids = [first_id, second.json()["id"]]
+    fake_llm = DeterministicSeedLLM()
+    runtime = AgentRuntime(fake_llm, model="deterministic-seed-runtime")
+    normalized_results = []
+
+    for simulation_id in simulation_ids:
+        with session_factory() as db:
+            simulation = db.get(Simulation, UUID(simulation_id))
+            result = asyncio.run(
+                advance_manual_tick(db, simulation, runtime=runtime, seed=4242)
+            )
+            normalized_results.append(
+                [
+                    (
+                        runtime_result.intent.action_type,
+                        runtime_result.intent.motivation_summary,
+                    )
+                    for runtime_result in result.runtime_results
+                ]
+            )
+            db.commit()
+
+    with session_factory() as db:
+        executions = list(
+            db.scalars(
+                select(RuntimeExecution)
+                .where(
+                    RuntimeExecution.simulation_id.in_(
+                        [UUID(value) for value in simulation_ids]
+                    )
+                )
+                .order_by(RuntimeExecution.simulation_id)
+            )
+        )
+
+    assert normalized_results[0] == normalized_results[1]
+    assert fake_llm.received_seeds == [4242, 4242, 4242, 4242]
+    assert len({execution.run_id for execution in executions}) == 2
+    assert {execution.seed for execution in executions} == {4242}
+    assert {execution.model for execution in executions} == {
+        "deterministic-seed-runtime"
+    }
+
+
 def test_concurrent_tick_returns_immediate_conflict(client, monkeypatch):
     from app.simulation.agent_runtime import AgentRuntime
 

--- a/backend/tests/test_slice1_e2e.py
+++ b/backend/tests/test_slice1_e2e.py
@@ -156,7 +156,7 @@ def test_slice_one_full_vertical_flow(client):
         assert execution.seed >= 0
         assert execution.model == "test-runtime-override"
         assert execution.prompt_version == "agent-runtime-10.1"
-        assert execution.policy_version == "policy-mvp-0.1"
+        assert execution.policy_version is None
         api_by_id = {result["agent_id"]: result for result in body["agent_results"]}
         assert set(api_by_id) == {str(result.agent_id) for result in stored}
         for result in stored:
@@ -409,7 +409,7 @@ def test_tick_api_uses_engine_and_each_batch_boundary_once(client, monkeypatch):
 
 
 def test_manual_tick_preserves_tick_engine_policy_extension(client):
-    from app.domain.models import Simulation
+    from app.domain.models import RuntimeExecution, Simulation
     from app.services.manual_tick import advance_manual_tick
     from app.simulation.agent_runtime import AgentRuntime, MockLLMClient
 
@@ -430,11 +430,52 @@ def test_manual_tick_preserves_tick_engine_policy_extension(client):
                     MockLLMClient(), model="test-direct-runtime"
                 ),
                 policy=policy,
+                policy_version="policy-test-2.0",
             )
         )
         db.commit()
 
+        execution = db.scalar(
+            select(RuntimeExecution).where(
+                RuntimeExecution.simulation_id == UUID(simulation_id)
+            )
+        )
+
     assert len(received_policy_inputs) == len(result.runtime_results) == 2
+    assert execution.policy_version == "policy-test-2.0"
     assert {item.agent_id for item in received_policy_inputs} == {
         str(runtime_result.agent_id) for runtime_result in result.runtime_results
     }
+
+
+def test_manual_tick_rejects_policy_version_mismatch(client):
+    from app.domain.models import Simulation
+    from app.services.manual_tick import advance_manual_tick
+    from app.simulation.agent_runtime import AgentRuntime, MockLLMClient
+
+    test_client, session_factory = client
+    simulation_id, _ = register_login_create(test_client)
+
+    async def policy(_inputs):
+        return None
+
+    with session_factory() as db:
+        simulation = db.get(Simulation, UUID(simulation_id))
+        with pytest.raises(ValueError, match="policy and policy_version"):
+            asyncio.run(
+                advance_manual_tick(
+                    db,
+                    simulation,
+                    runtime=AgentRuntime(MockLLMClient()),
+                    policy=policy,
+                )
+            )
+        with pytest.raises(ValueError, match="policy and policy_version"):
+            asyncio.run(
+                advance_manual_tick(
+                    db,
+                    simulation,
+                    runtime=AgentRuntime(MockLLMClient()),
+                    policy_version="policy-test-2.0",
+                )
+            )

--- a/backend/tests/test_slice1_e2e.py
+++ b/backend/tests/test_slice1_e2e.py
@@ -72,7 +72,14 @@ def register_login_create(test_client):
 
 
 def test_slice_one_full_vertical_flow(client):
-    from app.domain.models import Agent, Event, EventParticipant, RuntimeResult, Simulation
+    from app.domain.models import (
+        Agent,
+        Event,
+        EventParticipant,
+        RuntimeExecution,
+        RuntimeResult,
+        Simulation,
+    )
 
     test_client, session_factory = client
     simulation_id, headers = register_login_create(test_client)
@@ -141,6 +148,15 @@ def test_slice_one_full_vertical_flow(client):
             for result in stored
         )
         assert {result.model for result in stored} == {"test-runtime-override"}
+        execution = db.scalar(
+            select(RuntimeExecution).where(RuntimeExecution.run_id == stored_run_id)
+        )
+        assert execution.simulation_id == simulation_uuid
+        assert execution.tick_number == 1
+        assert execution.seed >= 0
+        assert execution.model == "test-runtime-override"
+        assert execution.prompt_version == "agent-runtime-10.1"
+        assert execution.policy_version == "policy-mvp-0.1"
         api_by_id = {result["agent_id"]: result for result in body["agent_results"]}
         assert set(api_by_id) == {str(result.agent_id) for result in stored}
         for result in stored:
@@ -173,7 +189,7 @@ def test_other_user_cannot_advance_owned_simulation(client):
 
 
 def test_runtime_results_and_tick_roll_back_together(client, monkeypatch):
-    from app.domain.models import RuntimeResult, Simulation
+    from app.domain.models import RuntimeExecution, RuntimeResult, Simulation
     from app.services.simulation_tick import SimulationTickService
 
     test_client, session_factory = client
@@ -195,6 +211,7 @@ def test_runtime_results_and_tick_roll_back_together(client, monkeypatch):
         simulation = db.get(Simulation, UUID(simulation_id))
         assert simulation.current_tick == 0
         assert db.scalar(select(func.count()).select_from(RuntimeResult)) == 0
+        assert db.scalar(select(func.count()).select_from(RuntimeExecution)) == 0
 
     monkeypatch.setattr(SimulationTickService, "run_runtime_phase", original)
     retry = test_client.post(
@@ -203,9 +220,11 @@ def test_runtime_results_and_tick_roll_back_together(client, monkeypatch):
     assert retry.status_code == 200
     with session_factory() as db:
         saved_run_ids = set(db.scalars(select(RuntimeResult.run_id)))
+        execution_run_ids = set(db.scalars(select(RuntimeExecution.run_id)))
     assert len(failed_run_ids) == 1
     assert len(saved_run_ids) == 1
     assert failed_run_ids[0] not in saved_run_ids
+    assert execution_run_ids == saved_run_ids
 
 
 def test_consecutive_ticks_use_distinct_batch_run_ids(client):

--- a/backend/tests/test_slice4_transaction.py
+++ b/backend/tests/test_slice4_transaction.py
@@ -76,7 +76,7 @@ def test_execution_metadata_and_runtime_results_share_rollback_boundary() -> Non
                         seed=42,
                         model=result.model,
                         prompt_version=result.prompt_version,
-                        policy_version="policy-mvp-0.1",
+                        policy_version=None,
                     ),
                 )
                 DatabaseRuntimeResultSink(session).save_batch([result])

--- a/backend/tests/test_slice4_transaction.py
+++ b/backend/tests/test_slice4_transaction.py
@@ -1,0 +1,140 @@
+import os
+
+import pytest
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.orm import sessionmaker
+from uuid6 import uuid7
+
+from app.domain.models import RuntimeExecution, RuntimeResult
+from app.services.database_runtime_results import DatabaseRuntimeResultSink
+from app.services.execution_metadata import ExecutionMetadataInput, record_execution_metadata
+from tests.runtime_factories import make_runtime_result
+
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required"
+)
+
+
+def test_execution_metadata_and_runtime_results_share_rollback_boundary() -> None:
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
+
+    from app.domain.models import Agent, Simulation, User
+    from app.services.fixtures import seed_slice_zero
+
+    owner_id = uuid7()
+    simulation_id = uuid7()
+    with session_factory.begin() as session:
+        session.add(
+            User(
+                id=owner_id,
+                username="slice4-transaction-owner",
+                display_name="Slice 4 Transaction",
+                password_hash="not-a-real-password-hash",
+                roles=["USER"],
+            )
+        )
+        session.flush()
+        session.add(Simulation(id=simulation_id, owner_id=owner_id, name="Slice 4"))
+        session.flush()
+        seed_slice_zero(session, simulation_id)
+
+    with session_factory() as session:
+        with pytest.raises(RuntimeError, match="fatal commit failure"):
+            with session.begin():
+                agent_id = session.scalar(
+                    select(Agent.id).where(
+                        Agent.simulation_id == simulation_id,
+                        Agent.fixture_key == "student-01",
+                    )
+                )
+                run_id = str(uuid7())
+                result = make_runtime_result(agent_id=str(agent_id)).model_copy(
+                    update={
+                        "run_id": run_id,
+                        "tick_number": 1,
+                        "agent_id": agent_id,
+                    }
+                )
+                result = result.model_copy(
+                    update={
+                        "idempotency_key": f"{run_id}:1:{result.agent_id}",
+                    }
+                )
+                record_execution_metadata(
+                    session,
+                    ExecutionMetadataInput(
+                        simulation_id=simulation_id,
+                        run_id=run_id,
+                        tick_number=1,
+                        seed=42,
+                        model=result.model,
+                        prompt_version=result.prompt_version,
+                        policy_version="policy-mvp-0.1",
+                    ),
+                )
+                DatabaseRuntimeResultSink(session).save_batch([result])
+                raise RuntimeError("fatal commit failure")
+
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(RuntimeExecution)) == 0
+        assert session.scalar(select(func.count()).select_from(RuntimeResult)) == 0
+    engine.dispose()
+
+
+def test_execution_metadata_is_queryable_after_commit() -> None:
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
+
+    from app.domain.models import Simulation, User
+
+    owner_id = uuid7()
+    simulation_id = uuid7()
+    run_id = str(uuid7())
+    with session_factory.begin() as session:
+        session.add(
+            User(
+                id=owner_id,
+                username="slice4-metadata-owner",
+                display_name="Slice 4 Metadata",
+                password_hash="not-a-real-password-hash",
+                roles=["USER"],
+            )
+        )
+        session.flush()
+        session.add(Simulation(id=simulation_id, owner_id=owner_id, name="Slice 4"))
+        session.flush()
+        record_execution_metadata(
+            session,
+            ExecutionMetadataInput(
+                simulation_id=simulation_id,
+                run_id=run_id,
+                tick_number=1,
+                seed=42,
+                model="mock-llm",
+                prompt_version="agent-runtime-10.1",
+                policy_version="policy-mvp-0.1",
+            ),
+        )
+
+    with session_factory() as session:
+        stored = session.scalar(
+            select(RuntimeExecution).where(RuntimeExecution.run_id == run_id)
+        )
+        assert stored.simulation_id == simulation_id
+        assert stored.tick_number == 1
+        assert stored.seed == 42
+        assert stored.model == "mock-llm"
+        assert stored.prompt_version == "agent-runtime-10.1"
+        assert stored.policy_version == "policy-mvp-0.1"
+    engine.dispose()

--- a/backend/tests/test_user_persona_api.py
+++ b/backend/tests/test_user_persona_api.py
@@ -1,0 +1,144 @@
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required"
+)
+
+
+@pytest.fixture()
+def client():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+    engine.dispose()
+
+
+def register_login_create(client: TestClient):
+    credentials = {
+        "username": "slice4-api-owner",
+        "display_name": "Slice 4 API",
+        "password": "Slice4-password!",
+    }
+    assert client.post("/v1/auth/register", json=credentials).status_code == 201
+    login = client.post(
+        "/v1/auth/login",
+        json={"username": credentials["username"], "password": credentials["password"]},
+    )
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    simulation = client.post(
+        "/v1/simulations", headers=headers, json={"name": "Slice 4 API"}
+    ).json()
+    agents = client.get(
+        f"/v1/simulations/{simulation['id']}/agents", headers=headers
+    ).json()
+    student = next(agent for agent in agents if agent["fixture_key"] == "student-03")
+    return simulation["id"], student["id"], headers
+
+
+def valid_payload(student_id: str) -> dict:
+    return {
+        "agent_id": student_id,
+        "mbti_type": "INFP",
+        "personality_rule_version": "mbti-big-five-v0.1",
+        "openness": 25,
+        "conscientiousness": -25,
+        "extraversion": -25,
+        "agreeableness": 20,
+        "emotional_stability": 0,
+    }
+
+
+def test_config_and_persona_api_contract(client) -> None:
+    simulation_id, student_id, headers = register_login_create(client)
+    config = client.get(
+        f"/v1/simulations/{simulation_id}/user-persona/config", headers=headers
+    )
+    assert config.status_code == 200
+    assert config.json()["data"]["rule_version"] == "mbti-big-five-v0.1"
+    assert config.json()["data"]["step"] == 5
+    assert set(config.json()["data"]["mbti_rules"]) == {
+        "ISTJ", "ESTP", "INFP", "ENTJ", "ESFJ"
+    }
+
+    missing = client.get(
+        f"/v1/simulations/{simulation_id}/user-persona", headers=headers
+    )
+    assert missing.status_code == 404
+    assert missing.json()["code"] == "RESOURCE_NOT_FOUND"
+
+    saved = client.post(
+        f"/v1/simulations/{simulation_id}/user-persona",
+        headers=headers,
+        json=valid_payload(student_id),
+    )
+    assert saved.status_code == 200
+    assert saved.json()["data"] == {
+        "agent_id": student_id,
+        "simulation_id": simulation_id,
+        "agent_type": "USER_PERSONA",
+        "mbti_type": "INFP",
+        "openness": 25,
+        "conscientiousness": -25,
+        "extraversion": -25,
+        "agreeableness": 20,
+        "emotional_stability": 0,
+        "personality_rule_version": "mbti-big-five-v0.1",
+        "status": "APPLIED",
+        "locked": False,
+        "persona_locked_at": None,
+    }
+
+    started = client.post(
+        f"/v1/simulations/{simulation_id}/start", headers=headers, json={}
+    )
+    assert started.status_code == 200
+    assert started.json()["data"]["status"] == "running"
+
+    locked = client.post(
+        f"/v1/simulations/{simulation_id}/user-persona",
+        headers=headers,
+        json=valid_payload(student_id),
+    )
+    assert locked.status_code == 409
+    assert locked.json()["code"] == "CONFLICT"
+
+
+def test_persona_domain_error_is_400_and_shape_error_is_422(client) -> None:
+    simulation_id, student_id, headers = register_login_create(client)
+    invalid = valid_payload(student_id)
+    invalid["extraversion"] = 10
+    domain_error = client.post(
+        f"/v1/simulations/{simulation_id}/user-persona",
+        headers=headers,
+        json=invalid,
+    )
+    shape_error = client.post(
+        f"/v1/simulations/{simulation_id}/user-persona",
+        headers=headers,
+        json={"agent_id": student_id},
+    )
+    assert domain_error.status_code == 400
+    assert domain_error.json()["code"] == "INVALID_PERSONALITY_CONFIGURATION"
+    assert shape_error.status_code == 422

--- a/backend/tests/test_user_persona_service.py
+++ b/backend/tests/test_user_persona_service.py
@@ -1,0 +1,226 @@
+import os
+
+import pytest
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import sessionmaker
+from uuid6 import uuid7
+
+from app.domain.models import Agent, Simulation, User, UserPersonaConfig
+from app.services.fixtures import seed_slice_zero
+from app.services.user_persona import (
+    InvalidPersonaAgentError,
+    InvalidPersonalityConfigurationError,
+    PersonaChangeConflictError,
+    PersonaInput,
+    PersonaRequiredError,
+    UserPersonaService,
+)
+
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required"
+)
+
+
+@pytest.fixture()
+def persona_context():
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
+
+    owner_id = uuid7()
+    simulation_id = uuid7()
+    with session_factory.begin() as session:
+        session.add(
+            User(
+                id=owner_id,
+                username="slice4-persona-owner",
+                display_name="Slice 4 Persona Owner",
+                password_hash="not-a-real-password-hash",
+                roles=["USER"],
+            )
+        )
+        session.flush()
+        session.add(
+            Simulation(id=simulation_id, owner_id=owner_id, name="Slice 4")
+        )
+        session.flush()
+        seed_slice_zero(session, simulation_id)
+    try:
+        yield session_factory, owner_id, simulation_id
+    finally:
+        engine.dispose()
+
+
+def persona_input(agent_id, *, mbti_type="INFP") -> PersonaInput:
+    return PersonaInput(
+        agent_id=agent_id,
+        mbti_type=mbti_type,
+        personality_rule_version="mbti-big-five-v0.1",
+        openness=25,
+        conscientiousness=-25,
+        extraversion=-25,
+        agreeableness=20,
+        emotional_stability=0,
+    )
+
+
+def test_persona_can_change_before_start_without_mutating_previous_student(
+    persona_context,
+) -> None:
+    session_factory, _, simulation_id = persona_context
+    service = UserPersonaService()
+    with session_factory.begin() as session:
+        students = list(
+            session.scalars(
+                select(Agent)
+                .where(
+                    Agent.simulation_id == simulation_id,
+                    Agent.agent_type == "student",
+                )
+                .order_by(Agent.fixture_key)
+            )
+        )
+        original_first_mbti = students[0].mbti_type
+        first = service.set_persona(
+            session, simulation_id, persona_input(students[0].id)
+        )
+        assert first.agent_id == students[0].id
+        second = service.set_persona(
+            session,
+            simulation_id,
+            PersonaInput(
+                agent_id=students[1].id,
+                mbti_type="ESTP",
+                personality_rule_version="mbti-big-five-v0.1",
+                openness=-25,
+                conscientiousness=-25,
+                extraversion=25,
+                agreeableness=-20,
+                emotional_stability=0,
+            ),
+        )
+        assert second.agent_id == students[1].id
+        assert students[0].mbti_type == original_first_mbti
+        assert session.query(UserPersonaConfig).count() == 1
+
+
+def test_persona_rejects_professor_and_cross_simulation_student(
+    persona_context,
+) -> None:
+    session_factory, owner_id, simulation_id = persona_context
+    service = UserPersonaService()
+    with session_factory.begin() as session:
+        professor_id = session.scalar(
+            select(Agent.id).where(
+                Agent.simulation_id == simulation_id,
+                Agent.agent_type == "professor",
+            )
+        )
+        with pytest.raises(InvalidPersonaAgentError):
+            service.set_persona(
+                session, simulation_id, persona_input(professor_id)
+            )
+
+        other_simulation_id = uuid7()
+        session.add(
+            Simulation(
+                id=other_simulation_id,
+                owner_id=owner_id,
+                name="Other Slice 4",
+            )
+        )
+        session.flush()
+        seed_slice_zero(session, other_simulation_id)
+        other_student_id = session.scalar(
+            select(Agent.id).where(
+                Agent.simulation_id == other_simulation_id,
+                Agent.fixture_key == "student-01",
+            )
+        )
+        with pytest.raises(InvalidPersonaAgentError):
+            service.set_persona(
+                session, simulation_id, persona_input(other_student_id)
+            )
+
+
+def test_personality_rule_range_and_step_are_validated(persona_context) -> None:
+    session_factory, _, simulation_id = persona_context
+    service = UserPersonaService()
+    with session_factory() as session:
+        student_id = session.scalar(
+            select(Agent.id).where(
+                Agent.simulation_id == simulation_id,
+                Agent.agent_type == "student",
+            )
+        )
+        invalid = persona_input(student_id)
+        invalid = PersonaInput(**{**invalid.__dict__, "extraversion": 10})
+        with pytest.raises(InvalidPersonalityConfigurationError):
+            service.set_persona(session, simulation_id, invalid)
+
+
+def test_start_applies_and_locks_persona_atomically(persona_context) -> None:
+    session_factory, _, simulation_id = persona_context
+    service = UserPersonaService()
+    with session_factory.begin() as session:
+        student = session.scalar(
+            select(Agent).where(
+                Agent.simulation_id == simulation_id,
+                Agent.fixture_key == "student-03",
+            )
+        )
+        service.set_persona(session, simulation_id, persona_input(student.id))
+        simulation = service.start(session, simulation_id)
+        assert simulation.status == "running"
+        assert simulation.started_at is not None
+        assert student.persona_locked_at is not None
+        assert student.agent_type == "student"
+        assert student.mbti_type == "INFP"
+        assert student.openness == 25
+
+        with pytest.raises(PersonaChangeConflictError):
+            service.set_persona(session, simulation_id, persona_input(student.id))
+
+
+def test_start_requires_persona(persona_context) -> None:
+    session_factory, _, simulation_id = persona_context
+    with session_factory() as session:
+        with pytest.raises(PersonaRequiredError):
+            UserPersonaService().start(session, simulation_id)
+
+
+def test_start_and_persona_lock_roll_back_together(persona_context) -> None:
+    session_factory, _, simulation_id = persona_context
+    service = UserPersonaService()
+    with session_factory() as session:
+        student = session.scalar(
+            select(Agent).where(
+                Agent.simulation_id == simulation_id,
+                Agent.fixture_key == "student-03",
+            )
+        )
+        original_openness = student.openness
+        with pytest.raises(RuntimeError, match="start failed"):
+            with session.begin_nested():
+                service.set_persona(session, simulation_id, persona_input(student.id))
+                service.start(session, simulation_id)
+                raise RuntimeError("start failed")
+        session.rollback()
+
+    with session_factory() as session:
+        simulation = session.get(Simulation, simulation_id)
+        student = session.scalar(
+            select(Agent).where(
+                Agent.simulation_id == simulation_id,
+                Agent.fixture_key == "student-03",
+            )
+        )
+        assert simulation.status == "ready"
+        assert simulation.started_at is None
+        assert student.persona_locked_at is None
+        assert student.openness == original_openness


### PR DESCRIPTION
## 작업 개요

Slice 4에서 기존 Student 중 User Persona를 선택·저장하고, Simulation 시작 시 설정 적용과 잠금을 원자적으로 처리합니다. Tick 실행 메타데이터를 Runtime 결과와 같은 transaction에 저장하여 실패 시 전체 rollback되도록 구성했습니다.

## 관련 Issue

Closes #112

Parent: #108  
Decision: #109

## 변경 내용

- Simulation별 User Persona 설정 저장, 조회 및 소속 Student 검증
- 시작 전 Persona 재선택, 시작 시 Big Five·MBTI 적용과 `persona_locked_at` 잠금
- 시작 후 Persona 변경 요청 409 처리 및 User Persona 설정·조회·시작 API 추가
- `run_id`, `seed`, `model`, `prompt_version`, `policy_version` 실행 메타데이터 저장
- Persona 설정과 Runtime 실행 기록을 위한 migration 및 PostgreSQL 통합 테스트 추가
- Runtime 결과·실행 기록·Tick 갱신이 상위 transaction에서 함께 commit 또는 rollback되도록 연동

## 결정 사항 및 이유

User Persona는 별도 Agent 타입으로 변경하지 않고 기존 Student를 가리키는 Simulation별 1:1 설정으로 저장했습니다. 시작 전 재선택 시 기존 Student 데이터가 오염되지 않고, 시작 transaction이 성공할 때만 선택된 Student에 설정과 잠금이 반영되도록 하기 위함입니다.

Repository와 Service는 `flush()`까지만 수행하고 commit·rollback은 API의 상위 transaction 경계가 소유하도록 구성했습니다. 실행 메타데이터 역시 Runtime 결과 저장과 동일한 Session을 사용해 Tick 저장 실패 시 부분 데이터가 남지 않습니다.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [x] 관련 문서 업데이트 확인 — 코드 변경이 최신 Task 0 계약 및 Issue #112와 일치함을 확인했으며 문서 변경은 없음

검증 결과:

- 전용 PostgreSQL DB migration `upgrade head` 성공
- `alembic downgrade -1` 후 `upgrade head` 재적용 성공
- `alembic check`: No new upgrade operations detected
- Task 3 및 관련 PostgreSQL 핵심 테스트: 26 passed
- 전체 Backend 회귀 테스트: 282 passed

## AI 사용 여부

사용 여부: 사용함  
사용한 작업: 계약·기존 구조 분석, TDD 테스트 작성, migration·Repository·Service·API 구현, PostgreSQL 및 전체 회귀 검증  
사람이 검토한 내용: Task 0 계약, Issue #112 범위, migration rollback 실행 범위, 전용 브랜치 커밋·푸시 승인

## 리뷰어가 봐야 할 부분

- `user_persona_configs`가 기존 Student를 참조하며 `agents.agent_type`을 변경하지 않는 구조
- 시작 시 Simulation 상태 변경, Agent 성격 적용, `persona_locked_at` 기록의 transaction 경계
- `runtime_executions`와 기존 `runtime_results`·Tick 갱신이 동일 Session에서 원자적으로 처리되는지
- MBTI별 Big Five 허용 범위와 5단위 검증이 Task 0 계약과 일치하는지