### PR TITLE
[Docs] AI 협업 가이드 3건 이관 (ai-fe-workflow, claude-session-guide, docs-structure)

### DIFF
--- a/docs/05-team-rules/ai-fe-workflow.md
+++ b/docs/05-team-rules/ai-fe-workflow.md
@@ -1,0 +1,183 @@
+---
+title: "[FE] AI-Native 개발 워크플로우 설계"
+source: confluence/AI협업/FE_AI_Native_개발_워크플로우
+canonical: https://jehye.atlassian.net/wiki/spaces/MA/pages/30277660
+status: approved
+visibility: public
+updated: 2026-08-25
+source_updated: 2026-08-17
+---
+
+# [FE] AI-Native 개발 워크플로우 설계
+
+## 0. 개요 및 목적
+
+- **목적**: AI가 스펙 기반 구현 초안을 작성하고 담당자가 검토하는 구조로, 화면 단위 FE 개발의 일관성과 속도를 확보한다.
+- **범위**: Figma 시안이 있는 화면의 FE 스펙 작성 → React 구현 → PR 머지. 디자인 생성과 백엔드 구현은 포함하지 않는다.
+
+## 1. 전체 워크플로우
+
+```
+[혜정] Figma URL 공유
+    │
+    ▼ /spec-draft 스킬 (Figma URL 입력 → FE 화면 모드 자동 전환)
+      Figma MCP + 도메인 문서 참조
+[스펙 초안 자동 생성]
+    │
+    ▼ confluence-post 스킬
+[Confluence Draft 생성]
+    │
+    ▼ [팀 전원] 검토·보완 → Publish
+[Confluence 확정 스펙]  ← 상태가 Approved일 때만 다음 단계 진행
+    │
+    ▼ [은혜] repo/docs/04-feature-specs/ 이관
+[AI 구현 → PR Draft 생성]
+    │
+    ▼ [팀 전원] 코드 리뷰
+[은혜] PR 머지
+```
+
+### 핵심 원칙
+
+1. **스펙이 source of truth** — Figma가 바뀌면 스펙부터 업데이트, 코드는 그 다음
+2. **도메인 맥락은 검토 단계에서 강제 주입** — Agent·Tick 개념은 Figma에 없으니 팀원이 스펙에 직접 명시
+3. **화면 단위 격리** — 화면 하나 = 스펙 하나 = PR 하나, 병렬 작업 가능
+4. **AI가 스펙 기반 구현 초안을 작성하고, 담당 개발자가 실행·테스트·코드 리뷰 및 최종 품질을 책임진다**
+
+## 2. 업무 분배
+
+| 단계 | 담당 | 역할 |
+| --- | --- | --- |
+| Figma URL 제공 | 혜정 | 구현할 화면의 Figma 링크 공유 |
+| 스펙 초안 생성 | AI | /spec-draft 스킬 (Figma URL 입력 → FE 화면 모드)로 자동 생성 |
+| Confluence Draft 생성 | AI | confluence-post 스킬 호출 |
+| 스펙 검토·보완 | 팀 전원 | 도메인 맥락 체크리스트 기준으로 검토 |
+| repo/docs/ 이관 | 은혜 | 확정 스펙 이관 처리 (Approved 상태 확인 후) |
+| React 구현 초안 | AI | 스펙 기반 컴포넌트 전체 작성 |
+| PR Draft 생성 | AI | PR 템플릿 기반 초안 작성 |
+| 코드 리뷰·실행 책임 | 혜정 + 팀원 | 구현 초안 실행·검증·코드 리뷰·머지 승인 |
+| PR 머지 | 은혜 | approve 확인 후 머지 |
+
+### 스펙 검토 책임 분담
+
+| 검토 영역 | 담당 |
+| --- | --- |
+| 화면·컴포넌트 구조 | FE 담당자 (혜정) |
+| API 계약 | 해당 API 담당자 |
+| 도메인 규칙 | 기능 담당자 |
+| Approved 전환 권한 | 문서 담당자 (은혜) |
+
+## 3. Claude 설정
+
+### 3-1. AGENTS.md @fe 페르소나 보강
+
+_적용 예정 — 팀 승인 후 AGENTS.md에 반영. 아래는 반영될 내용 초안이다._
+
+```
+### @fe — 공통 (4명)
+
+**주요 담당**: React + React Flow, 화면 컴포넌트, Agent 상태 표시
+
+**워크플로우**
+1. Figma URL 받기 → /spec-draft 스킬 (Figma URL 입력)로 스펙 초안 + Confluence Draft 생성
+2. 팀 검토 후 스펙 Approved → repo/docs/04-feature-specs/ 이관 확인
+3. 확정 스펙 기반으로 React 컴포넌트 구현 초안 작성 (AI가 전체 작성, 혜정이 실행·검증 책임)
+4. PR Draft 생성 → 팀 코드 리뷰 → 머지
+
+**구현 원칙**
+- 화면 하나 = 스펙 하나 = PR 하나
+- 기존 frontend/src/ 패턴 따르기 (App.jsx 구조 참조)
+- 컴포넌트는 화면 단위로 분리, props로 통신
+
+**자동 로딩 문서**
+- docs/03-system-design/
+- docs/04-feature-specs/ (FE 관련)
+- frontend/src/App.jsx (기존 패턴 참조)
+```
+
+### 3-2. /spec-draft — FE 화면 모드
+
+Figma URL을 입력하면 자동으로 FE 화면 스펙 모드로 전환된다. 상세 실행 절차는 `repo/.claude/skills/spec-draft/SKILL.md` 모드 B를 참조한다.
+
+- **입력**: Figma URL + 화면 이름 (+ FR 번호, 모르면 TBD)
+- **출력**: Confluence Draft → 팀 검토 → Approved → `docs/04-feature-specs/FR-{번호두자리}-{화면명-kebab}-screen.md` 이관
+
+### 3-3. FE 스펙 도메인 맥락 검토 체크리스트
+
+팀 검토 시 아래 항목을 모두 확인한 후 Approved로 전환한다.
+
+- [ ] Tick 기반 상태 변화가 반영됐는가 — 화면이 보여주는 상태가 어느 Tick 시점 기준인지 명시
+- [ ] Agent 상태 수치 범위가 맞는가 — docs/02-domain/ 기준 확인 (hunger, fatigue, stress 등)
+- [ ] 시뮬레이션 생성·Draft 화면이면 Magic Layer 파라미터(magic_frequency, magic_impact, Magic ON/OFF 토글)가 스펙에 포함됐는가
+- [ ] API 엔드포인트가 실제 구현된 것과 일치하는가
+- [ ] 관계 그래프 관련 화면이면 React Flow 노드/엣지 구조가 명시됐는가
+- [ ] 빈 상태 (Agent 0명, 시뮬레이션 없음 등) 처리가 정의됐는가
+- [ ] 401/403 응답 시 동작이 정의됐는가
+
+## 4. FE 스펙 문서 형식
+
+### 4-1. Confluence FE 스펙 페이지 템플릿
+
+/spec-draft 스킬 (FE 화면 모드)이 생성하는 Confluence 페이지 형식. 상세 템플릿은 `repo/.claude/skills/spec-draft/SKILL.md` 모드 B 참조.
+
+```
+> **상태**: Draft / **작성자**: @Jehye / **작성일**: YYYY-MM-DD
+
+## 0. 개요 및 목적
+## 1. 컴포넌트 트리
+## 2. State / Props
+| 이름 | 타입 | 출처 | 설명 |
+## 3. API 연동
+| Method | Endpoint | 호출 시점 | 응답 |
+## 4. 빈 상태 / 로딩 / 에러 처리
+## 5. 테스트 포인트
+- 컴포넌트 단위 테스트 (vitest/jest)
+- API mock 또는 통합 테스트
+- E2E (핵심 경로)
+- 401·403 접근 권한
+- 지원 해상도 동작 확인
+- 접근성 기준 (키보드 탐색, aria)
+- Figma 시각 비교
+- 로딩·빈 데이터·서버 오류·재시도 케이스
+## 변경 이력
+| 버전 | 날짜 | 변경 내용 | 작성자 |
+| 1.0.0 | YYYY-MM-DD | 최초 작성 | @Jehye |
+```
+
+### 4-2. repo/docs/ 이관 시 frontmatter
+
+Confluence 상태가 Approved로 전환된 후 `repo/docs/04-feature-specs/`에 이관.
+
+**파일명 규칙**: `FR-{번호두자리}-{화면명-kebab}-screen.md`
+
+예: `FR-03-user-persona-select-screen.md`, `FR-07-simulation-dashboard-screen.md`
+
+```yaml
+---
+title: "[화면명] FE 스펙"
+source: confluence/[Confluence 경로]
+canonical: https://jehye.atlassian.net/wiki/spaces/MA/pages/[pageId]/[제목]
+status: approved
+visibility: public
+updated: YYYY-MM-DD
+source_updated: YYYY-MM-DD
+---
+```
+
+## 5. 예상 소요 시간
+
+| 구분 | 시간 |
+| --- | --- |
+| 워크플로우 세팅 (AGENTS.md + /spec-draft FE 모드) | 1~1.5시간 |
+| 화면 하나 end-to-end (검토 대기 포함) | 1~2일 |
+| AI 실작업 시간 (화면 1개) | 40~70분 |
+| FE MVP 전체 (약 9개 화면) | AI 10~15시간 / 팀 2~3주 |
+
+## 변경 이력
+
+| 버전 | 날짜 | 변경 이력 | 수정자 |
+| --- | --- | --- | --- |
+| 2.2.0 | 2026-08-17 | §3-2 SKILL.md 참조 링크로 교체. §3-1 적용 예정 상태 명시. §4-1에 SKILL.md 참조 추가. | @Jehye |
+| 2.1.0 | 2026-08-17 | /fe-spec 스킬 제거, /spec-draft FE 화면 모드로 통합 | @Jehye |
+| 2.0.0 | 2026-08-17 | 리뷰 반영: "AI가 코드 전담" 표현 수정, 스펙 검토 책임 분담 표 신설, 파일명 규칙 추가, 테스트 포인트 항목 확장 | @Jehye |
+| 1.2.0 | 2026-08-12 | 최초 작성 | @Jehye |

