### PR TITLE
[Feature] Slice 5 Task 2 — Agent별 Context 분리 및 중복 효과 방지

### DIFF
--- a/backend/app/repositories/simulations.py
+++ b/backend/app/repositories/simulations.py
@@ -8,6 +8,7 @@ from app.domain.models import (
     AgentState,
     Location,
     ProfessorProfile,
+    Relationship,
     Simulation,
     StudentProfile,
 )
@@ -72,5 +73,18 @@ def list_active_runtime_location_ids(db: Session, simulation_id: UUID) -> list[U
                 Location.is_active.is_(True),
             )
             .order_by(Location.id.asc())
+        ).all()
+    )
+
+
+def list_runtime_relationships(db: Session, simulation_id: UUID) -> list[Relationship]:
+    return list(
+        db.scalars(
+            select(Relationship)
+            .where(Relationship.simulation_id == simulation_id)
+            .order_by(
+                Relationship.source_agent_id.asc(),
+                Relationship.target_agent_id.asc(),
+            )
         ).all()
     )

--- a/backend/app/services/runtime_input_adapter.py
+++ b/backend/app/services/runtime_input_adapter.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping, Sequence
 from uuid import UUID
 
-from app.domain.models import Agent, AgentState, Event, EventParticipant
+from app.domain.models import Agent, AgentState, Event, EventParticipant, Relationship
 from app.services.runtime_orchestrator import (
     RuntimeBatchExecutionResult,
     RuntimeOrchestrator,
@@ -10,6 +10,7 @@ from app.simulation.agent_runtime import (
     AgentContext,
     Block,
     EventSummary,
+    RelationshipSummary,
     ScheduleSummary,
 )
 
@@ -92,6 +93,24 @@ class RuntimeInputAdapter:
             )
         return tuple(summaries)
 
+    @staticmethod
+    def to_relationship_summaries(
+        relationships: Sequence[Relationship],
+    ) -> tuple[RelationshipSummary, ...]:
+        return tuple(
+            RelationshipSummary(
+                source_agent_id=relationship.source_agent_id,
+                target_agent_id=relationship.target_agent_id,
+                affection=relationship.affection,
+                closeness=relationship.closeness,
+                trust=relationship.trust,
+                tension=relationship.tension,
+                rivalry=relationship.rivalry,
+                dependency=relationship.dependency,
+            )
+            for relationship in relationships
+        )
+
     def run(
         self,
         *,
@@ -106,6 +125,7 @@ class RuntimeInputAdapter:
         event_participants: Mapping[UUID, Sequence[EventParticipant]],
         valid_agent_ids: Sequence[UUID],
         valid_location_ids: Sequence[UUID],
+        relationships: Sequence[Relationship] = (),
     ) -> RuntimeBatchExecutionResult:
         self._validate_uuid_sequence("preselected_agent_ids", preselected_agent_ids)
         self._validate_uuid_sequence("valid_agent_ids", valid_agent_ids)
@@ -116,6 +136,7 @@ class RuntimeInputAdapter:
             for agent in agents
         )
         event_summaries = self.to_event_summaries(events, event_participants)
+        relationship_summaries = self.to_relationship_summaries(relationships)
         return self._orchestrator.run_preselected(
             run_id=run_id,
             tick_number=tick_number,
@@ -126,6 +147,7 @@ class RuntimeInputAdapter:
             events=event_summaries,
             valid_agent_ids=valid_agent_ids,
             valid_location_ids=valid_location_ids,
+            relationships=relationship_summaries,
         )
 
     @staticmethod

--- a/backend/app/services/runtime_orchestrator.py
+++ b/backend/app/services/runtime_orchestrator.py
@@ -15,6 +15,7 @@ from app.simulation.agent_runtime import (
     AgentRuntimeResult,
     Block,
     EventSummary,
+    RelationshipSummary,
     ScheduleSummary,
 )
 
@@ -53,6 +54,7 @@ class RuntimeOrchestrator:
         events: Sequence[EventSummary],
         valid_agent_ids: Sequence[UUID],
         valid_location_ids: Sequence[UUID],
+        relationships: Sequence[RelationshipSummary] = (),
     ) -> RuntimeBatchExecutionResult:
         selected_agents = self._target_selector.select(
             agent_candidates,
@@ -76,6 +78,8 @@ class RuntimeOrchestrator:
                 schedule=schedule,
                 valid_agent_ids=valid_agent_ids,
                 valid_location_ids=valid_location_ids,
+                agent_candidates=agent_candidates,
+                relationships=relationships,
             )
             for agent in selected_agents
         )

--- a/backend/app/services/simulation_tick.py
+++ b/backend/app/services/simulation_tick.py
@@ -8,6 +8,7 @@ from app.repositories.simulations import (
     list_active_runtime_location_ids,
     list_runtime_agents,
     list_runtime_agent_states,
+    list_runtime_relationships,
 )
 from app.services.runtime_input_adapter import RuntimeInputAdapter
 from app.services.runtime_orchestrator import RuntimeBatchExecutionResult
@@ -40,6 +41,7 @@ class SimulationTickService:
         states = list_runtime_agent_states(db, agent_ids)
         agent_states = self._validate_agent_states(agent_ids, states)
         valid_location_ids = list_active_runtime_location_ids(db, simulation_id)
