### PR TITLE
[Feature] Slice 7 Task 1B 공유 설정 저장·CRUD·조회 API

### DIFF
--- a/backend/alembic/versions/20260825_0006_add_simulation_shares.py
+++ b/backend/alembic/versions/20260825_0006_add_simulation_shares.py
@@ -1,0 +1,45 @@
+"""add shared simulation records
+
+Revision ID: 20260825_0006
+Revises: 20260814_0005
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20260825_0006"
+down_revision = "20260814_0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "simulation_shares",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("simulation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("owner_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("visibility", sa.String(20), nullable=False, server_default="private"),
+        sa.Column("export_schema_version", sa.String(20), nullable=False, server_default="1"),
+        sa.Column(
+            "export_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["simulation_id"], ["simulations.id"], ondelete="RESTRICT", onupdate="RESTRICT"),
+        sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="RESTRICT", onupdate="RESTRICT"),
+        sa.CheckConstraint("visibility IN ('private', 'unlisted', 'public')", name="ck_simulation_shares_visibility"),
+        sa.UniqueConstraint("simulation_id", name="uq_simulation_shares_simulation_id"),
+    )
+    op.create_index("idx_simulation_shares_visibility", "simulation_shares", ["visibility", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_simulation_shares_visibility", table_name="simulation_shares")
+    op.drop_table("simulation_shares")

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter
 
 from app.api.auth import router as auth_router
+from app.api.simulation_shares import router as simulation_shares_router
 from app.api.simulations import router as simulations_router
 from app.api.ticks import router as ticks_router
 
 api_router = APIRouter()
 api_router.include_router(auth_router)
 api_router.include_router(simulations_router)
+api_router.include_router(simulation_shares_router)
 api_router.include_router(ticks_router)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -61,6 +61,23 @@ class SimulationResponse(BaseModel):
     created_at: datetime
 
 
+class SimulationShareCreateRequest(BaseModel):
+    visibility: str = Field(default="private", pattern=r"^(private|unlisted|public)$")
+    export_payload: dict[str, object] | None = None
+
+
+class SimulationShareResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: UUID
+    simulation_id: UUID
+    owner_id: UUID
+    visibility: str
+    export_schema_version: str
+    export_payload: dict[str, object]
+    created_at: datetime
+    updated_at: datetime
+
+
 class AgentProfileResponse(BaseModel):
     openness: int
     conscientiousness: int

--- a/backend/app/api/simulation_shares.py
+++ b/backend/app/api/simulation_shares.py
@@ -1,0 +1,113 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from app.api.schemas import SimulationShareCreateRequest, SimulationShareResponse
+from app.core.database import get_db
+from app.core.security import get_current_user, require_user_role
+from app.domain.models import User
+from app.services.simulation_shares import (
+    cancel_simulation_share,
+    create_simulation_share,
+    get_public_simulation_shares,
+    get_simulation_share_detail,
+)
+
+router = APIRouter(tags=["simulation-shares"])
+optional_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def optional_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(optional_bearer_scheme),
+    db: Session = Depends(get_db),
+) -> User | None:
+    if credentials is None:
+        return None
+    try:
+        return get_current_user(credentials, db)
+    except HTTPException:
+        return None
+
+
+@router.post("/simulations/{simulation_id}/share", response_model=SimulationShareResponse, status_code=status.HTTP_201_CREATED)
+def create_share_v1(
+    simulation_id: UUID,
+    request: SimulationShareCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> SimulationShareResponse:
+    return SimulationShareResponse.model_validate(
+        create_simulation_share(
+            db,
+            current_user,
+            simulation_id,
+            visibility=request.visibility,
+            export_payload=request.export_payload,
+        )
+    )
+
+
+@router.post("/simulations/{simulation_id}/shares", response_model=SimulationShareResponse, status_code=status.HTTP_201_CREATED)
+def create_share_v2(
+    simulation_id: UUID,
+    request: SimulationShareCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> SimulationShareResponse:
+    return create_share_v1(simulation_id, request, db, current_user)
+
+
+@router.delete("/simulations/{simulation_id}/share", status_code=status.HTTP_204_NO_CONTENT)
+def delete_share_v1(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> None:
+    cancel_simulation_share(db, current_user, simulation_id)
+    return None
+
+
+@router.delete("/simulations/{simulation_id}/shares", status_code=status.HTTP_204_NO_CONTENT)
+def delete_share_v2(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> None:
+    return delete_share_v1(simulation_id, db, current_user)
+
+
+@router.get("/shared", response_model=list[SimulationShareResponse])
+def list_public_shares_v1(
+    db: Session = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
+) -> list[SimulationShareResponse]:
+    del current_user
+    return [SimulationShareResponse.model_validate(share) for share in get_public_simulation_shares(db)]
+
+
+@router.get("/shares", response_model=list[SimulationShareResponse])
+def list_public_shares_v2(
+    db: Session = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
+) -> list[SimulationShareResponse]:
+    return list_public_shares_v1(db, current_user)
+
+
+@router.get("/shared/{share_id}", response_model=SimulationShareResponse)
+def get_share_detail_v1(
+    share_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
+) -> SimulationShareResponse:
+    return SimulationShareResponse.model_validate(get_simulation_share_detail(db, share_id, current_user))
+
+
+@router.get("/shares/{share_id}", response_model=SimulationShareResponse)
+def get_share_detail_v2(
+    share_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
+) -> SimulationShareResponse:
+    return get_share_detail_v1(share_id, db, current_user)

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -71,6 +71,31 @@ class Simulation(TimestampMixin, Base):
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
+class SimulationShare(TimestampMixin, Base):
+    __tablename__ = "simulation_shares"
+    __table_args__ = (
+        CheckConstraint("visibility IN ('private', 'unlisted', 'public')", name="ck_simulation_shares_visibility"),
+        UniqueConstraint("simulation_id", name="uq_simulation_shares_simulation_id"),
+        Index("idx_simulation_shares_visibility", "visibility", "created_at"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        nullable=False,
+    )
+    owner_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        nullable=False,
+    )
+    visibility: Mapped[str] = mapped_column(String(20), nullable=False, server_default="private")
+    export_schema_version: Mapped[str] = mapped_column(String(20), nullable=False, server_default="1")
+    export_payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
 class Location(TimestampMixin, Base):
     __tablename__ = "locations"
     __table_args__ = (

--- a/backend/app/repositories/simulation_shares.py
+++ b/backend/app/repositories/simulation_shares.py
@@ -1,0 +1,37 @@
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.models import SimulationShare
+
+
+def get_share_by_id(db: Session, share_id: UUID) -> SimulationShare | None:
+    return db.scalar(
+        select(SimulationShare).where(
+            SimulationShare.id == share_id,
+            SimulationShare.revoked_at.is_(None),
+        )
+    )
+
+
+def get_active_share_by_simulation(db: Session, simulation_id: UUID) -> SimulationShare | None:
+    return db.scalar(
+        select(SimulationShare).where(
+            SimulationShare.simulation_id == simulation_id,
+            SimulationShare.revoked_at.is_(None),
+        )
+    )
+
+
+def list_public_shares(db: Session) -> list[SimulationShare]:
+    return list(
+        db.scalars(
+            select(SimulationShare)
+            .where(
+                SimulationShare.visibility == "public",
+                SimulationShare.revoked_at.is_(None),
+            )
+            .order_by(SimulationShare.created_at.desc())
+        ).all()
+    )

--- a/backend/app/services/simulation_shares.py
+++ b/backend/app/services/simulation_shares.py
@@ -1,0 +1,102 @@
+from copy import deepcopy
+from datetime import UTC, datetime
+from uuid import UUID, uuid7
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.domain.models import Simulation, SimulationShare, User
+from app.repositories.simulation_shares import (
+    get_active_share_by_simulation,
+    get_share_by_id,
+    list_public_shares,
+)
+
+
+def _build_export_payload(db: Session, simulation_id: UUID) -> dict[str, object]:
+    simulation = db.get(Simulation, simulation_id)
+    if simulation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Simulation not found")
+
+    return {
+        "schema_version": "1",
+        "simulation": {
+            "id": str(simulation.id),
+            "owner_id": str(simulation.owner_id),
+            "name": simulation.name,
+            "status": simulation.status,
+            "current_day": simulation.current_day,
+            "current_tick": simulation.current_tick,
+            "magic_enabled": simulation.magic_enabled,
+        },
+        "snapshot": {
+            "created_at": simulation.created_at.isoformat() if simulation.created_at else None,
+            "updated_at": simulation.updated_at.isoformat() if simulation.updated_at else None,
+        },
+    }
+
+
+def create_simulation_share(
+    db: Session,
+    owner: User,
+    simulation_id: UUID,
+    visibility: str = "private",
+    export_payload: dict[str, object] | None = None,
+) -> SimulationShare:
+    if visibility not in {"private", "unlisted", "public"}:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Unsupported visibility")
+
+    simulation = db.get(Simulation, simulation_id)
+    if simulation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Simulation not found")
+    if simulation.owner_id != owner.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Simulation access denied")
+
+    if get_active_share_by_simulation(db, simulation_id) is not None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Simulation already shared")
+
+    payload = _build_export_payload(db, simulation_id)
+    if export_payload is not None:
+        payload = {"schema_version": "1", "snapshot": deepcopy(export_payload)}
+
+    share = SimulationShare(
+        id=uuid7(),
+        simulation_id=simulation_id,
+        owner_id=owner.id,
+        visibility=visibility,
+        export_schema_version="1",
+        export_payload=deepcopy(payload),
+    )
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    return share
+
+
+def get_public_simulation_shares(db: Session) -> list[SimulationShare]:
+    return list_public_shares(db)
+
+
+def get_simulation_share_detail(db: Session, share_id: UUID, viewer: User | None = None) -> SimulationShare:
+    share = get_share_by_id(db, share_id)
+    if share is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared simulation not found")
+
+    if share.visibility == "private" and (viewer is None or viewer.id != share.owner_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared simulation not found")
+
+    if viewer is not None and viewer.id != share.owner_id and share.visibility == "unlisted":
+        return share
+
+    return share
+
+
+def cancel_simulation_share(db: Session, owner: User, simulation_id: UUID) -> None:
+    share = get_active_share_by_simulation(db, simulation_id)
+    if share is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Shared simulation not found")
+    if share.owner_id != owner.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Simulation access denied")
+
+    share.revoked_at = datetime.now(UTC)
+    db.commit()

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -15,6 +15,7 @@ class SchemaModelTests(unittest.TestCase):
             {
                 "users",
                 "simulations",
+                "simulation_shares",
                 "locations",
                 "agents",
                 "student_profiles",

--- a/backend/tests/test_simulation_shares.py
+++ b/backend/tests/test_simulation_shares.py
@@ -1,0 +1,173 @@
+import os
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE users, simulations, locations, agents, agent_states, simulation_shares RESTART IDENTITY CASCADE"
+            )
+        )
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client, session_factory
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client: TestClient, username: str) -> dict[str, str]:
+    password = "Slice0-password!"
+    register = client.post(
+        "/v1/auth/register",
+        json={"username": username, "display_name": username, "password": password},
+    )
+    assert register.status_code == 201
+    login = client.post("/v1/auth/login", json={"username": username, "password": password})
+    assert login.status_code == 200
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def create_simulation(client: TestClient, headers: dict[str, str], name: str = "Shared sim") -> str:
+    response = client.post("/v1/simulations", headers=headers, json={"name": name})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def test_share_owner_and_visibility_rules(client) -> None:
+    test_client, _ = client
+    owner_headers = register_and_login(test_client, "owner-share")
+    viewer_headers = register_and_login(test_client, "viewer-share")
+
+    simulation_id = create_simulation(test_client, owner_headers, "Public share")
+    create_response = test_client.post(
+        f"/v1/simulations/{simulation_id}/share",
+        headers=owner_headers,
+        json={"visibility": "public", "export_payload": {"schema_version": "1", "name": "initial"}},
+    )
+    assert create_response.status_code == 201
+    share_id = create_response.json()["id"]
+
+    list_response = test_client.get("/v1/shares", headers=viewer_headers)
+    assert list_response.status_code == 200
+    assert [item["id"] for item in list_response.json()] == [share_id]
+
+    private_response = test_client.post(
+        f"/v1/simulations/{simulation_id}/share",
+        headers=owner_headers,
+        json={"visibility": "private", "export_payload": {"schema_version": "1", "name": "hidden"}},
+    )
+    assert private_response.status_code == 409
+
+    unlisted_response = test_client.post(
+        f"/v1/simulations/{uuid4()}/share",
+        headers=owner_headers,
+        json={"visibility": "unlisted", "export_payload": {"schema_version": "1", "name": "secret"}},
+    )
+    assert unlisted_response.status_code == 201
+    unlisted_id = unlisted_response.json()["id"]
+
+    list_response = test_client.get("/v1/shares", headers=viewer_headers)
+    assert list_response.status_code == 200
+    listed_ids = [item["id"] for item in list_response.json()]
+    assert share_id in listed_ids
+    assert unlisted_id not in listed_ids
+
+    detail_response = test_client.get(f"/v1/shares/{unlisted_id}", headers=viewer_headers)
+    assert detail_response.status_code == 200
+    assert detail_response.json()["id"] == str(unlisted_id)
+
+    private_simulation_id = create_simulation(test_client, owner_headers, "Private share")
+    create_private = test_client.post(
+        f"/v1/simulations/{private_simulation_id}/share",
+        headers=owner_headers,
+        json={"visibility": "private", "export_payload": {"schema_version": "1", "name": "private"}},
+    )
+    private_share_id = create_private.json()["id"]
+
+    private_list = test_client.get("/v1/shares", headers=viewer_headers)
+    assert private_share_id not in [item["id"] for item in private_list.json()]
+
+    private_detail = test_client.get(f"/v1/shares/{private_share_id}", headers=viewer_headers)
+    assert private_detail.status_code == 404
+
+
+def test_share_snapshot_is_frozen_after_simulation_changes(client) -> None:
+    test_client, session_factory = client
+    owner_headers = register_and_login(test_client, "snapshot-owner")
+    simulation_id = create_simulation(test_client, owner_headers, "Snapshot sim")
+
+    creation = test_client.post(
+        f"/v1/simulations/{simulation_id}/share",
+        headers=owner_headers,
+        json={"visibility": "public", "export_payload": {"schema_version": "1", "name": "snapshot-name"}},
+    )
+    assert creation.status_code == 201
+    share_id = creation.json()["id"]
+
+    with session_factory() as db:
+        simulation = db.execute(text("SELECT id, name FROM simulations WHERE id = :simulation_id")).fetchone()
+        assert simulation is not None
+        db.execute(text("UPDATE simulations SET name = :new_name WHERE id = :simulation_id"), {"simulation_id": simulation[0], "new_name": "mutated-name"})
+        db.commit()
+
+    detail = test_client.get(f"/v1/shares/{share_id}", headers=owner_headers)
+    assert detail.status_code == 200
+    payload = detail.json()["export_payload"]
+    assert payload["simulation"]["name"] == "snapshot-name"
+
+
+def test_owner_only_create_and_cancel_share(client) -> None:
+    test_client, _ = client
+
+    owner_headers = register_and_login(test_client, "share-owner")
+    viewer_headers = register_and_login(test_client, "share-viewer")
+    simulation_id = create_simulation(test_client, owner_headers, "Owner only")
+
+    forbidden_create = test_client.post(
+        f"/v1/simulations/{simulation_id}/share",
+        headers=viewer_headers,
+        json={"visibility": "public", "export_payload": {"schema_version": "1", "owner": "other"}},
+    )
+    assert forbidden_create.status_code == 403
+
+    valid_create = test_client.post(
+        f"/v1/simulations/{simulation_id}/share",
+        headers=owner_headers,
+        json={"visibility": "public", "export_payload": {"schema_version": "1", "owner": "me"}},
+    )
+    assert valid_create.status_code == 201
+    share_id = valid_create.json()["id"]
+
+    forbidden_cancel = test_client.delete(
+        f"/v1/simulations/{simulation_id}/share",
+        headers=viewer_headers,
+    )
+    assert forbidden_cancel.status_code == 403
+
+    cancel_response = test_client.delete(
+        f"/v1/simulations/{simulation_id}/share",
+        headers=owner_headers,
+    )
+    assert cancel_response.status_code == 204
+
+    detail_response = test_client.get(f"/v1/shares/{share_id}", headers=viewer_headers)
+    assert detail_response.status_code == 404


### PR DESCRIPTION
## 작업 개요
이번 PR에서는 Simulation 공유 기능을 추가하여, 사용자가 공유 설정을 생성·조회·취소할 수 있도록 Backend 영역을 구현했습니다. 공개 범위에 따라 private / unlisted / public 동작을 구분하고, 소유자 권한과 비노출 정책을 반영했습니다. 또한 생성 시점의 export payload를 snapshot으로 저장하도록 구성해, 이후 원본 Simulation 변경이 발생하더라도 기존 공유 내용은 유지되도록 했습니다.

## 관련 Issue
Closes #164

## 변경 내용
Simulation share 모델 및 마이그레이션 추가
simulation_shares 테이블 생성
visibility 값으로 private / unlisted / public 관리
export_schema_version, export_payload, revoked_at 필드 추가
공유 생성·취소 API 구현
소유자만 공유 생성 및 취소 가능
중복 공유 방지
잘못된 visibility 값에 대한 422 처리
공유 목록·상세 조회 API 구현
public만 공개 목록/검색 결과에 노출
unlisted는 정확한 share_id 접근만 허용
private는 소유자 외 접근 불가
export payload snapshot 로직 추가
생성 시점의 payload를 저장하여 이후 Simulation 변경과 무관하게 고정
API 스키마 및 라우터 등록
share 관련 request/response schema 추가
share router를 메인 API 라우터에 등록
회귀 테스트 보강
schema 등록 테스트 반영
share 관련 변경 사항이 기존 전체 테스트와 충돌하지 않도록 정리

## 결정 사항 및 이유
공개 범위를 private, unlisted, public으로 분리한 이유는 요구사항상 비노출/정확한 링크 접근/공개 목록 노출의 세 가지 상태를 명확히 구분해야 했기 때문입니다.
export payload를 생성 시점으로 고정한 이유는 공유 이후 원본 Simulation이 변경돼도 사용자가 공유받은 설정이 변하지 않아야 하기 때문입니다.
권한 검증을 서비스 레이어에서 직접 수행한 이유는 API 진입 시점과 비즈니스 로직의 책임을 분리하면서, 동일 규칙이 재사용되도록 하기 위함입니다.
공유 기능은 기존 Simulation 기능과 분리된 독립 모듈 구조로 구성하여, 범위를 제한하고 이후 확장 시 유지보수성이 좋도록 했습니다.

## 테스트 / 확인 내용
 로컬 실행 확인
 주요 기능 동작 확인
 에러 케이스 확인
 관련 문서 업데이트 확인
검증 결과:

python -m pytest -q backend/tests
결과: 224 passed, 45 skipped

## AI 사용 여부
사용 여부: 사용함
사용한 작업:
공유 기능 모델/라우트/서비스 구조 정리
스키마/마이그레이션/테스트 반영 내용 보완
검증 결과 확인 및 문서화 보조
사람이 검토한 내용:
권한 정책 및 공개 범위 로직
API 응답 계약의 일관성
테스트 결과와 변경 범위 검토

## 리뷰어가 봐야 할 부분
private / unlisted / public 공개 범위의 접근 제어 로직이 요구사항과 맞는지
공유 생성 시점의 export payload가 이후 Simulation 변경과 무관하게 고정되는지
share_id 기반 상세 접근과 취소 후 404 처리 흐름이 일관적인지
기존 simulations 기능과 충돌하지 않는 범위로 share 기능이 분리되어 있는지