--- a/docs/05-team-rules/claude-session-guide.md
+++ b/docs/05-team-rules/claude-session-guide.md
@@ -1,0 +1,141 @@
+---
+title: "[AI 협업] Claude 세션 협업 가이드"
+source: confluence/AI협업/Claude_세션_협업_가이드
+canonical: https://jehye.atlassian.net/wiki/spaces/MA/pages/30048328
+status: approved
+visibility: public
+updated: 2026-08-25
+source_updated: 2026-08-17
+---
+
+# [AI 협업] Claude 세션 협업 가이드
+
+Magic Academy 프로젝트에서 Claude Code를 활용하는 협업 방식을 정의한다.  
+페르소나 체계, 스킬 운용 방식, 승인 게이트, AI 네이티브 개발 워크플로우를 포함한다.
+
+## 1. 페르소나 체계 (3종)
+
+담당자가 아닌 **지금 하는 작업 유형**을 기준으로 선택한다.
+
+| 페르소나 | 쓰는 상황 | 자동 로딩 문서 |
+| --- | --- | --- |
+| `@pm` | Issue 작성, 스펙 초안, 요구사항 정리 | `docs/01-product/`, `docs/02-domain/`, `docs/04-feature-specs/`, `docs/05-team-rules/git-workflow-pr.md` |
+| `@dev` | Slice 단위 구현 (백엔드·DB·인프라) | `docs/02-domain/`, `docs/03-system-design/architecture.md`, 해당 컴포넌트 문서, 해당 Slice 스펙, 컨벤션·DoD·커밋 규칙 |
+| `@fe` | React, React Flow, 화면 컴포넌트 | `docs/02-domain/`, `docs/03-system-design/architecture.md`, `user-flow.md`, FE 관련 feature-specs, 컨벤션 |
+
+**담당 영역 보호 규칙**: 페르소나는 현재 작업 방식을 선택하는 기준이며, 문서·기능의 담당 권한을 대체하지 않는다. 담당 영역 밖의 스펙이나 구현을 변경할 때는 해당 담당자의 검토를 받는다.
+
+## 2. 세션 시작 방법
+
+1. `AGENTS.md` 읽기 — 프로젝트 규칙·도메인·코딩 원칙 확인
+2. 지금 하려는 작업 유형 파악
+3. 위 페르소나 표에서 맞는 것 선택
+4. 해당 페르소나의 자동 로딩 문서 읽기
+
+## 3. 스킬
+
+### /issue-writer
+
+- **언제**: GitHub Issue를 만들기 전
+- **방법**: 작업 내용을 설명하면 제목·본문 초안 생성 → 확인 후 `gh issue create` 실행
+- **주의**: 초안 → 사용자 승인 → 생성 순서 필수. Issue 본문은 한국어로 작성
+
+### /spec-draft
+
+- **언제**: 기능 구현 전 `docs/04-feature-specs/` 스펙 문서를 작성할 때, 또는 FE 화면 스펙을 Confluence에 올릴 때
+- **모드 A — 일반 기능 스펙**: 기능 이름·FR 번호·핵심 동작 설명 → 스펙 초안 생성 → `docs/04-feature-specs/FR-{번호}-{기능명}.md`에 직접 저장
+- **모드 B — FE 화면 스펙**: Figma URL 입력 시 자동 전환 → Figma MCP로 디자인 추출 → 스펙 초안 생성 → Confluence Draft 생성 → Approved 후 `docs/04-feature-specs/FR-{번호}-{화면명}-screen.md`에 이관
+- **주의**: 미정 항목은 `[미정]`으로 표시, 임의 확정하지 않음. 파일 작성·Confluence Draft 생성 전 초안 확인 필수
+
+### /pr-review
+
+- **언제**: PR 코드 리뷰를 작성할 때
+- **방법**: diff 분석 후 아래 태그 기반 리뷰 초안 생성 → 확인 후 GitHub에 게시
+
+| 태그 | 의미 |
+| --- | --- |
+| `[Must]` | 반드시 수정 |
+| `[Question]` | 확인 필요 |
+| `[Suggest]` | 개선 제안 |
+| `[Nit]` | 사소한 수정 |
+| `[Good]` | 좋은 구현, 유지 권장 |
+
+### /confluence-post
+
+- **언제**: 문서 초안을 Confluence에 올릴 때
+- **방법**: 문서 초안 제공 → Draft 페이지 생성 → 링크 공유 → 승인 후 Publish
+- **주의**: Publish는 Confluence UI에서 직접 버튼 클릭 (MCP 제약)
+
+### /briefing
+
+- **언제**: 기능 완료 시, 작업 방향이 바뀌었을 때, 세션이 길어졌을 때
+- **방법**: `/briefing` 입력 / **출력 형식**: Done / In progress / Next
+
+### /context-scope
+
+- **언제**: 지금 작업에 어떤 문서를 읽어야 할지 모를 때
+- **방법**: 현재 작업 유형을 설명하면 Always Load / Task-Specific / Skip 분류로 안내
+
+## 4. 주요 승인 게이트
+
+| 작업 | 절차 |
+| --- | --- |
+| git commit | staged diff 확인 → 메시지 초안 출력 → 승인 → 실행 |
+| git push | 대상 브랜치·커밋 확인 → 승인 → 실행 |
+| GitHub Issue 생성 | 초안 출력 → 승인 → `gh issue create` |
+| GitHub PR 생성 | 템플릿 기반 초안 출력 → 승인 → `gh pr create --draft` |
+| Confluence 초안 텍스트 작성 | 자동 실행 (승인 불필요) |
+| Confluence 페이지 생성 | 제목·위치·구조 확인 → 승인 → Draft 생성 |
+| Confluence Publish | Confluence UI에서 직접 클릭 (MCP 제약) |
+| PR 리뷰 코멘트 게시 | 태그 포함 초안 출력 → 승인 → 게시 |
+
+## 5. AI 네이티브 개발 워크플로우
+
+### 단계별 흐름
+
+| 단계 | 작업 | 페르소나 | 사용 스킬 | 승인 게이트 |
+| --- | --- | --- | --- | --- |
+| 기획 | 요구사항 정리, Issue 작성 | `@pm` | `/issue-writer` | 초안 → 승인 → `gh issue create` |
+| 설계 | 스펙 문서 작성 | `@pm` | `/spec-draft` | 초안 → 승인 → 파일 저장 (모드 A) 또는 Confluence Draft (모드 B) |
+| 구현 | Slice 단위 코드 작성 | `@dev` / `@fe` | — | — |
+| 커밋 | 변경사항 커밋 | — | — | staged diff 확인 → 승인 → `git commit` |
+| PR | Draft PR 생성 | — | — | 초안 → 승인 → `gh pr create --draft` |
+| 리뷰 | 코드 리뷰 작성 | — | `/pr-review` | 초안 → 승인 → GitHub 게시 |
+| 문서화 | Confluence 페이지 생성/수정 | `@pm` | `/confluence-post` | 초안 → 승인 → Draft → UI에서 Publish |
+
+### 세션 흐름 예시 (@dev 기준)
+
+1. `AGENTS.md` 읽기
+2. `@dev` 선택 → 문서 로드  
+   **[공통 — 항상]**: `docs/02-domain/`, `docs/03-system-design/architecture.md`, `conventions.md`, `definition-of-done.md`, `git-workflow-commit.md`  
+   **[Slice마다]**: 해당 컴포넌트 문서 + `docs/04-feature-specs/<해당 Slice>.md`
+3. `docs/00-start-here/what-is-pending.md` 확인
+4. 구현 (TDD: 테스트 먼저 → 구현)
+5. `/briefing` → git commit (승인 후) → git push (승인 후)
+
+### 브랜치 전략
+
+```
+main
+ └── develop
+      ├── feature/{issue번호}-{기능명}   ← 기능 추가
+      ├── fix/{issue번호}-{버그명}        ← 버그 수정
+      ├── docs/{issue번호}-{문서명}       ← 문서 작업
+      ├── refactor/{issue번호}-{대상}     ← 리팩터링
+      └── chore/{issue번호}-{대상}        ← 환경·설정
+```
+
+- 모든 브랜치는 PR을 통해 `develop`에 병합, 이후 `main`으로 병합
+- `main` 직접 push 금지
+- 브랜치 격리: git worktree 사용 (`.worktrees/<브랜치명>`)
+  - `.worktrees/`는 `.gitignore`에 등록
+  - 작업 완료 후 `git worktree remove`로 제거
+  - 상세 규칙: `docs/05-team-rules/git-workflow-commit.md` 참조
+
+## 변경 이력
+
+| 날짜 | 내용 | 수정자 |
+| --- | --- | --- |
+| 2026-08-17 | /fe-spec 스킬 제거, /spec-draft 모드 A/B 통합 반영 | @Jehye |
+| 2026-08-17 | 리뷰 반영: 담당 영역 보호 규칙 추가, /spec-draft FE 화면 스펙 구분, 승인 게이트 세분화, 브랜치 전략 확장 | @Jehye |
+| 2026-08-12 | 최초 작성 — 페르소나 3종 체계, 스킬, 워크플로우 | @Jehye |

