### PR TITLE
[Feature] Slice 3 Agent Inspector API develop 이관 (#139)

### DIFF
--- a/.github/workflows/backend-static.yml
+++ b/.github/workflows/backend-static.yml
@@ -1,0 +1,46 @@
+name: Backend Slice 3 Static Checks
+
+on:
+  pull_request:
+    paths:
+      - "backend/**/*.py"
+      - "backend/requirements*.txt"
+      - ".github/workflows/backend-static.yml"
+  workflow_dispatch:
+
+jobs:
+  slice-3-mypy:
+    name: Slice 3 Mypy
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install backend development dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Run Slice 3 Mypy checks
+        shell: bash
+        run: |
+          files=(
+            app/simulation/tick_engine.py
+            app/repositories/memory_repository.py
+            app/services/manual_tick.py
+          )
+          if [[ -f app/services/memory_adapter.py ]]; then
+            files+=(app/services/memory_adapter.py)
+          fi
+          python -m mypy "${files[@]}"

--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -1,0 +1,62 @@
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    AgentDetailResponse,
+    AgentStateDetailResponse,
+    DecisionExplanationDetailResponse,
+    MemoryResponse,
+    RelationshipResponse,
+)
+from app.core.database import get_db
+from app.core.security import require_user_role
+from app.domain.models import User
+from app.services.agents import (
+    get_agent_detail,
+    get_agent_state,
+    get_decision_explanation,
+    list_agent_memories,
+    list_agent_relationships,
+)
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+DatabaseSession = Annotated[Session, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(require_user_role)]
+
+
+@router.get("/{agent_id}", response_model=AgentDetailResponse)
+def get_detail(agent_id: UUID, db: DatabaseSession, current_user: CurrentUser):
+    return get_agent_detail(db, agent_id, current_user)
+
+
+@router.get("/{agent_id}/state", response_model=AgentStateDetailResponse)
+def get_state(agent_id: UUID, db: DatabaseSession, current_user: CurrentUser):
+    return get_agent_state(db, agent_id, current_user)
+
+
+@router.get("/{agent_id}/memories", response_model=list[MemoryResponse])
+def get_memories(
+    agent_id: UUID,
+    db: DatabaseSession,
+    current_user: CurrentUser,
+    limit: Annotated[int, Query(ge=1, le=10)] = 5,
+):
+    return list_agent_memories(db, agent_id, current_user, limit)
+
+
+@router.get("/{agent_id}/relationships", response_model=list[RelationshipResponse])
+def get_relationships(agent_id: UUID, db: DatabaseSession, current_user: CurrentUser):
+    return list_agent_relationships(db, agent_id, current_user)
+
+
+@router.get("/{agent_id}/decision-explanation", response_model=DecisionExplanationDetailResponse)
+def get_explanation(
+    agent_id: UUID,
+    db: DatabaseSession,
+    current_user: CurrentUser,
+    tick: Annotated[int, Query(ge=0)],
+):
+    return get_decision_explanation(db, agent_id, current_user, tick)

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter
 
+from app.api.agents import router as agents_router
 from app.api.auth import router as auth_router
 from app.api.simulations import router as simulations_router
 from app.api.ticks import router as ticks_router
 
 api_router = APIRouter()
 api_router.include_router(auth_router)
+api_router.include_router(agents_router)
 api_router.include_router(simulations_router)
 api_router.include_router(ticks_router)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -106,3 +106,62 @@ class AgentResponse(BaseModel):
     professor_profile: ProfessorProfileResponse | None
     state: AgentStateResponse
     location: LocationResponse
