### PR TITLE
[Test] Slice 2 signal 조합 매트릭스 보강 (#41)

### DIFF
--- a/backend/app/repositories/relationships.py
+++ b/backend/app/repositories/relationships.py
@@ -12,7 +12,6 @@ from app.domain.relationship_metrics import (
     RelationshipMetric,
 )
 
-
 RelationshipRow: TypeAlias = Relationship
 
 

--- a/backend/app/simulation/policy/engine.py
+++ b/backend/app/simulation/policy/engine.py
@@ -7,7 +7,10 @@ from app.simulation.policy.models import (
     PolicyEvaluationResult,
     PolicyStatus,
 )
-from app.simulation.policy.registries.signal_policy import get_relationship_delta, get_state_delta
+from app.simulation.policy.registries.signal_policy import (
+    get_relationship_delta,
+    get_state_delta,
+)
 
 SUPPORTED_POLICY_VERSIONS = {"policy-mvp-0.1"}
 

--- a/backend/app/simulation/policy/registries/signal_policy.py
+++ b/backend/app/simulation/policy/registries/signal_policy.py
@@ -1,4 +1,8 @@
-from app.simulation.agent_runtime import RelationshipSignalType, SignalIntensity, StateSignalType
+from app.simulation.agent_runtime import (
+    RelationshipSignalType,
+    SignalIntensity,
+    StateSignalType,
+)
 
 INTENSITY_TO_RELATIONSHIP_BASE: dict[SignalIntensity, int] = {
     SignalIntensity.LOW: 1,

--- a/backend/tests/test_slice2_policy_engine.py
+++ b/backend/tests/test_slice2_policy_engine.py
@@ -2,6 +2,7 @@
 from uuid import UUID
 
 import pytest
+
 from app.simulation.agent_runtime import (
     ActionAlternative,
     ActionType,
@@ -19,10 +20,38 @@ from app.simulation.agent_runtime import (
     StateSignalType,
 )
 
-
 AGENT_A = UUID("00000000-0000-0000-0000-00000000000a")
 AGENT_B = UUID("00000000-0000-0000-0000-00000000000b")
 AGENT_X = UUID("00000000-0000-0000-0000-00000000000f")
+
+
+RELATIONSHIP_SIGNAL_METRICS = {
+    RelationshipSignalType.TRUST_UP: "trust",
+    RelationshipSignalType.TRUST_DOWN: "trust",
+    RelationshipSignalType.TENSION_UP: "tension",
+    RelationshipSignalType.TENSION_DOWN: "tension",
+    RelationshipSignalType.AFFECTION_UP: "affection",
+    RelationshipSignalType.AFFECTION_DOWN: "affection",
+    RelationshipSignalType.CLOSENESS_UP: "closeness",
+    RelationshipSignalType.CLOSENESS_DOWN: "closeness",
+    RelationshipSignalType.RIVALRY_UP: "rivalry",
+    RelationshipSignalType.RIVALRY_DOWN: "rivalry",
+    RelationshipSignalType.DEPENDENCY_UP: "dependency",
+    RelationshipSignalType.DEPENDENCY_DOWN: "dependency",
+}
+
+STATE_SIGNAL_METRICS = {
+    StateSignalType.HUNGER_UP: "hunger",
+    StateSignalType.HUNGER_DOWN: "hunger",
+    StateSignalType.FATIGUE_UP: "fatigue",
+    StateSignalType.FATIGUE_DOWN: "fatigue",
+    StateSignalType.STRESS_UP: "stress",
+    StateSignalType.STRESS_DOWN: "stress",
+    StateSignalType.SATISFACTION_UP: "satisfaction",
+    StateSignalType.SATISFACTION_DOWN: "satisfaction",
+    StateSignalType.MOOD_UP: "mood",
+    StateSignalType.MOOD_DOWN: "mood",
+}
 
 
 # ── signal_policy ──────────────────────────────────────────────────────────────
@@ -72,6 +101,98 @@ def test_mood_down_low_returns_negative_2():
     assert get_state_delta(StateSignalType.MOOD_DOWN, SignalIntensity.LOW) == -2
 
 
+@pytest.mark.parametrize("signal_type", list(RelationshipSignalType))
+@pytest.mark.parametrize("intensity,base", [(SignalIntensity.LOW, 1), (SignalIntensity.MEDIUM, 3), (SignalIntensity.HIGH, 5)])
+def test_every_relationship_signal_and_intensity_has_signed_delta(signal_type, intensity, base):
+    from app.simulation.policy.registries.signal_policy import get_relationship_delta
+
+    delta = get_relationship_delta(signal_type, intensity)
+    expected_sign = 1 if signal_type.value.endswith("_UP") else -1
+    assert delta == expected_sign * base
+
+
+@pytest.mark.parametrize("signal_type", list(StateSignalType))
+@pytest.mark.parametrize("intensity,base", [(SignalIntensity.LOW, 2), (SignalIntensity.MEDIUM, 5), (SignalIntensity.HIGH, 8)])
+def test_every_state_signal_and_intensity_has_signed_delta(signal_type, intensity, base):
+    from app.simulation.policy.registries.signal_policy import get_state_delta
+
+    delta = get_state_delta(signal_type, intensity)
+    expected_sign = 1 if signal_type.value.endswith("_UP") else -1
+    assert delta == expected_sign * base
+
+
+@pytest.mark.parametrize("signal_type,metric", list(RELATIONSHIP_SIGNAL_METRICS.items()))
+def test_every_relationship_signal_reaches_policy_effect(signal_type, metric):
+    from app.simulation.policy.engine import evaluate_policy
+
+    result = evaluate_policy(
+        _make_eval_input(
+            [
+                _make_runtime_result(
+                    AGENT_A,
+                    AGENT_B,
+                    rel_signals=[_make_rel_signal(signal_type, SignalIntensity.MEDIUM, AGENT_B)],
+                )
+            ]
+        )
+    )
+    effects = [effect for effect in result.effect_candidates if effect.metric == metric]
+    assert len(effects) == 1
+    assert effects[0].target_agent_id == str(AGENT_B)
+
+
+@pytest.mark.parametrize("signal_type,metric", list(STATE_SIGNAL_METRICS.items()))
+def test_every_state_signal_reaches_policy_effect(signal_type, metric):
+    from app.simulation.policy.engine import evaluate_policy
+
+    result = evaluate_policy(
+        _make_eval_input(
+            [
+                _make_runtime_result(
+                    AGENT_A,
+                    None,
+                    state_signals=[StateSignal(signal_type=signal_type, intensity=SignalIntensity.MEDIUM)],
+                )
+            ]
+        )
+    )
+    effects = [effect for effect in result.effect_candidates if effect.metric == metric]
+    assert len(effects) == 1
+    assert effects[0].target_agent_id is None
+
+
+def test_relationship_and_state_signals_are_combined_in_one_policy_evaluation():
+    from app.simulation.policy.engine import evaluate_policy
+
+    result = evaluate_policy(
+        _make_eval_input(
+            [
+                _make_runtime_result(
+                    AGENT_A,
+                    AGENT_B,
+                    rel_signals=[
+                        _make_rel_signal(
+                            RelationshipSignalType.TRUST_UP,
+                            SignalIntensity.MEDIUM,
+                            AGENT_B,
+                        )
+                    ],
+                    state_signals=[
+                        StateSignal(
+                            signal_type=StateSignalType.FATIGUE_DOWN,
+                            intensity=SignalIntensity.HIGH,
+                        )
+                    ],
+                )
+            ]
+        )
+    )
+    assert {(effect.target_agent_id, effect.metric) for effect in result.effect_candidates} == {
+        (str(AGENT_B), "trust"),
+        (None, "fatigue"),
+    }
+
+
 def _make_rel_signal(signal_type, intensity, target_id):
     return RelationshipSignal(signal_type=signal_type, intensity=intensity, target_agent_id=target_id)
 
@@ -117,7 +238,11 @@ def _make_runtime_result(agent_id, target_id, rel_signals=None, state_signals=No
 # ── engine ─────────────────────────────────────────────────────────────────────
 
 def _make_eval_input(runtime_results, rel_snapshots=None, agent_snapshots=None):
-    from app.simulation.policy.models import AgentSnapshot, PolicyEvaluationInput, RelationshipSnapshot
+    from app.simulation.policy.models import (
+        AgentSnapshot,
+        PolicyEvaluationInput,
+        RelationshipSnapshot,
+    )
     return PolicyEvaluationInput(
         run_id="sim-test-1",
         tick_number=1,


### PR DESCRIPTION
## 작업 목적

Slice 2 Policy Engine의 signal 전체 조합과 통합 동작을 테스트로 고정합니다.

## 변경 내용

- 관계 signal 12종 × intensity 3종 signed delta 검증
- 상태 signal 10종 × intensity 3종 signed delta 검증
- 모든 관계 signal의 Policy effect 전달 검증
- 모든 상태 signal의 Policy effect 전달 검증
- 하나의 Runtime 결과에서 관계·상태 signal 동시 처리 검증
- Slice 2 관련 Ruff import 정리

## 검증

- Slice 2 Policy 테스트: `114 passed`
- 전체 비DB 백엔드 테스트: `317 passed, 55 skipped`
- Slice 2 관련 Ruff 통과

## 참고

Task 5 Tick Engine 통합과 Task 6 E2E는 이미 develop에 반영된 구현·테스트를 기준으로 Issue #41 완료 상태를 갱신합니다.

Closes #41