--- a/docs/05-team-rules/docs-structure.md
+++ b/docs/05-team-rules/docs-structure.md
@@ -1,0 +1,142 @@
+---
+title: "[AI 협업] docs/ 문서 구조 가이드"
+source: confluence/AI협업/docs_문서_구조_가이드
+canonical: https://jehye.atlassian.net/wiki/spaces/MA/pages/30048346
+status: approved
+visibility: public
+updated: 2026-08-25
+source_updated: 2026-08-17
+---
+
+# [AI 협업] docs/ 문서 구조 가이드
+
+## 0. 개요 및 목적
+
+- **목적**: Magic Academy GitHub `docs/` 폴더의 구조와 각 문서의 내용 범위를 정의한다.
+- **범위**: 폴더 구조, 파일별 내용 범위 원칙, Always Load 지정 기준.
+
+`docs/`는 Confluence 원본의 AI 개발용 스냅샷이다. 각 파일 frontmatter의 `source` / `canonical`이 원본 경로다.
+
+**문서 유형별 원본 기준**
+
+| 유형 | 원본 |
+| --- | --- |
+| 제품 정의·정책·팀 결정 | Confluence |
+| AI 개발용 스냅샷 | `docs/` (본 가이드 대상) |
+| DB 마이그레이션·OpenAPI·코드·테스트 | 저장소 산출물 |
+
+불일치 발견 시 임의 선택하지 않고 원본 담당자에게 동기화 요청한다.
+
+## 1. 폴더 구조
+
+```
+docs/
+├── 00-start-here/    # AI 진입점 — 세션 시작 시 반드시 읽기
+├── 01-product/       # 제품 정의 (미이관 — Confluence 원본 참조)
+├── 02-domain/        # 핵심 도메인 모델 ← 구현 전 반드시 읽기
+├── 03-system-design/ # 아키텍처 · 컴포넌트 설계
+├── 04-feature-specs/ # 기능별 상세 스펙 (구현 직전 작성)
+├── 05-team-rules/    # 코드 컨벤션 · Git · AI 협업 규칙
+├── _meta/            # AI 환경 설계 내부 문서 (팀 비공개)
+├── decisions/        # ADR (Architecture Decision Records)
+├── superpowers/      # Claude 계획·스펙 초안 (팀 비공개)
+└── README.md         # 폴더 구조 안내
+```
+
+## 2. 00-start-here/
+
+새 세션은 이 폴더부터 시작한다. Always Load 문서는 작업 유형에 관계없이 항상 읽는다.
+
+| 파일 | 내용 범위 | 상태 | Always Load |
+| --- | --- | --- | --- |
+| `index.md` | 프로젝트 한 줄 정의, 읽기 순서, source of truth 규칙 | 이관 완료 | ✅ |
+| `what-is-decided.md` | 기술 스택·아키텍처·Agent 수·Tick 단위 등 팀 확정 사항 | 이관 완료 | ✅ |
+| `what-is-pending.md` | 임의 확정 금지 미정 항목 목록 | 이관 완료 | ✅ |
+| `context-scope.md` | 작업 유형별 파일 로드 범위 정의 (토큰 예산 포함) | 이관 완료 | — |
+| `context-quality.md` | 작업 시작 전 AI 자가 점검 체크리스트 | 이관 완료 | — |
+
+**AGENTS.md와의 역할 구분**: AGENTS.md는 페르소나·팀 규칙·도메인 개요를 담고, `00-start-here/`는 현재 확정/미정 항목 상태와 컨텍스트 범위를 보완한다. 두 곳 모두 세션 시작 시 읽되, 중복 내용은 AGENTS.md 기준을 따른다. Always Load 파일은 요약 없이 전문을 읽는다.
+
+## 3. 01-product/
+
+원본: Confluence. 미이관 항목은 Confluence에서 직접 확인한다.
+
+| 파일 | 내용 범위 | 상태 |
+| --- | --- | --- |
+| `functional-requirements.md` | PRD 핵심 기능 정의 (FR 목록) | 이관 완료 |
+| `mvp-scope.md` | MVP 범위 및 기능 우선순위 | 이관 완료 |
+
+## 4. 02-domain/
+
+구현 전 반드시 읽는다. 도메인 모델과 어긋나는 구현은 하지 않는다.
+
+| 파일 | 내용 범위 | 상태 |
+| --- | --- | --- |
+| `overview.md` | 시뮬레이션 3축(관계·조직·사건) 개요 | 이관 완료 |
+| `agents.md` | Agent 종류·역할·속성 정의 | 이관 완료 |
+| `relationships.md` | Agent 간 관계 타입·속성 정의 | 이관 완료 |
+| `events.md` | 사건 타입·트리거·효과 정의 | 이관 완료 |
+| `organizations.md` | 조직 구조·소속 관계 정의 | 이관 완료 |
+| `time-and-space.md` | Time Tick 구조, 공간·배경 정의 | 이관 완료 |
+| `glossary.md` | 프로젝트 전체 용어 통일 정의 | 이관 완료 |
+
+## 5. 03-system-design/
+
+컴포넌트 단위 설계 문서. Slice 구현 시 해당 컴포넌트 파일을 선택적으로 로드한다.
+
+| 파일 | 내용 범위 | 상태 |
+| --- | --- | --- |
+| `architecture.md` | 전체 시스템 레이어 구조, 컴포넌트 간 의존 관계 | 이관 완료 |
+| `agent-runtime.md` | Agent 실행 루프, LangGraph 노드 구조, 프롬프트 분리 설계 | 이관 완료 |
+| `tick-engine.md` | Tick 기반 시간 진행 로직, 블록 구조, 스킵 조건 | 이관 완료 |
+| `magic-layer.md` | Magic Layer Agent 설계, 감정·사건 조작 인터페이스 | 이관 완료 |
+| `security-principles.md` | LLM 입출력 보안, 공급망, Secure SDLC 원칙 (구현 상세 비공개) | 이관 완료 |
+| `infra.md` | Docker Compose 구성, 배포 환경, 운영 전략 | 이관 완료 |
+| `policy-engine.md` | 행동 정책 규칙 엔진 설계 | 이관 완료 |
+| `tech-stack.md` | 기술 스택 확정 근거 (선행조사 통합 결론) | 이관 완료 |
+| `user-flow.md` | 프론트엔드 화면 흐름, React Flow 구조 | 이관 완료 |
+
+## 6. 04-feature-specs/
+
+기능 구현 직전에 작성한다. 스펙 없이 구현 시작 금지.
+
+**파일명 형식**
+
+- 일반 기능 스펙: `FR-{번호두자리}-{기능명-kebab}.md`
+- FE 화면 스펙: `FR-{번호두자리}-{화면명-kebab}-screen.md` (화면 하나 = 스펙 하나 = PR 하나)
+
+| 파일 | 내용 범위 | 상태 |
+| --- | --- | --- |
+| `FR-13-initial-setup.md` | 초기 환경 설정 스펙 | 이관 완료 |
+| `mvp-feature-spec.md` | MVP 기능 전체 스펙 (구현 계약 수준) | 이관 완료 |
+| `FR-{번호}-{화면명}-screen.md` | FE 화면 단위 스펙 (Approved 후 이관) | 미작성 |
+
+## 7. 05-team-rules/
+
+| 파일 | 내용 범위 | 상태 |
+| --- | --- | --- |
+| `conventions.md` | 코드 스타일, 폴더 구조 컨벤션 | 이관 완료 |
+| `definition-of-done.md` | Slice 완료 기준 체크리스트 | 이관 완료 |
+| `git-workflow-commit.md` | 브랜치 전략, 커밋 메시지 컨벤션 | 이관 완료 |
+| `git-workflow-pr.md` | Issue 라벨, PR 크기·리뷰 컨벤션 | 이관 완료 |
+| `ai-usage.md` | AI 사용 가능·주의·금지 작업 정의 | 이관 완료 |
+| `claude-session-guide.md` | 페르소나 3종, 스킬, 워크플로우 | 이관 완료 |
+| `ai-fe-workflow.md` | FE AI 협업 워크플로우 | 이관 완료 |
+| `docs-structure.md` | docs/ 구조와 각 파일 범위 (본 문서) | 이관 완료 |
+
+## 8. 동기화 절차
+
+- **담당**: 은혜
+- **시점**: Confluence 문서 Approved 상태 전환 후
+- **방법**: frontmatter `source_updated`와 Confluence 최종 수정일 비교 → 다르면 재이관
+- **직접 편집 금지**: `docs/` 파일은 Confluence 원본에서만 갱신
+- **Historical 처리**: Confluence에서 Historical 전환 후 로컬 파일 제거 또는 `_archived/`로 이동
+- **충돌 시**: 임의 결정하지 않고 Confluence 작성자에게 확인
+
+## 변경 이력
+
+| 날짜 | 내용 | 수정자 |
+| --- | --- | --- |
+| 2026-08-17 | fe-spec → /spec-draft 통합 반영 | @Jehye |
+| 2026-08-17 | 리뷰 반영: 누락 폴더 구조 추가, SoT 규칙 세분화, 파일 표 상태 열 추가, FE 스펙 파일명 규칙 추가, 동기화 절차 신설 | @Jehye |
+| 2026-08-12 | 최초 작성 | @Jehye |