+
+
+class OrganizationResponse(BaseModel):
+    id: UUID
+    organization_type: str
+    name: str
+    membership_role: str | None
+
+
+class AgentDetailResponse(AgentResponse):
+    organizations: list[OrganizationResponse]
+
+
+class AgentStateDetailResponse(AgentStateResponse):
+    current_location: LocationResponse
+    updated_at: datetime
+
+
+class MemoryResponse(BaseModel):
+    id: UUID
+    content: str
+    memory_type: str
+    importance: int
+    created_tick: int
+    occurred_at: datetime
+    event_id: UUID | None
+
+
+class RelationshipResponse(BaseModel):
+    target_agent_id: UUID
+    target_agent_name: str
+    affection: int
+    closeness: int
+    trust: int
+    tension: int
+    rivalry: int
+    dependency: int
+    relationship_type: str | None
+    updated_at: datetime
+
+
+class DecisionAlternativeResponse(BaseModel):
+    action_type: str
+    description: str
+    relative_priority: str
+    selected: bool
+
+
+class InfluencingFactorResponse(BaseModel):
+    source: str
+    description: str
+    direction: str
+
+
+class DecisionExplanationDetailResponse(BaseModel):
+    agent_id: UUID
+    tick: int
+    alternatives: list[DecisionAlternativeResponse]
+    influencing_factors: list[InfluencingFactorResponse]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -57,4 +57,4 @@ class Settings(BaseSettings):
 
 @lru_cache
 def get_settings() -> Settings:
-    return Settings()
+    return Settings()  # type: ignore[call-arg]

--- a/backend/app/repositories/relationships.py
+++ b/backend/app/repositories/relationships.py
@@ -12,7 +12,6 @@ from app.domain.relationship_metrics import (
     RelationshipMetric,
 )
 
-
 RelationshipRow: TypeAlias = Relationship
 
 
@@ -100,11 +99,12 @@ def apply_deltas(session: Session, deltas: list[RelationshipDelta]) -> None:
             )
         related_agent_ids.update((delta.source_agent_id, delta.target_agent_id))
 
-    agent_simulation_ids = dict(
-        session.execute(
+    agent_simulation_ids: dict[UUID, UUID] = {
+        agent_id: simulation_id
+        for agent_id, simulation_id in session.execute(
             select(Agent.id, Agent.simulation_id).where(Agent.id.in_(related_agent_ids))
-        ).all()
-    )
+        )
+    }
     pending: list[tuple[Relationship, RelationshipDelta]] = []
     for delta in deltas:
         source_simulation_id = agent_simulation_ids.get(delta.source_agent_id)