+        relationships = list_runtime_relationships(db, simulation_id)
         self._validate_events(
             simulation_id=simulation_id,
             events=events,
@@ -60,6 +62,7 @@ class SimulationTickService:
             event_participants=event_participants,
             valid_agent_ids=agent_ids,
             valid_location_ids=valid_location_ids,
+            relationships=relationships,
         )
 
     @staticmethod

--- a/backend/app/simulation/agent_context_assembler.py
+++ b/backend/app/simulation/agent_context_assembler.py
@@ -36,7 +36,7 @@ class AgentContextAssembler:
         schedule: ScheduleSummary,
         valid_agent_ids: Sequence[UUID],
         valid_location_ids: Sequence[UUID],
-        agent_candidates: Sequence[AgentContext] | None = None,
+        agent_candidates: Sequence[AgentContext],
         relationships: Sequence[RelationshipSummary] = (),
     ) -> AgentRuntimeInput:
         observer = AgentContext(
@@ -78,10 +78,9 @@ class AgentContextAssembler:
                 relationship.source_agent_id.int,
             ),
         )
-        runtime_valid_agent_ids = (
-            sorted(observable_agent_ids, key=lambda value: value.int)
-            if agent_candidates is not None
-            else sorted(set(valid_agent_ids), key=lambda value: value.int)
+        runtime_valid_agent_ids = sorted(
+            observable_agent_ids,
+            key=lambda value: value.int,
         )
         return AgentRuntimeInput(
             run_id=run_id,
@@ -100,10 +99,10 @@ class AgentContextAssembler:
     @staticmethod
     def _nearby_agents(
         observer: AgentContext,
-        agent_candidates: Sequence[AgentContext] | None,
+        agent_candidates: Sequence[AgentContext],
         valid_agent_ids: set[UUID],
     ) -> list[AgentSummary]:
-        if agent_candidates is None or observer.current_location_id is None:
+        if observer.current_location_id is None:
             return []
         summaries = [
             AgentSummary(
@@ -137,7 +136,10 @@ class AgentContextAssembler:
             if not (
                 observer.agent_id in event.participant_agent_ids
                 or event.location_id == observer.current_location_id
-                or event.event_id == schedule.event_id
+                or (
+                    schedule.is_mandatory
+                    and event.event_id == schedule.event_id
+                )
             ):
                 continue
             visible_events.append(

--- a/backend/app/simulation/agent_context_assembler.py
+++ b/backend/app/simulation/agent_context_assembler.py
@@ -4,12 +4,14 @@ from uuid import UUID
 
 from app.simulation.agent_runtime import (
     AgentContext,
+    AgentSummary,
     AgentRuntimeInput,
     AgentStateContext,
     BigFiveContext,
     Block,
     EventSummary,
     MBTI,
+    RelationshipSummary,
     ScheduleSummary,
 )
 
@@ -34,27 +36,122 @@ class AgentContextAssembler:
         schedule: ScheduleSummary,
         valid_agent_ids: Sequence[UUID],
         valid_location_ids: Sequence[UUID],
+        agent_candidates: Sequence[AgentContext] | None = None,
+        relationships: Sequence[RelationshipSummary] = (),
     ) -> AgentRuntimeInput:
+        observer = AgentContext(
+            agent_id=agent_id,
+            fixture_key=fixture_key,
+            agent_type=agent_type,
+            name=name,
+            mbti=mbti,
+            big_five=big_five,
+            state=state,
+            current_location_id=current_location_id,
+            active_status=active_status,
+        )
+        nearby_agents = self._nearby_agents(
+            observer,
+            agent_candidates,
+            set(valid_agent_ids),
+        )
+        observable_agent_ids = {summary.agent_id for summary in nearby_agents}
+        visible_events = self._visible_events(
+            observer,
+            events,
+            schedule,
+            observable_agent_ids,
+        )
+        normalized_relationships = tuple(
+            RelationshipSummary.model_validate(relationship)
+            for relationship in relationships
+        )
+        visible_relationships = sorted(
+            (
+                relationship
+                for relationship in normalized_relationships
+                if relationship.source_agent_id == observer.agent_id
+                and relationship.target_agent_id in observable_agent_ids
+            ),
+            key=lambda relationship: (
+                relationship.target_agent_id.int,
+                relationship.source_agent_id.int,
+            ),
+        )
+        runtime_valid_agent_ids = (
+            sorted(observable_agent_ids, key=lambda value: value.int)
+            if agent_candidates is not None
+            else sorted(set(valid_agent_ids), key=lambda value: value.int)
+        )
         return AgentRuntimeInput(
             run_id=run_id,
             tick_number=tick_number,
             block=block,
-            agent=AgentContext(
-                agent_id=agent_id,
-                fixture_key=fixture_key,
-                agent_type=agent_type,
-                name=name,
-                mbti=mbti,
-                big_five=big_five,
-                state=state,
-                current_location_id=current_location_id,
-                active_status=active_status,
-            ),
-            nearby_agents=[],
-            relationships=[],
+            agent=observer,
+            nearby_agents=nearby_agents,
+            relationships=visible_relationships,
             memories=[],
-            events=list(events),
+            events=visible_events,
             schedule=schedule,
-            valid_agent_ids=list(valid_agent_ids),
-            valid_location_ids=list(valid_location_ids),
+            valid_agent_ids=runtime_valid_agent_ids,
+            valid_location_ids=sorted(set(valid_location_ids), key=lambda value: value.int),
         )
+
+    @staticmethod
+    def _nearby_agents(
+        observer: AgentContext,
+        agent_candidates: Sequence[AgentContext] | None,
+        valid_agent_ids: set[UUID],
+    ) -> list[AgentSummary]:
+        if agent_candidates is None or observer.current_location_id is None:
+            return []
+        summaries = [
+            AgentSummary(
+                agent_id=candidate.agent_id,
+                name=candidate.name,
+                agent_type=candidate.agent_type,
+                active_status=candidate.active_status,
+                current_location_id=candidate.current_location_id,
+                mood=candidate.state.mood,
+                stress=candidate.state.stress,
+                fatigue=candidate.state.fatigue,
+            )
+            for candidate in agent_candidates
+            if candidate.agent_id != observer.agent_id
+            and candidate.agent_id in valid_agent_ids
+            and candidate.active_status
+            and candidate.current_location_id == observer.current_location_id
+        ]
+        return sorted(summaries, key=lambda summary: summary.agent_id.int)
+
+    @staticmethod
+    def _visible_events(
+        observer: AgentContext,
+        events: Sequence[EventSummary],
+        schedule: ScheduleSummary,
+        observable_agent_ids: set[UUID],
+    ) -> list[EventSummary]:
+        visible_participant_ids = observable_agent_ids | {observer.agent_id}
+        visible_events = []
+        for event in events:
+            if not (
+                observer.agent_id in event.participant_agent_ids
+                or event.location_id == observer.current_location_id
+                or event.event_id == schedule.event_id
+            ):
+                continue
+            visible_events.append(
+                event.model_copy(
+                    update={
+                        "participant_agent_ids": sorted(
+                            (
+                                participant_id
+                                for participant_id in event.participant_agent_ids
+                                if participant_id in visible_participant_ids
+                            ),
+                            key=lambda value: value.int,
+                        )
+                    }
+                )
+            )
+        return sorted(visible_events, key=lambda event: event.event_id.int)

--- a/backend/app/simulation/agent_runtime.py
+++ b/backend/app/simulation/agent_runtime.py
@@ -223,7 +223,9 @@ class AgentRuntimeInput(StrictModel):
         events_by_id = {event.event_id: event for event in self.events}
         scheduled_event = events_by_id.get(self.schedule.event_id)
         if scheduled_event is None:
-            raise ValueError("schedule event_id must be included in events")
+            if self.schedule.is_mandatory:
+                raise ValueError("mandatory schedule event_id must be included in events")
+            return self
         if scheduled_event.event_type != self.schedule.schedule_type:
             raise ValueError("schedule_type must match the linked event_type")
         if scheduled_event.location_id != self.schedule.location_id:

--- a/backend/app/simulation/agent_runtime.py
+++ b/backend/app/simulation/agent_runtime.py
@@ -159,6 +159,28 @@ class AgentContext(StrictModel):
     active_status: bool = Field(strict=True)
 
 
+class AgentSummary(StrictModel):
+    agent_id: UUID
+    name: str
+    agent_type: Literal["student", "professor"]
+    active_status: bool = Field(strict=True)
+    current_location_id: UUID
+    mood: int = Field(ge=-100, le=100)
+    stress: int = Field(ge=0, le=100)
+    fatigue: int = Field(ge=0, le=100)
+
+
+class RelationshipSummary(StrictModel):
+    source_agent_id: UUID
+    target_agent_id: UUID
+    affection: int
+    closeness: int
+    trust: int
+    tension: int
+    rivalry: int
+    dependency: int
+
+
 class EventSummary(StrictModel):
     event_id: UUID
     event_type: EventType
@@ -188,8 +210,8 @@ class AgentRuntimeInput(StrictModel):
     tick_number: int = Field(ge=0)
     block: Block
     agent: AgentContext
-    nearby_agents: list[dict[str, Any]]
-    relationships: list[dict[str, Any]]
+    nearby_agents: list[AgentSummary]
+    relationships: list[RelationshipSummary]
     memories: list[dict[str, Any]]
     events: list[EventSummary]
     schedule: ScheduleSummary

--- a/backend/app/simulation/policy/conflict.py
+++ b/backend/app/simulation/policy/conflict.py
@@ -1,11 +1,16 @@
 from app.simulation.policy.models import METRIC_RANGE, EffectCandidate
 
 
+class ConflictingEffectIdError(ValueError):
+    pass
+
+
 def resolve_conflicts(candidates: list[EffectCandidate]) -> list[EffectCandidate]:
     """같은 (source, target, metric) 쌍의 delta를 합산하고 clamp한다. (MVP: 단순 가산)"""
     groups: dict[tuple, EffectCandidate] = {}
+    unique_candidates = _deduplicate_effect_ids(candidates)
 
-    for c in candidates:
+    for c in unique_candidates:
         key = (c.source_agent_id, c.target_agent_id, c.metric)
         if key not in groups:
             groups[key] = EffectCandidate(
@@ -32,3 +37,21 @@ def resolve_conflicts(candidates: list[EffectCandidate]) -> list[EffectCandidate
         result.append(resolved)
 
     return result
+
+
+def _deduplicate_effect_ids(
+    candidates: list[EffectCandidate],
+) -> list[EffectCandidate]:
+    seen_by_effect_id: dict[str, EffectCandidate] = {}
+    unique_candidates = []
+    for candidate in candidates:
+        existing = seen_by_effect_id.get(candidate.effect_id)
+        if existing is None:
+            seen_by_effect_id[candidate.effect_id] = candidate
+            unique_candidates.append(candidate)
+            continue
+        if existing != candidate:
+            raise ConflictingEffectIdError(
+                f"conflicting payloads for effect_id {candidate.effect_id}"
+            )
+    return unique_candidates

--- a/backend/tests/test_agent_context_assembler.py
+++ b/backend/tests/test_agent_context_assembler.py
@@ -66,6 +66,7 @@ def make_inputs() -> dict:
         ),
         "valid_agent_ids": STUDENT_IDS.copy(),
         "valid_location_ids": LOCATION_IDS.copy(),
+        "agent_candidates": [],
     }
 
 
@@ -80,7 +81,7 @@ def test_assembles_slice_one_student_class_context() -> None:
     assert runtime_input.agent.active_status is True
     assert runtime_input.agent.agent_id == STUDENT_IDS[0]
     assert runtime_input.events[0].event_id == CLASS_EVENT_ID
-    assert runtime_input.valid_agent_ids == STUDENT_IDS
+    assert runtime_input.valid_agent_ids == []
     assert runtime_input.valid_location_ids == LOCATION_IDS
     assert runtime_input.relationships == []
     assert runtime_input.memories == []
@@ -88,7 +89,7 @@ def test_assembles_slice_one_student_class_context() -> None:
     assert runtime_input.model_dump(mode="json")["events"][0]["event_type"] == "class"
 
 
-def test_sorts_reference_ids_without_mutating_inputs() -> None:
+def test_empty_observation_set_has_no_valid_agent_ids_without_mutating_inputs() -> None:
     inputs = make_inputs()
     inputs["valid_agent_ids"] = list(reversed(STUDENT_IDS))
     inputs["valid_location_ids"] = list(reversed(LOCATION_IDS))
@@ -96,7 +97,7 @@ def test_sorts_reference_ids_without_mutating_inputs() -> None:
 
     runtime_input = AgentContextAssembler().assemble(**inputs)
 
-    assert runtime_input.valid_agent_ids == STUDENT_IDS
+    assert runtime_input.valid_agent_ids == []
     assert runtime_input.valid_location_ids == LOCATION_IDS
     assert inputs == original
 
@@ -106,6 +107,30 @@ def test_same_input_produces_equal_runtime_input() -> None:
     assembler = AgentContextAssembler()
 
     assert assembler.assemble(**inputs) == assembler.assemble(**inputs)
+
+
+def test_non_mandatory_off_location_schedule_event_is_not_visible() -> None:
+    inputs = make_inputs()
+    inputs["events"] = [
+        EventSummary(
+            event_id=CLASS_EVENT_ID,
+            event_type="class",
+            location_id=LOCATION_IDS[1],
+            participant_agent_ids=[],
+        )
+    ]
+    inputs["schedule"] = ScheduleSummary(
+        event_id=CLASS_EVENT_ID,
+        schedule_type="class",
+        is_mandatory=False,
+        location_id=LOCATION_IDS[1],
+        start_tick=3,
+        end_tick=3,
+    )
+
+    runtime_input = AgentContextAssembler().assemble(**inputs)
+
+    assert runtime_input.events == []
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_agent_context_assembler.py
+++ b/backend/tests/test_agent_context_assembler.py
@@ -88,7 +88,7 @@ def test_assembles_slice_one_student_class_context() -> None:
     assert runtime_input.model_dump(mode="json")["events"][0]["event_type"] == "class"
 
 
-def test_preserves_collection_order_without_mutating_inputs() -> None:
+def test_sorts_reference_ids_without_mutating_inputs() -> None:
     inputs = make_inputs()
     inputs["valid_agent_ids"] = list(reversed(STUDENT_IDS))
     inputs["valid_location_ids"] = list(reversed(LOCATION_IDS))
@@ -96,8 +96,8 @@ def test_preserves_collection_order_without_mutating_inputs() -> None:
 
     runtime_input = AgentContextAssembler().assemble(**inputs)
 
-    assert runtime_input.valid_agent_ids == list(reversed(STUDENT_IDS))
-    assert runtime_input.valid_location_ids == list(reversed(LOCATION_IDS))
+    assert runtime_input.valid_agent_ids == STUDENT_IDS
+    assert runtime_input.valid_location_ids == LOCATION_IDS
     assert inputs == original
 
 

--- a/backend/tests/test_agent_context_visibility.py
+++ b/backend/tests/test_agent_context_visibility.py
@@ -1,0 +1,249 @@
+from copy import deepcopy
+from types import SimpleNamespace
+from uuid import UUID
+
+from app.services.runtime_orchestrator import RuntimeOrchestrator
+from app.services.runtime_results import InMemoryRuntimeResultSink
+from app.simulation.agent_runtime import (
+    AgentContext,
+    AgentRuntimeInput,
+    AgentRuntimeResult,
+    EventSummary,
+    RuntimeStatus,
+    ScheduleSummary,
+    validate_intent_candidate,
+)
+from app.simulation.anthropic_llm_client import AnthropicLLMClient
+from app.simulation.agent_runtime import MockLLMClient
+
+
+AGENT_A = UUID("00000000-0000-0000-0000-000000000001")
+AGENT_B = UUID("00000000-0000-0000-0000-000000000002")
+AGENT_C = UUID("00000000-0000-0000-0000-000000000003")
+AGENT_D = UUID("00000000-0000-0000-0000-000000000004")
+LOCATION_ONE = UUID("10000000-0000-0000-0000-000000000001")
+LOCATION_TWO = UUID("10000000-0000-0000-0000-000000000002")
+MANDATORY_EVENT = UUID("20000000-0000-0000-0000-000000000001")
+PARTICIPANT_EVENT = UUID("20000000-0000-0000-0000-000000000002")
+SAME_LOCATION_EVENT = UUID("20000000-0000-0000-0000-000000000003")
+UNRELATED_EVENT = UUID("20000000-0000-0000-0000-000000000004")
+
+
+def make_agent(
+    agent_id: UUID,
+    *,
+    location_id: UUID,
+    active: bool = True,
+) -> AgentContext:
+    return AgentContext(
+        agent_id=agent_id,
+        fixture_key=f"student-{agent_id.int}",
+        agent_type="student",
+        name=f"Agent {agent_id.int}",
+        mbti="ISTJ",
+        big_five={
+            "openness": 0,
+            "conscientiousness": 0,
+            "extraversion": 0,
+            "agreeableness": 0,
+            "emotional_stability": 0,
+        },
+        state={
+            "hunger": 10,
+            "fatigue": agent_id.int,
+            "stress": agent_id.int + 10,
+            "satisfaction": 50,
+            "mood": agent_id.int - 2,
+        },
+        current_location_id=location_id,
+        active_status=active,
+    )
+
+
+def make_event(
+    event_id: UUID,
+    *,
+    location_id: UUID,
+    participants: list[UUID] | None = None,
+    event_type: str = "meeting",
+) -> EventSummary:
+    return EventSummary(
+        event_id=event_id,
+        event_type=event_type,
+        location_id=location_id,
+        participant_agent_ids=participants or [],
+        title=f"Event {event_id.int}",
+        description="visible world data",
+    )
+
+
+def make_schedule() -> ScheduleSummary:
+    return ScheduleSummary(
+        event_id=MANDATORY_EVENT,
+        schedule_type="class",
+        is_mandatory=True,
+        location_id=LOCATION_TWO,
+        start_tick=3,
+        end_tick=3,
+    )
+
+
+def make_relationship(source: UUID, target: UUID, *, trust: int) -> dict:
+    return {
+        "source_agent_id": source,
+        "target_agent_id": target,
+        "affection": 1,
+        "closeness": 2,
+        "trust": trust,
+        "tension": 4,
+        "rivalry": 5,
+        "dependency": 6,
+    }
+
+
+class RecordingRuntime:
+    def __init__(self) -> None:
+        self.inputs: list[AgentRuntimeInput] = []
+
+    def run(self, runtime_input: AgentRuntimeInput) -> AgentRuntimeResult:
+        self.inputs.append(runtime_input)
+        intent = validate_intent_candidate(
+            MockLLMClient().generate(runtime_input),
+            runtime_input,
+        )
+        agent_id = runtime_input.agent.agent_id
+        return AgentRuntimeResult(
+            run_id=runtime_input.run_id,
+            tick_number=runtime_input.tick_number,
+            agent_id=agent_id,
+            status=RuntimeStatus.PROPOSED,
+            intent=intent,
+            retry_count=0,
+            failure_reason=None,
+            model="recording-runtime",
+            prompt_version="test",
+            idempotency_key=f"{runtime_input.run_id}:{runtime_input.tick_number}:{agent_id}",
+        )
+
+
+def assemble_visibility_inputs() -> tuple[list[AgentRuntimeInput], tuple[object, ...]]:
+    agents = [
+        make_agent(AGENT_D, location_id=LOCATION_TWO),
+        make_agent(AGENT_C, location_id=LOCATION_ONE, active=False),
+        make_agent(AGENT_B, location_id=LOCATION_ONE),
+        make_agent(AGENT_A, location_id=LOCATION_ONE),
+    ]
+    events = [
+        make_event(UNRELATED_EVENT, location_id=LOCATION_TWO),
+        make_event(SAME_LOCATION_EVENT, location_id=LOCATION_ONE),
+        make_event(
+            PARTICIPANT_EVENT,
+            location_id=LOCATION_TWO,
+            participants=[AGENT_D, AGENT_A],
+        ),
+        make_event(
+            MANDATORY_EVENT,
+            location_id=LOCATION_TWO,
+            participants=[AGENT_D],
+            event_type="class",
+        ),
+    ]
+    relationships = [
+        make_relationship(AGENT_B, AGENT_A, trust=90),
+        make_relationship(AGENT_A, AGENT_D, trust=80),
+        make_relationship(AGENT_A, AGENT_B, trust=70),
+    ]
+    original = deepcopy((agents, events, relationships))
+    runtime = RecordingRuntime()
+    RuntimeOrchestrator(runtime, InMemoryRuntimeResultSink()).run_preselected(
+        run_id="slice-5-run",
+        tick_number=3,
+        block="MORNING",
+        agent_candidates=agents,
+        preselected_agent_ids=[AGENT_A, AGENT_D],
+        schedule=make_schedule(),
+        events=events,
+        relationships=relationships,
+        valid_agent_ids=[AGENT_D, AGENT_C, AGENT_B, AGENT_A],
+        valid_location_ids=[LOCATION_TWO, LOCATION_ONE],
+    )
+    return runtime.inputs, (agents, events, relationships, original)
+
+
+def test_orchestrator_builds_independent_agent_visibility_contexts() -> None:
+    runtime_inputs, _ = assemble_visibility_inputs()
+
+    assert len(runtime_inputs) == 2
+    assert runtime_inputs[0] is not runtime_inputs[1]
+    by_agent = {item.agent.agent_id: item for item in runtime_inputs}
+    observer = by_agent[AGENT_A]
+
+    assert [event.event_id for event in observer.events] == [
+        MANDATORY_EVENT,
+        PARTICIPANT_EVENT,
+        SAME_LOCATION_EVENT,
+    ]
+    assert [summary.agent_id for summary in observer.nearby_agents] == [AGENT_B]
+    assert observer.nearby_agents[0].active_status is True
+    assert observer.nearby_agents[0].current_location_id == LOCATION_ONE
+    assert observer.nearby_agents[0].mood == 0
+    assert observer.nearby_agents[0].stress == 12
+    assert observer.nearby_agents[0].fatigue == 2
+    assert [relationship.target_agent_id for relationship in observer.relationships] == [
+        AGENT_B
+    ]
+    assert observer.relationships[0].source_agent_id == AGENT_A
+    assert observer.relationships[0].trust == 70
+    assert observer.valid_agent_ids == [AGENT_B]
+    assert observer.agent.active_status is True
+    assert observer.agent.current_location_id == LOCATION_ONE
+    assert observer.agent.state.model_dump()["mood"] == -1
+    assert observer.agent.state.model_dump()["stress"] == 11
+    assert observer.agent.state.model_dump()["fatigue"] == 1
+
+
+def test_context_filters_hidden_ids_and_is_stably_sorted_without_mutation() -> None:
+    runtime_inputs, values = assemble_visibility_inputs()
+    agents, events, relationships, original = values
+    observer = next(item for item in runtime_inputs if item.agent.agent_id == AGENT_A)
+    payload = observer.model_dump(mode="json")
+    serialized = str(payload)
+
+    assert str(AGENT_C) not in serialized
+    assert str(AGENT_D) not in serialized
+    assert observer.events[0].participant_agent_ids == []
+    assert observer.events[1].participant_agent_ids == [AGENT_A]
+    assert [location for location in observer.valid_location_ids] == [
+        LOCATION_ONE,
+        LOCATION_TWO,
+    ]
+    assert (agents, events, relationships) == original
+
+
+class FakeMessages:
+    def __init__(self, parsed_output: object) -> None:
+        self.parsed_output = parsed_output
+        self.calls: list[dict] = []
+
+    def parse(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(parsed_output=self.parsed_output)
+
+
+def test_hidden_agent_ids_are_not_serialized_into_anthropic_request() -> None:
+    runtime_inputs, _ = assemble_visibility_inputs()
+    observer = next(item for item in runtime_inputs if item.agent.agent_id == AGENT_A)
+    candidate = validate_intent_candidate(MockLLMClient().generate(observer), observer)
+    messages = FakeMessages(candidate)
+    client = AnthropicLLMClient(
+        client=SimpleNamespace(messages=messages),
+        model="test-model",
+        max_tokens=100,
+    )
+
+    client.generate(observer)
+
+    content = messages.calls[0]["messages"][0]["content"]
+    assert str(AGENT_B) in content
+    assert str(AGENT_C) not in content
+    assert str(AGENT_D) not in content

--- a/backend/tests/test_runtime_input_adapter.py
+++ b/backend/tests/test_runtime_input_adapter.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 import pytest
 
-from app.domain.models import Agent, AgentState, Event, EventParticipant
+from app.domain.models import Agent, AgentState, Event, EventParticipant, Relationship
 from app.services.runtime_input_adapter import RuntimeInputAdapter
 from app.services.runtime_orchestrator import RuntimeOrchestrator
 from app.services.runtime_results import InMemoryRuntimeResultSink
@@ -87,6 +87,21 @@ def make_participant(event_id: UUID, agent_id: UUID) -> EventParticipant:
         event_id=event_id,
         agent_id=agent_id,
         result={},
+    )
+
+
+def make_relationship(source_agent_id: UUID, target_agent_id: UUID) -> Relationship:
+    return Relationship(
+        id=UUID(int=(source_agent_id.int + target_agent_id.int + 200) % (1 << 128)),
+        simulation_id=SIMULATION_ID,
+        source_agent_id=source_agent_id,
+        target_agent_id=target_agent_id,
+        affection=1,
+        closeness=2,
+        trust=3,
+        tension=4,
+        rivalry=5,
+        dependency=6,
     )
 
 
@@ -229,6 +244,16 @@ def test_participant_event_mismatch_is_rejected() -> None:
             [make_event()],
             {CLASS_EVENT_ID: [make_participant(SECOND_EVENT_ID, STUDENT_ID)]},
         )
+
+
+def test_directional_relationship_is_mapped_to_typed_summary() -> None:
+    summary = RuntimeInputAdapter.to_relationship_summaries(
+        [make_relationship(STUDENT_ID, PROFESSOR_ID)]
+    )[0]
+
+    assert summary.source_agent_id == STUDENT_ID
+    assert summary.target_agent_id == PROFESSOR_ID
+    assert summary.model_dump()["trust"] == 3
 
 
 class SpyOrchestrator:

--- a/backend/tests/test_slice2_policy_engine.py
+++ b/backend/tests/test_slice2_policy_engine.py
@@ -309,11 +309,11 @@ def test_duplicate_relationship_signals_are_deduplicated():
 
 # ── conflict ───────────────────────────────────────────────────────────────────
 
-def _rel_effect(source, target, metric, delta, before):
+def _rel_effect(source, target, metric, delta, before, *, effect_id=None):
     from app.simulation.policy.models import EffectCandidate, EffectTargetType
     lo, hi = (-100, 100) if metric in {"trust", "affection", "mood"} else (0, 100)
     return EffectCandidate(
-        effect_id=f"test:{source}:{target}:{metric}",
+        effect_id=effect_id or f"test:{source}:{target}:{metric}",
         target_type=EffectTargetType.RELATIONSHIP,
         source_agent_id=source,
         target_agent_id=target,
@@ -329,8 +329,8 @@ def _rel_effect(source, target, metric, delta, before):
 def test_multiple_deltas_on_same_pair_are_summed():
     from app.simulation.policy.conflict import resolve_conflicts
     candidates = [
-        _rel_effect("a", "b", "trust", 3, 20),
-        _rel_effect("a", "b", "trust", 2, 20),
+        _rel_effect("a", "b", "trust", 3, 20, effect_id="effect-1"),
+        _rel_effect("a", "b", "trust", 2, 20, effect_id="effect-2"),
     ]
     committed = resolve_conflicts(candidates)
     ab_trust = [c for c in committed if c.source_agent_id == "a" and c.metric == "trust"]
@@ -356,8 +356,8 @@ def test_ab_and_ba_are_independent_in_conflict():
 def test_summed_delta_clamped_at_range():
     from app.simulation.policy.conflict import resolve_conflicts
     candidates = [
-        _rel_effect("a", "b", "trust", 5, 97),
-        _rel_effect("a", "b", "trust", 5, 97),
+        _rel_effect("a", "b", "trust", 5, 97, effect_id="effect-1"),
+        _rel_effect("a", "b", "trust", 5, 97, effect_id="effect-2"),
     ]
     committed = resolve_conflicts(candidates)
     assert committed[0].after_preview == 100
@@ -385,6 +385,56 @@ def test_merged_candidates_join_rule_id_and_reason():
     assert "REL_TRUST_UP_HIGH" in committed[0].rule_id
     assert "MEDIUM 반응" in committed[0].reason
     assert "HIGH 반응" in committed[0].reason
+
+
+def test_identical_effect_id_and_payload_is_applied_once():
+    from copy import deepcopy
+
+    from app.simulation.policy.conflict import resolve_conflicts
+
+    event_effect = _rel_effect(
+        "a", "b", "trust", 3, 20, effect_id="canonical-event-effect"
+    )
+    magic_effect = deepcopy(event_effect)
+
+    committed = resolve_conflicts([event_effect, magic_effect])
+
+    assert len(committed) == 1
+    assert committed[0].delta == 3
+    assert committed[0].effect_id == "canonical-event-effect"
+
+
+def test_same_effect_id_with_different_payload_raises_error():
+    from app.simulation.policy.conflict import resolve_conflicts
+
+    candidates = [
+        _rel_effect("a", "b", "trust", 3, 20, effect_id="same-effect"),
+        _rel_effect("a", "b", "trust", 5, 20, effect_id="same-effect"),
+    ]
+
+    with pytest.raises(ValueError, match="conflicting payloads.*same-effect"):
+        resolve_conflicts(candidates)
+
+
+def test_distinct_effect_ids_for_same_metric_sum_in_first_seen_order():
+    from copy import deepcopy
+
+    from app.simulation.policy.conflict import resolve_conflicts
+
+    candidates = [
+        _rel_effect("a", "b", "affection", 2, 10, effect_id="first"),
+        _rel_effect("a", "b", "trust", 3, 20, effect_id="second"),
+        _rel_effect("a", "b", "affection", 4, 10, effect_id="third"),
+    ]
+    original = deepcopy(candidates)
+
+    committed = resolve_conflicts(candidates)
+
+    assert [(effect.metric, effect.delta) for effect in committed] == [
+        ("affection", 6),
+        ("trust", 3),
+    ]
+    assert candidates == original
 
 
 def test_missing_relationship_snapshot_treats_as_neutral_zero():

--- a/docs/04-feature-specs/slice-5-integration.md
+++ b/docs/04-feature-specs/slice-5-integration.md
@@ -115,7 +115,30 @@ Event Master가 참여 후보 선정에 사용하는 `agent_summaries`(L1) 필�
 | active_status, current_location_id | 참여 가능 여부·장소 조건 |
 | mood, stress, fatigue | 상태 조건 판단 |
 
-`relationship_summaries`는 MEETING 후보 선정에만 사용한다. 이 필드 목록은 Task 2(Agent별 Context 분리, 가윤)의 Context Assembler 구현과 함께 최종 확정되며, Task 0은 이 표를 Slice 5 착수 시점의 작업 기준으로 확정한다.
+Event Master의 L1 `agent_summaries`와 Agent Runtime의 `nearby_agents`는 용도가 다르다. L1은 Event Master가 Event 참여 후보를 선정하기 위한 전체 후보 snapshot이고, `nearby_agents`는 각 observer Agent가 현재 관찰할 수 있는 Agent만 포함하는 Runtime 전용 부분집합이다. Event Master의 `relationship_summaries`는 MEETING 후보 선정에만 사용한다.
+
+Agent Runtime의 `nearby_agents`는 다음 `AgentSummary` 필드를 사용한다.
+
+| Runtime AgentSummary 필드 | 설명 |
+| --- | --- |
+| agent_id, name, agent_type | 관찰 가능한 Agent 식별 |
+| active_status, current_location_id | 활성 상태와 현재 위치 |
+| mood, stress, fatigue | Runtime 판단용 상태 요약 |
+
+Agent Runtime의 `relationships`는 다음 `RelationshipSummary` 필드를 사용한다.
+
+| Runtime RelationshipSummary 필드 | 설명 |
+| --- | --- |
+| source_agent_id, target_agent_id | 방향성 관계의 observer와 visible Agent |
+| affection, closeness, trust | 호감도·친밀도·신뢰도 |
+| tension, rivalry, dependency | 긴장도·경쟁·의존도 |
+
+Runtime Context 가시성 규칙은 다음과 같다.
+
+- `nearby_agents`에는 observer와 같은 위치의 active Agent만 포함한다. observer 자신, 비활성 Agent, 다른 위치 Agent는 제외한다.
+- `relationships`에는 `observer → visible Agent` 방향의 관계만 포함한다.
+- Event는 observer가 participant이거나 Event 위치가 observer의 현재 위치와 같을 때 노출한다.
+- mandatory Schedule Event는 위 Event 가시성 조건과 관계없이 항상 노출한다. non-mandatory Schedule Event에는 이 예외를 적용하지 않는다.
 
 ---
 


### PR DESCRIPTION
## 작업 개요

Slice 5 통합 흐름에서 각 Agent가 실제로 관찰할 수 있는 정보만 Runtime Context에 포함하도록 Context를 분리했습니다.

또한 동일 Event 또는 Magic 효과가 여러 경로에서 전달되더라도 Policy Resolver에서 중복 적용되지 않도록 `effect_id` 기반 중복·상충 검증을 추가했습니다.

## 관련 Issue

Closes #102

Related to #101
Related to #103

## 변경 내용

* Agent별 Event, nearby Agent, 방향성 Relationship Context 필터링
* `AgentSummary`, `RelationshipSummary` 기반 typed Runtime Context 구성
* mandatory Schedule Event의 Context 포함 보장
* Agent별 관찰 가능한 `valid_agent_ids` 구성 및 hidden Agent ID 누출 방지
* Event·Agent·Relationship·valid ID의 결정적 정렬
* Runtime snapshot에서 방향성 Relationship 조회 및 전달
* Resolver 합산 전 `effect_id` 기반 중복 제거
* 동일 `effect_id`의 상충 payload에 대한 명시적 오류 처리
* Context 분리 및 효과 중복 방지 테스트 추가
* non-mandatory off-location Schedule Event 비노출
* `agent_candidates` 필수화 및 전체 `valid_agent_ids` fallback 제거
* Slice 5 문서 §3 Runtime Context 계약 구체화

## 결정 사항 및 이유

Agent Context는 다음 기준으로 구성했습니다.

* 본인이 participant인 Event
* 현재 위치가 같은 Event
* 해당 Agent의 mandatory Schedule Event
* 같은 위치의 active Agent
* 관찰 Agent에서 관찰 가능한 Agent로 향하는 Relationship

관찰 불가능한 Agent는 `nearby_agents`, `relationships`, `valid_agent_ids`뿐 아니라 실제 LLM 요청 payload에서도 제외했습니다.

효과 중복 여부는 `target`이나 `metric`이 아닌 canonical `effect_id`로 판단합니다. 서로 다른 정상 효과가 같은 상태값을 변경할 수 있으므로, 서로 다른 `effect_id`는 기존 정책대로 합산합니다.

책임 범위는 다음과 같이 분리했습니다.

* Task 1: Event/Magic 후보의 안정적인 canonical `effect_id` 생성
* Task 2: Resolver 입력에서 동일 ID 중복 및 상충 payload 검증
* Task 3: Transaction 및 DB 저장 단계의 재적용 방지

현재 Resolver가 서로 다른 효과를 합산한 결과에는 최초 `effect_id`가 유지됩니다. 합산에 참여한 전체 구성 ID를 저장해야 하는 경우 Task 3에서 provenance 저장 방식 또는 모델 확장이 필요합니다.

## 테스트 / 확인 내용

* [x] 로컬 실행 확인
* [x] 주요 기능 동작 확인
* [x] 에러 케이스 확인
* [x] 관련 문서 계약 확인
* [x] Context·Runtime·Policy 관련 회귀 테스트: 154 passed, 25 skipped
* [x] 전체 Backend 테스트: 235 passed, 55 skipped
* [x] 새 skip 추가 없음
* [x] `git diff --check` 통과
* [x] 작업 트리 clean

## AI 사용 여부

사용 여부: 사용함

사용한 작업:

* 기존 Runtime 및 Policy 구조 분석
* TDD 테스트 시나리오 작성
* Agent별 Context 필터링 구현
* `effect_id` 기반 중복·상충 검증 구현
* 관련 및 전체 회귀 테스트 실행
* 변경 사항을 기능별 두 커밋으로 분리

사람이 검토한 내용:

* Task 0 및 담당자 협의로 확정된 관찰 범위
* Task 1·Task 2·Task 3 책임 경계
* 변경 파일과 구현 범위
* 테스트 결과 및 새 skip 미추가 여부
* 커밋 분리와 작업 트리 상태

## 리뷰어가 봐야 할 부분

* Agent별 Event 및 nearby Agent 관찰 범위가 확정 계약과 일치하는지
* 방향성 Relationship이 observer → visible Agent 범위로 제한되는지
* hidden Agent ID가 Anthropic 요청 payload에 포함되지 않는지
* 동일 `effect_id` 중복 제거와 상충 payload 오류 정책이 적절한지
* Task 1의 canonical `effect_id` 생성 및 Task 3의 persistence idempotency와 연결 가능한지