--- a/docs/_meta/SYNC.md
+++ b/docs/_meta/SYNC.md
@@ -219,9 +219,9 @@ source_updated: YYYY-MM-DD             # 원본 마지막 반영일 (drift 판�
 | 상태 | Confluence 문서 | 원본 상태 | 재검사 조건 |
 |------|----------------|-----------|-------------|
 | ⏸ | [Spec] 2단계 프롬프트 캐싱 구현 계약 (#31522898) | In Review | Approved 전환 후 `03-system-design/` 이관 검토 |
-| ⏸ | [FE] AI-Native 개발 워크플로우 설계 (#30277660) | Draft | Approved 전환 후 팀 규칙·기능 스펙으로 분리 검토 |
-| ⏸ | [AI 협업] docs/ 문서 구조 가이드 (#30048346) | Draft | Approved 전환 후 `docs/README.md`·`_meta/SYNC.md`와 정합성 검토 |
-| ⏸ | [AI 협업] Claude 세션 협업 가이드 (#30048328) | Draft | Approved 전환 후 현재 저장소 규칙과 정합성 검토 |
+| ✅ | [FE] AI-Native 개발 워크플로우 설계 (#30277660) | 이관 완료 | `05-team-rules/ai-fe-workflow.md` (2026-08-25) |
+| ✅ | [AI 협업] docs/ 문서 구조 가이드 (#30048346) | 이관 완료 | `05-team-rules/docs-structure.md` (2026-08-25) |
+| ✅ | [AI 협업] Claude 세션 협업 가이드 (#30048328) | 이관 완료 | `05-team-rules/claude-session-guide.md` (2026-08-25) |
 | ⏸ | 프론트 화면 구조 초안 (#7503873) | Draft | 화면별 스펙 Approved 전환 후 `04-feature-specs/` 이관 |
 | ⏸ | Magic Academy 배경 디자인 시안 (#35651585) | Draft | 디자인 확정 및 저장소 이미지 자산 경로 확보 후 이관 검토 |
 


### PR DESCRIPTION
## 작업 개요

Confluence AI 협업 가이드 3건을 `docs/05-team-rules/`에 이관했다.
기존 PR #155(Confluence 문서 이관 및 공개 범위 정리)에서 보류했던 문서 중
담당자(은혜)가 직접 처리 가능한 3건을 추가 반영한다.

## 관련 Issue

관련 Issue 없음 (PR #155 후속 이관 작업)

## 변경 내용

- `docs/05-team-rules/ai-fe-workflow.md` 신규: FE AI 협업 워크플로우
  (Figma URL → /spec-draft → Confluence → 구현 → PR 전 과정 정의)
- `docs/05-team-rules/claude-session-guide.md` 신규: Claude 세션 협업 가이드
  (페르소나 3종, 스킬 목록, 승인 게이트, 워크플로우)
- `docs/05-team-rules/docs-structure.md` 신규: docs/ 문서 구조 가이드
  (폴더별 파일 목록·상태·이관 범위 정의)
- `docs/_meta/SYNC.md`: 위 3건 ⏸ → ✅ 완료 처리

## 결정 사항 및 이유

PR #155 당시 3건이 Confluence Draft 상태라 보류했으나, 내용이 이미 완성됐고
담당자(은혜)가 실질적으로 Approved 전환 결정권을 가지므로 현 시점에 이관했다.
보류 나머지 3건(프롬프트 캐싱 In Review, 프론트/디자인 Draft는 혜정 담당)은
원본 상태 변경 후 재검사 예정.

## 테스트 / 확인 내용

- [x] 신규 파일 3개 frontmatter (title, source, canonical, status, visibility, updated, source_updated) 검증
- [x] `git diff --check` 통과
- [x] 공개 범위 검증 — 팀 규칙/워크플로우 내용만, 민감 정보 없음
- [x] SYNC.md 이관 큐 상태 업데이트 확인
- [ ] 관련 문서 업데이트 확인 (해당 없음)

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: Confluence 원본 기반 docs/ 파일 변환 및 작성, SYNC.md 업데이트
- 사람이 검토한 내용: 이관 대상 문서 선정, 공개 범위 판단, 최종 내용 확인

## 리뷰어가 봐야 할 부분

- `claude-session-guide.md` §1 페르소나 체계가 현재 AGENTS.md와 일치하는지 확인
- `docs-structure.md` §6 04-feature-specs 파일 목록이 실제 파일과 일치하는지 확인