--- a/backend/app/services/agents.py
+++ b/backend/app/services/agents.py
@@ -1,0 +1,200 @@
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    AgentDetailResponse,
+    AgentProfileResponse,
+    AgentResponse,
+    AgentStateDetailResponse,
+    AgentStateResponse,
+    DecisionExplanationDetailResponse,
+    LocationResponse,
+    MemoryResponse,
+    OrganizationResponse,
+    ProfessorProfileResponse,
+    RelationshipResponse,
+    StudentProfileResponse,
+)
+from app.domain.models import (
+    Agent,
+    AgentMemory,
+    AgentState,
+    Location,
+    Organization,
+    OrganizationMembership,
+    ProfessorProfile,
+    Relationship,
+    RuntimeResult,
+    Simulation,
+    StudentProfile,
+    User,
+)
+
+
+def _require_owned_agent(db: Session, agent_id: UUID, owner: User) -> Agent:
+    agent = db.get(Agent, agent_id)
+    if agent is None or agent.deleted_at is not None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+    simulation = db.get(Simulation, agent.simulation_id)
+    if simulation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+    if simulation.owner_id != owner.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Agent access denied")
+    return agent
+
+
+def _agent_response(db: Session, agent: Agent) -> AgentResponse:
+    state = db.scalar(select(AgentState).where(AgentState.agent_id == agent.id))
+    if state is None or state.location_id is None:
+        raise HTTPException(status_code=500, detail="Agent state is incomplete")
+    location = db.get(Location, state.location_id)
+    if location is None:
+        raise HTTPException(status_code=500, detail="Agent location is missing")
+    student = db.get(StudentProfile, agent.id)
+    professor = db.get(ProfessorProfile, agent.id)
+    return AgentResponse(
+        id=agent.id,
+        fixture_key=agent.fixture_key,
+        fixture_version=agent.fixture_version,
+        name=agent.name,
+        agent_type=agent.agent_type,
+        mbti_type=agent.mbti_type,
+        profile=AgentProfileResponse(
+            openness=agent.openness,
+            conscientiousness=agent.conscientiousness,
+            extraversion=agent.extraversion,
+            agreeableness=agent.agreeableness,
+            emotional_stability=agent.emotional_stability,
+        ),
+        student_profile=(
+            StudentProfileResponse(grade=student.grade, interest_field=student.interest_field)
+            if student else None
+        ),
+        professor_profile=(
+            ProfessorProfileResponse(academic_rank=professor.academic_rank, specialty=professor.specialty)
+            if professor else None
+        ),
+        state=AgentStateResponse(
+            hunger=state.hunger,
+            fatigue=state.fatigue,
+            stress=state.stress,
+            satisfaction=state.satisfaction,
+            mood=state.mood,
+            current_action=state.current_action,
+        ),
+        location=LocationResponse(id=location.id, code=location.code, name=location.name),
+    )
+
+
+def get_agent_detail(db: Session, agent_id: UUID, owner: User) -> AgentDetailResponse:
+    agent = _require_owned_agent(db, agent_id, owner)
+    base = _agent_response(db, agent)
+    memberships = db.execute(
+        select(OrganizationMembership, Organization)
+        .join(Organization, Organization.id == OrganizationMembership.organization_id)
+        .where(OrganizationMembership.agent_id == agent.id, OrganizationMembership.left_at.is_(None))
+        .order_by(Organization.organization_type, Organization.id)
+    ).all()
+    return AgentDetailResponse(
+        **base.model_dump(),
+        organizations=[
+            OrganizationResponse(
+                id=organization.id,
+                organization_type=organization.organization_type,
+                name=organization.name,
+                membership_role=membership.membership_role,
+            )
+            for membership, organization in memberships
+        ],
+    )
+
+
+def get_agent_state(db: Session, agent_id: UUID, owner: User) -> AgentStateDetailResponse:
+    agent = _require_owned_agent(db, agent_id, owner)
+    state = db.scalar(select(AgentState).where(AgentState.agent_id == agent.id))
+    if state is None or state.location_id is None:
+        raise HTTPException(status_code=500, detail="Agent state is incomplete")
+    location = db.get(Location, state.location_id)
+    if location is None:
+        raise HTTPException(status_code=500, detail="Agent location is missing")
+    return AgentStateDetailResponse(
+        hunger=state.hunger,
+        fatigue=state.fatigue,
+        stress=state.stress,
+        satisfaction=state.satisfaction,
+        mood=state.mood,
+        current_action=state.current_action,
+        current_location=LocationResponse(id=location.id, code=location.code, name=location.name),
+        updated_at=state.updated_at,
+    )
+
+
+def list_agent_memories(db: Session, agent_id: UUID, owner: User, limit: int) -> list[MemoryResponse]:
+    _require_owned_agent(db, agent_id, owner)
+    memories = db.scalars(
+        select(AgentMemory)
+        .where(AgentMemory.agent_id == agent_id)
+        .order_by(AgentMemory.occurred_at.desc(), AgentMemory.id.desc())
+        .limit(limit)
+    ).all()
+    return [
+        MemoryResponse(
+            id=item.id,
+            content=item.content,
+            memory_type=item.memory_type,
+            importance=item.importance,
+            created_tick=item.created_tick,
+            occurred_at=item.occurred_at,
+            event_id=item.event_id,
+        )
+        for item in memories
+    ]
+
+
+def list_agent_relationships(db: Session, agent_id: UUID, owner: User) -> list[RelationshipResponse]:
+    _require_owned_agent(db, agent_id, owner)
+    rows = db.execute(
+        select(Relationship, Agent)
+        .join(Agent, Agent.id == Relationship.target_agent_id)
+        .where(Relationship.source_agent_id == agent_id)
+        .order_by(Relationship.updated_at.desc(), Relationship.id.desc())
+    ).all()
+    return [
+        RelationshipResponse(
+            target_agent_id=target.id,
+            target_agent_name=target.name,
+            affection=relationship.affection,
+            closeness=relationship.closeness,
+            trust=relationship.trust,
+            tension=relationship.tension,
+            rivalry=relationship.rivalry,
+            dependency=relationship.dependency,
+            relationship_type=relationship.relationship_type,
+            updated_at=relationship.updated_at,
+        )
+        for relationship, target in rows
+    ]
+
+
+def get_decision_explanation(
+    db: Session, agent_id: UUID, owner: User, tick: int
+) -> DecisionExplanationDetailResponse:
+    _require_owned_agent(db, agent_id, owner)
+    result = db.scalar(
+        select(RuntimeResult)
+        .where(RuntimeResult.agent_id == agent_id, RuntimeResult.tick_number == tick)
+        .order_by(RuntimeResult.created_at.desc(), RuntimeResult.id.desc())
+        .limit(1)
+    )
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Decision explanation not found")
+    explanation = result.intent.get("decision_explanation", {})
+    return DecisionExplanationDetailResponse(
+        agent_id=agent_id,
+        tick=tick,
+        alternatives=explanation.get("alternatives", []),
+        influencing_factors=explanation.get("influencing_factors", []),
+    )

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -15,6 +15,7 @@ from app.simulation.agent_runtime import (
     AgentRuntime,
     AgentRuntimeResult,
     Block,
+    EventType,
     ScheduleSummary,
 )
 from app.simulation.tick_engine import (
@@ -126,7 +127,7 @@ async def advance_manual_tick(
     )
     schedule = ScheduleSummary(
         event_id=event.id,
-        schedule_type="class",
+        schedule_type=EventType.CLASS,
         is_mandatory=True,
         location_id=event.location_id,
         start_tick=current_tick,

--- a/backend/app/services/policy_commit.py
+++ b/backend/app/services/policy_commit.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
+from typing import cast
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.domain.models import Agent, AgentState, Relationship
+from app.domain.relationship_metrics import RelationshipMetric
 from app.repositories.relationships import RelationshipDelta, apply_deltas
 from app.simulation.agent_runtime import AgentRuntimeResult
 from app.simulation.policy.conflict import resolve_conflicts
@@ -111,7 +113,7 @@ def evaluate_and_apply_policy(
             RelationshipDelta(
                 source_agent_id=UUID(effect.source_agent_id),
                 target_agent_id=UUID(effect.target_agent_id),
-                metric=effect.metric,
+                metric=cast(RelationshipMetric, effect.metric),
                 before=effect.before,
                 requested_total=effect.delta,
                 applied_delta=effect.after_preview - effect.before,

--- a/backend/app/services/runtime_input_adapter.py
+++ b/backend/app/services/runtime_input_adapter.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping, Sequence
+from typing import Literal
 from uuid import UUID
 
 from app.domain.models import Agent, AgentState, Event, EventParticipant
@@ -7,19 +8,22 @@ from app.services.runtime_orchestrator import (
     RuntimeOrchestrator,
 )
 from app.simulation.agent_runtime import (
+    MBTI,
     AgentContext,
+    AgentStateContext,
+    BigFiveContext,
     Block,
     EventSummary,
+    EventType,
     ScheduleSummary,
 )
-
 
 ACTIVE_STATUS_VALUES = {
     "active": True,
     "inactive_temporary": False,
 }
 
-RUNTIME_AGENT_TYPES = {
+RUNTIME_AGENT_TYPES: dict[str, Literal["student", "professor"]] = {
     "student": "student",
     "professor": "professor",
     "user_persona": "student",
@@ -48,21 +52,21 @@ class RuntimeInputAdapter:
             fixture_key=agent.fixture_key,
             agent_type=agent_type,
             name=agent.name,
-            mbti=agent.mbti_type,
-            big_five={
-                "openness": agent.openness,
-                "conscientiousness": agent.conscientiousness,
-                "extraversion": agent.extraversion,
-                "agreeableness": agent.agreeableness,
-                "emotional_stability": agent.emotional_stability,
-            },
-            state={
-                "hunger": state.hunger,
-                "fatigue": state.fatigue,
-                "stress": state.stress,
-                "satisfaction": state.satisfaction,
-                "mood": state.mood,
-            },
+            mbti=MBTI(agent.mbti_type),
+            big_five=BigFiveContext(
+                openness=agent.openness,
+                conscientiousness=agent.conscientiousness,
+                extraversion=agent.extraversion,
+                agreeableness=agent.agreeableness,
+                emotional_stability=agent.emotional_stability,
+            ),
+            state=AgentStateContext(
+                hunger=state.hunger,
+                fatigue=state.fatigue,
+                stress=state.stress,
+                satisfaction=state.satisfaction,
+                mood=state.mood,
+            ),
             current_location_id=state.location_id,
             active_status=active_status,
         )
@@ -74,6 +78,8 @@ class RuntimeInputAdapter:
     ) -> tuple[EventSummary, ...]:
         summaries = []
         for event in events:
+            if event.location_id is None:
+                raise ValueError("Event.location_id is required for Runtime input")
             participants = event_participants.get(event.id, ())
             participant_agent_ids = []
             for participant in participants:
@@ -83,7 +89,7 @@ class RuntimeInputAdapter:
             summaries.append(
                 EventSummary(
                     event_id=event.id,
-                    event_type=event.event_type,
+                    event_type=EventType(event.event_type),
                     location_id=event.location_id,
                     participant_agent_ids=participant_agent_ids,
                     title=event.title,

--- a/backend/app/simulation/policy/engine.py
+++ b/backend/app/simulation/policy/engine.py
@@ -7,7 +7,10 @@ from app.simulation.policy.models import (
     PolicyEvaluationResult,
     PolicyStatus,
 )
-from app.simulation.policy.registries.signal_policy import get_relationship_delta, get_state_delta
+from app.simulation.policy.registries.signal_policy import (
+    get_relationship_delta,
+    get_state_delta,
+)
 
 SUPPORTED_POLICY_VERSIONS = {"policy-mvp-0.1"}
 
@@ -107,11 +110,11 @@ def evaluate_policy(inp: PolicyEvaluationInput) -> PolicyEvaluationResult:
             )
 
         state_directions: dict[str, set[int]] = {}
-        for signal in reaction.state_signals:
-            metric = STATE_SIGNAL_TO_METRIC.get(signal.signal_type)
+        for state_signal in reaction.state_signals:
+            metric = STATE_SIGNAL_TO_METRIC.get(state_signal.signal_type)
             if metric is not None:
                 state_directions.setdefault(metric, set()).add(
-                    1 if signal.signal_type.value.endswith("_UP") else -1
+                    1 if state_signal.signal_type.value.endswith("_UP") else -1
                 )
         conflicting_state_metrics = {
             metric for metric, directions in state_directions.items() if len(directions) > 1
@@ -173,35 +176,38 @@ def evaluate_policy(inp: PolicyEvaluationInput) -> PolicyEvaluationResult:
                 reason=f"{action_type}의 {signal.intensity} {signal.signal_type} 반응",
             ))
 
-        for signal in reaction.state_signals:
-            metric = STATE_SIGNAL_TO_METRIC.get(signal.signal_type)
+        for state_signal in reaction.state_signals:
+            metric = STATE_SIGNAL_TO_METRIC.get(state_signal.signal_type)
             if metric is None:
-                warnings.append(f"unknown state signal: {signal.signal_type}")
+                warnings.append(f"unknown state signal: {state_signal.signal_type}")
                 continue
             if metric in conflicting_state_metrics:
                 rejected.append({
                     "agent_id": source_agent_id,
-                    "signal_type": signal.signal_type,
+                    "signal_type": state_signal.signal_type,
                     "reason": "CONFLICTING_DUPLICATE_EFFECT",
                 })
                 has_rejection = True
                 continue
-            rule_id = f"STATE_{signal.signal_type}_{signal.intensity}"
-            effect_source_key = (
+            rule_id = f"STATE_{state_signal.signal_type}_{state_signal.intensity}"
+            state_effect_source_key = (
                 runtime_result.idempotency_key,
                 "AGENT_STATE",
                 source_agent_id,
                 metric,
                 rule_id,
             )
-            if effect_source_key in seen_effect_source_keys:
+            if state_effect_source_key in seen_effect_source_keys:
                 continue
-            seen_effect_source_keys.add(effect_source_key)
+            seen_effect_source_keys.add(state_effect_source_key)
             current = state_index.get(source_agent_id, {}).get(metric, 0)
-            delta = get_state_delta(signal.signal_type, signal.intensity)
+            delta = get_state_delta(
+                state_signal.signal_type,
+                state_signal.intensity,
+            )
             after_preview = _clamp_preview(current, delta, metric)
             effect_candidates.append(EffectCandidate(
-                effect_id=f"{inp.run_id}:{inp.tick_number}:{source_agent_id}:state:{signal.signal_type}",
+                effect_id=f"{inp.run_id}:{inp.tick_number}:{source_agent_id}:state:{state_signal.signal_type}",
                 target_type=EffectTargetType.AGENT_STATE,
                 source_agent_id=source_agent_id,
                 target_agent_id=None,
@@ -210,7 +216,7 @@ def evaluate_policy(inp: PolicyEvaluationInput) -> PolicyEvaluationResult:
                 before=current,
                 after_preview=after_preview,
                 rule_id=rule_id,
-                reason=f"{signal.intensity} {signal.signal_type} 반응",
+                reason=f"{state_signal.intensity} {state_signal.signal_type} 반응",
             ))
 
     status = PolicyStatus.PARTIAL if has_rejection else PolicyStatus.EVALUATED

--- a/backend/app/simulation/policy/models.py
+++ b/backend/app/simulation/policy/models.py
@@ -5,13 +5,17 @@ from app.domain.relationship_metrics import RELATIONSHIP_METRIC_RANGES
 from app.simulation.agent_runtime import AgentRuntimeResult
 
 METRIC_RANGE: dict[str, tuple[int, int]] = {
-    **RELATIONSHIP_METRIC_RANGES,
-    "mood": (-100, 100),
-    "hunger": (0, 100),
-    "fatigue": (0, 100),
-    "stress": (0, 100),
-    "satisfaction": (0, 100),
+    str(metric): bounds for metric, bounds in RELATIONSHIP_METRIC_RANGES.items()
 }
+METRIC_RANGE.update(
+    {
+        "mood": (-100, 100),
+        "hunger": (0, 100),
+        "fatigue": (0, 100),
+        "stress": (0, 100),
+        "satisfaction": (0, 100),
+    }
+)
 
 
 class PolicyStatus(str, Enum):

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
+mypy>=1.15.0,<3.0.0
 pytest>=8.0.0
 pytest-asyncio>=0.24.0

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -1,0 +1,179 @@
+import os
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from uuid6 import uuid7
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def client():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations, locations, agents, agent_states RESTART IDENTITY CASCADE"))
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client, session_factory
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client: TestClient, username: str) -> dict[str, str]:
+    password = "Slice23-password!"
+    assert client.post(
+        "/v1/auth/register",
+        json={"username": username, "display_name": username, "password": password},
+    ).status_code == 201
+    login = client.post("/v1/auth/login", json={"username": username, "password": password})
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def create_simulation(client: TestClient, headers: dict[str, str]) -> dict:
+    response = client.post("/v1/simulations", headers=headers, json={"name": "Slice 2-3"})
+    assert response.status_code == 201
+    return response.json()
+
+
+def test_agent_detail_state_and_query_validation(client):
+    test_client, _ = client
+    headers = register_and_login(test_client, "agent-api-owner")
+    simulation = create_simulation(test_client, headers)
+    agents = test_client.get(f"/v1/simulations/{simulation['id']}/agents", headers=headers).json()
+    agent_id = agents[0]["id"]
+
+    detail = test_client.get(f"/v1/agents/{agent_id}", headers=headers)
+    state = test_client.get(f"/v1/agents/{agent_id}/state", headers=headers)
+    invalid_limit = test_client.get(f"/v1/agents/{agent_id}/memories?limit=11", headers=headers)
+
+    assert detail.status_code == 200
+    assert detail.json()["id"] == agent_id
+    assert "organizations" in detail.json()
+    assert state.status_code == 200
+    assert state.json()["current_location"]["id"] == agents[0]["location"]["id"]
+    assert invalid_limit.status_code == 422
+
+
+def test_memory_relationship_and_decision_explanation(client):
+    from app.domain.models import AgentMemory, Relationship, RuntimeResult
+
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "inspector-owner")
+    simulation = create_simulation(test_client, headers)
+    agents = test_client.get(f"/v1/simulations/{simulation['id']}/agents", headers=headers).json()
+    source_id, target_id = UUID(agents[0]["id"]), UUID(agents[1]["id"])
+    with session_factory() as db:
+        db.add(AgentMemory(
+            id=uuid7(), agent_id=source_id, event_id=None, content="기억",
+            memory_type="observation", importance=50, created_tick=1,
+            occurred_at=datetime.now(UTC), embedding=None,
+        ))
+        db.add(Relationship(
+            id=uuid7(), simulation_id=UUID(simulation["id"]), source_agent_id=source_id,
+            target_agent_id=target_id, trust=3,
+        ))
+        db.add(RuntimeResult(
+            id=uuid7(), run_id="api-test", tick_number=1, agent_id=source_id,
+            status="PROPOSED", action_type="STUDY",
+            intent={
+                "decision_explanation": {
+                    "alternatives": [
+                        {
+                            "action_type": "STUDY",
+                            "description": "공부한다.",
+                            "relative_priority": "HIGH",
+                            "selected": True,
+                            "reasoning": "must not be exposed",
+                        }
+                    ],
+                    "influencing_factors": [],
+                    "chain_of_thought": "must not be exposed",
+                },
+                "hidden_prompt": "must not be exposed",
+                "reasoning": "must not be exposed",
+            },
+            retry_count=0, failure_reason=None, model="mock", prompt_version="test",
+            idempotency_key=f"api-test:1:{source_id}", result_fingerprint="0" * 64,
+        ))
+        db.commit()
+
+    memories = test_client.get(f"/v1/agents/{source_id}/memories", headers=headers)
+    relationships = test_client.get(f"/v1/agents/{source_id}/relationships", headers=headers)
+    explanation = test_client.get(f"/v1/agents/{source_id}/decision-explanation?tick=1", headers=headers)
+    assert memories.status_code == 200 and memories.json()[0]["content"] == "기억"
+    assert relationships.status_code == 200 and relationships.json()[0]["trust"] == 3
+    assert explanation.status_code == 200
+    assert explanation.json()["alternatives"] == [
+        {
+            "action_type": "STUDY",
+            "description": "공부한다.",
+            "relative_priority": "HIGH",
+            "selected": True,
+        }
+    ]
+    serialized = explanation.text
+    for forbidden in ("chain_of_thought", "hidden_prompt", "reasoning"):
+        assert forbidden not in serialized
+
+
+def test_other_owner_cannot_access_agent(client):
+    test_client, _ = client
+    owner_headers = register_and_login(test_client, "agent-owner")
+    other_headers = register_and_login(test_client, "agent-other")
+    simulation = create_simulation(test_client, owner_headers)
+    agent_id = test_client.get(
+        f"/v1/simulations/{simulation['id']}/agents", headers=owner_headers
+    ).json()[0]["id"]
+    paths = (
+        f"/v1/agents/{agent_id}",
+        f"/v1/agents/{agent_id}/state",
+        f"/v1/agents/{agent_id}/relationships",
+        f"/v1/agents/{agent_id}/memories",
+        f"/v1/agents/{agent_id}/decision-explanation?tick=1",
+    )
+    for path in paths:
+        assert test_client.get(path, headers=other_headers).status_code == 403
+
+    missing_id = uuid7()
+    missing_paths = (
+        f"/v1/agents/{missing_id}",
+        f"/v1/agents/{missing_id}/state",
+        f"/v1/agents/{missing_id}/relationships",
+        f"/v1/agents/{missing_id}/memories",
+        f"/v1/agents/{missing_id}/decision-explanation?tick=1",
+    )
+    for path in missing_paths:
+        assert test_client.get(path, headers=owner_headers).status_code == 404
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/memories?limit=0",
+        "/memories?limit=11",
+        "/decision-explanation?tick=-1",
+        "/decision-explanation",
+    ),
+)
+def test_agent_query_validation(client, path):
+    test_client, _ = client
+    headers = register_and_login(test_client, f"query-{abs(hash(path))}")
+    simulation = create_simulation(test_client, headers)
+    agent_id = test_client.get(
+        f"/v1/simulations/{simulation['id']}/agents", headers=headers
+    ).json()[0]["id"]
+
+    assert test_client.get(f"/v1/agents/{agent_id}{path}", headers=headers).status_code == 422

--- a/backend/tests/test_slice1_e2e.py
+++ b/backend/tests/test_slice1_e2e.py
@@ -152,9 +152,17 @@ def test_slice_one_full_vertical_flow(client):
         api_by_id = {result["agent_id"]: result for result in body["agent_results"]}
         assert set(api_by_id) == {str(result.agent_id) for result in stored}
         for result in stored:
+            assert set(result.intent["decision_explanation"]) == {
+                "alternatives",
+                "influencing_factors",
+            }
+            serialized_intent = str(result.intent)
+            for forbidden in ("chain_of_thought", "hidden_prompt", "reasoning"):
+                assert forbidden not in serialized_intent
             api_result = api_by_id[str(result.agent_id)]
             assert api_result["runtime_status"] == result.status
             assert api_result["action_type"] == result.action_type
+        inspected_agent_id = stored[0].agent_id
         simulation = db.get(Simulation, simulation_uuid)
         assert (simulation.current_tick, simulation.current_day) == (1, 1)
         assert db.scalar(select(func.count()).select_from(RuntimeResult)) == 2
@@ -163,6 +171,20 @@ def test_slice_one_full_vertical_flow(client):
         )
         assert {state.fatigue for state in states} == {17}
         assert db.scalar(select(func.count()).select_from(Relationship)) == 0
