### PR TITLE
[Chore] Slice 2·3 후속 Task #151 — Feature base PR Backend E2E CI

### DIFF
--- a/.github/workflows/backend-e2e.yml
+++ b/.github/workflows/backend-e2e.yml
@@ -2,13 +2,16 @@ name: Backend E2E
 
 on:
   pull_request:
-    branches:
-      - develop
+    paths:
+      - "backend/**"
+      - "docker/**"
+      - "docker-compose.yml"
+      - ".github/workflows/backend-e2e.yml"
   workflow_dispatch:
 
 jobs:
-  slice-1-postgresql-e2e:
-    name: Slice 1 PostgreSQL E2E
+  backend-postgresql-e2e:
+    name: Backend PostgreSQL E2E
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -54,12 +57,5 @@ jobs:
       - name: Apply database migrations
         run: python -m alembic upgrade head
 
-      - name: Run Slice 1 PostgreSQL E2E and runtime regressions
-        run: >-
-          python -m pytest -q
-          tests/test_slice1_e2e.py
-          tests/test_tick_api.py
-          tests/test_slice_zero_api.py
-          tests/test_agent_runtime.py
-          tests/test_agent_runtime_graph.py
-          tests/test_runtime_orchestrator.py
+      - name: Run backend tests
+        run: python -m pytest -q tests


### PR DESCRIPTION
## 변경 사항

- Backend E2E workflow의 `develop` 대상 브랜치 제한을 제거했습니다.
- 백엔드 및 관련 인프라 파일이 변경된 PR에서만 workflow가 실행되도록 경로 필터를 추가했습니다.
- 일부 Slice 테스트만 실행하던 구성을 전체 백엔드 테스트 실행으로 변경했습니다.
- Job 이름을 현재 실행 범위에 맞게 `Backend PostgreSQL E2E`로 수정했습니다.

## 원인

PR #141처럼 기능 브랜치를 base로 사용하는 PR은 기존 `branches: [develop]` 조건에 해당하지 않아 CI/status check가 생성되지 않았습니다.

## 검증

- Workflow YAML 파싱 성공
- `git diff --check` 통과
- PostgreSQL/pgvector 환경에서 전체 백엔드 테스트: `283 passed`

Closes #151