+
+    explanation = test_client.get(
+        f"/v1/agents/{inspected_agent_id}/decision-explanation?tick=1",
+        headers=headers,
+    )
+    assert explanation.status_code == 200
+    assert set(explanation.json()) == {
+        "agent_id",
+        "tick",
+        "alternatives",
+        "influencing_factors",
+    }
+    for forbidden in ("chain_of_thought", "hidden_prompt", "reasoning"):
+        assert forbidden not in explanation.text
 
 
 def test_slice_two_policy_applies_directional_relationship_delta(client, monkeypatch):


### PR DESCRIPTION
## 작업 목적

#141에 포함됐던 Slice 3 Agent Inspector API를 최신 `develop` 기준의 독립 PR로 이관하고, Slice 3 정적 검사 환경을 보강합니다.

## 변경 내용

- `GET /agents/{agent_id}`
- `GET /agents/{agent_id}/state`
- `GET /agents/{agent_id}/relationships`
- `GET /agents/{agent_id}/memories?limit=`
- `GET /agents/{agent_id}/decision-explanation?tick=`
- 5개 endpoint 소유권·404 검증
- Memory limit 및 Decision Explanation tick 경계값 검증
- 실제 Tick 실행 후 구조화 Decision Explanation DB 저장 범위 검증
- Inspector 응답에서 `chain_of_thought`, `hidden_prompt`, `reasoning` 비노출 검증
- Mypy 개발 의존성 및 Slice 3 전용 정적 검사 workflow 추가
- `tick_engine`, `memory_repository`, `manual_tick` 타입 검사와 관련 타입 오류 수정
- PR #137 병합 후 `memory_adapter.py` 자동 검사

## 제외 범위

- Slice 2 기능 변경
- Memory adapter 구현 및 ERD 마이그레이션
- UI 변경
- Backend E2E workflow 범위 변경 (#153에서 별도 진행)

## 검증

- 변경 범위 Ruff 통과
- Slice 3 Mypy 통과
- Workflow YAML 파싱 성공
- 비DB 테스트: `228 passed, 62 skipped`
- PostgreSQL/pgvector 실DB 전체 테스트: `290 passed`

Closes #139