### PR TITLE
[Test] Slice 6 Task 2 — Replay·시점 복원 인수 테스트 (#119)

### DIFF
--- a/backend/tests/test_slice6_acceptance.py
+++ b/backend/tests/test_slice6_acceptance.py
@@ -1,39 +1,17 @@
-"""
-Slice 6 인수 조건 — Replay·시점 복원
+"""Slice 6 사용자 관점 HTTP 인수 테스트."""
 
-완료 기준:
-- 저장된 설정·Snapshot을 기준으로 Replay 시나리오가 통과한다.
-- Snapshot을 식별자와 시점으로 조회할 수 있다.
-- 시점 복원은 원본 DB를 수정하지 않고 payload를 반환한다.
-- Replay payload의 runtime_results는 원본 기록 순서와 일치한다.
-- 복원 불가·기록 없음·권한 오류 상태를 명시적 예외로 처리한다.
-- Slice 0~5 누적 회귀 기준이 통과한다.
-"""
 import os
-import subprocess
+from uuid import UUID, uuid4
 
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, func, select, text
 from sqlalchemy.orm import sessionmaker
-
-from app.domain.models import (
-    Agent,
-    AgentState,
-    RuntimeResult,
-    Simulation,
-    SimulationSnapshot,
-    User,
-)
-from app.repositories.simulation_snapshots import SimulationSnapshotRepository
-from app.services.fixtures import seed_slice_zero
-from app.services.simulation_snapshots import (
-    SimulationConfigInput,
-    SimulationSnapshotService,
-    SnapshotAccessDeniedError,
-    SnapshotNotFoundError,
-    UnsupportedSnapshotSchemaError,
-)
 from uuid6 import uuid7
+
+from app.domain.models import Agent, Event, RuntimeResult, Simulation, SimulationSnapshot
+from app.services.simulation_snapshots import SimulationSnapshotService
+from app.simulation.instrumentation import get_counts, reset_counters
 
 
 TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
@@ -44,6 +22,9 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture()
 def acceptance_context():
+    from app.core.database import get_db
+    from app.main import app
+
     engine = create_engine(TEST_DATABASE_URL)
     session_factory = sessionmaker(
         bind=engine, autoflush=False, expire_on_commit=False
@@ -51,265 +32,236 @@ def acceptance_context():
     with engine.begin() as connection:
         connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
 
-    owner_id = uuid7()
-    simulation_id = uuid7()
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client, session_factory
+    app.dependency_overrides.clear()
+    engine.dispose()
+
+
+def _register(client: TestClient, username: str) -> dict[str, str]:
+    password = "Slice6-acceptance!"
+    response = client.post(
+        "/v1/auth/register",
+        json={"username": username, "display_name": username, "password": password},
+    )
+    assert response.status_code == 201
+    response = client.post(
+        "/v1/auth/login", json={"username": username, "password": password}
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _create_simulation(
+    client: TestClient, headers: dict[str, str], name: str
+) -> UUID:
+    response = client.post("/v1/simulations", headers=headers, json={"name": name})
+    assert response.status_code == 201
+    return UUID(response.json()["id"])
+
+
+def _database_state(session_factory, simulation_id: UUID) -> dict[str, int]:
+    with session_factory() as session:
+        return {
+            "simulations": session.scalar(select(func.count()).select_from(Simulation)),
+            "runtime_results": session.scalar(
+                select(func.count()).select_from(RuntimeResult)
+            ),
+            "snapshots": session.scalar(
+                select(func.count()).select_from(SimulationSnapshot)
+            ),
+            "events": session.scalar(select(func.count()).select_from(Event)),
+            "current_tick": session.get(Simulation, simulation_id).current_tick,
+        }
+
+
+def _persist_recorded_tick(
+    session_factory, simulation_id: UUID
+) -> tuple[list[UUID], UUID]:
+    result_ids: list[UUID] = []
     with session_factory.begin() as session:
-        session.add(
-            User(
-                id=owner_id,
-                username="slice6-acceptance",
-                display_name="Slice 6 Acceptance",
-                password_hash="not-a-real-password-hash",
-                roles=["USER"],
+        simulation = session.get(Simulation, simulation_id)
+        simulation.current_tick = 1
+        for sequence, fixture_key in enumerate(("student-02", "student-01")):
+            agent_id = session.scalar(
+                select(Agent.id).where(
+                    Agent.simulation_id == simulation_id,
+                    Agent.fixture_key == fixture_key,
+                )
             )
-        )
-        session.flush()
-        session.add(
-            Simulation(
-                id=simulation_id,
-                owner_id=owner_id,
-                name="Slice 6 Replay Source",
-            )
-        )
-        session.flush()
-        seed_slice_zero(session, simulation_id)
-    try:
-        yield session_factory, owner_id, simulation_id
-    finally:
-        engine.dispose()
-
-
-# ── Replay 대표 시나리오 ───────────────────────────────────────────────────────
-
-
-def test_replay_returns_runtime_results_in_recorded_order(acceptance_context) -> None:
-    """Replay payload의 runtime_results는 tick_number·created_at·id 순으로 원본 기록과 일치한다."""
-    session_factory, owner_id, simulation_id = acceptance_context
-    service = SimulationSnapshotService()
-
-    with session_factory.begin() as session:
-        agent_id = session.scalar(
-            select(Agent.id).where(
-                Agent.simulation_id == simulation_id,
-                Agent.fixture_key == "student-01",
-            )
-        )
-        for tick, run_id in enumerate(["run-a", "run-b", "run-c"]):
+            result_id = uuid7()
+            result_ids.append(result_id)
             session.add(
                 RuntimeResult(
-                    id=uuid7(),
-                    run_id=run_id,
-                    tick_number=tick,
+                    id=result_id,
+                    run_id=f"slice6-acceptance-run:{simulation_id}",
+                    tick_number=1,
                     agent_id=agent_id,
                     status="PROPOSED",
                     action_type="IDLE",
-                    intent={},
+                    intent={"recorded_sequence": sequence},
                     retry_count=0,
-                    model="test-model",
-                    prompt_version="test-prompt-v1",
-                    idempotency_key=f"{run_id}:{tick}:student-01",
-                    result_fingerprint="a" * 64,
+                    model="acceptance-model",
+                    prompt_version="acceptance-v1",
+                    idempotency_key=f"slice6-acceptance:{simulation_id}:1:{fixture_key}",
+                    result_fingerprint=(str(sequence + 1) * 64)[:64],
                 )
             )
-        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
+        session.flush()
+        snapshot = SimulationSnapshotService().create_snapshot(session, simulation)
         snapshot_id = snapshot.id
-
-    with session_factory() as session:
-        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
-
-    run_ids = [row["run_id"] for row in restored["runtime_results"]]
-    tick_numbers = [row["tick_number"] for row in restored["runtime_results"]]
-    assert run_ids == ["run-a", "run-b", "run-c"]
-    assert tick_numbers == [0, 1, 2]
+    return result_ids, snapshot_id
 
 
-def test_replay_with_no_runtime_results_returns_empty_list(acceptance_context) -> None:
-    """실행 기록이 없는 Simulation의 Replay는 빈 runtime_results를 반환한다."""
-    session_factory, owner_id, simulation_id = acceptance_context
-    service = SimulationSnapshotService()
+def test_settings_snapshot_replay_restore_http_golden_path(acceptance_context) -> None:
+    client, session_factory = acceptance_context
+    owner_headers = _register(client, "slice6-acceptance-owner")
+    other_headers = _register(client, "slice6-acceptance-other")
+    simulation_id = _create_simulation(client, owner_headers, "Slice 6 Golden Path")
 
-    with session_factory.begin() as session:
-        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
-        snapshot_id = snapshot.id
-
-    with session_factory() as session:
-        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
-
-    assert restored["runtime_results"] == []
-
-
-# ── 설정 저장 후 Replay 시나리오 ─────────────────────────────────────────────
-
-
-def test_replay_snapshot_includes_saved_config(acceptance_context) -> None:
-    """설정 저장 후 생성된 Snapshot은 config 정보를 payload에 포함한다."""
-    session_factory, owner_id, simulation_id = acceptance_context
-    service = SimulationSnapshotService()
-
-    with session_factory.begin() as session:
-        simulation = session.get(Simulation, simulation_id)
-        service.save_config(
-            session,
-            simulation,
-            SimulationConfigInput("high", "low", True, {"agent_id": "student-02"}),
-        )
-        snapshot = service.create_snapshot(session, simulation)
-        snapshot_id = snapshot.id
-
-    with session_factory() as session:
-        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
-
-    assert restored["config"]["event_frequency"] == "high"
-    assert restored["config"]["event_impact"] == "low"
-    assert restored["config"]["magic_enabled"] is True
-    assert restored["config"]["user_persona_settings"] == {"agent_id": "student-02"}
-
-
-# ── Snapshot 조회 시나리오 ───────────────────────────────────────────────────
-
-
-def test_snapshot_query_by_tick_number_returns_correct_snapshot(acceptance_context) -> None:
-    """tick_number로 Snapshot을 조회하면 해당 시점의 Snapshot이 반환된다."""
-    session_factory, _, simulation_id = acceptance_context
-    service = SimulationSnapshotService()
-    repo = SimulationSnapshotRepository()
-
-    with session_factory.begin() as session:
-        simulation = session.get(Simulation, simulation_id)
-        snapshot = service.create_snapshot(session, simulation)
-        snapshot_id = snapshot.id
-        tick = simulation.current_tick
-
-    with session_factory() as session:
-        found = repo.get_at_tick(session, simulation_id, tick)
-        assert found is not None
-        assert found.id == snapshot_id
-        assert found.tick_number == tick
-
-
-def test_snapshot_query_for_missing_tick_returns_none(acceptance_context) -> None:
-    """기록이 없는 tick의 Snapshot 조회는 None을 반환한다."""
-    session_factory, _, simulation_id = acceptance_context
-    repo = SimulationSnapshotRepository()
-
-    with session_factory() as session:
-        assert repo.get_at_tick(session, simulation_id, 999) is None
-
-
-# ── 지정 시점 복원 시나리오 ─────────────────────────────────────────────────
-
-
-def test_restore_at_specified_tick_returns_agent_states(acceptance_context) -> None:
-    """지정 시점 복원은 해당 시점의 에이전트 상태를 반환한다."""
-    session_factory, owner_id, simulation_id = acceptance_context
-    service = SimulationSnapshotService()
-
-    with session_factory.begin() as session:
-        source_state = session.scalar(
-            select(AgentState)
-            .join(Agent, Agent.id == AgentState.agent_id)
-            .where(
-                Agent.fixture_key == "student-01",
-                Agent.simulation_id == simulation_id,
-            )
-        )
-        source_state.stress = 42
-        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
-        snapshot_id = snapshot.id
-
-    with session_factory() as session:
-        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
-
-    target_agent_id = next(
-        a["id"] for a in restored["agents"] if a["fixture_key"] == "student-01"
+    saved = client.put(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "high",
+            "event_impact": "low",
+            "magic_enabled": False,
+        },
     )
-    restored_state = next(
-        s for s in restored["agent_states"] if s["agent_id"] == target_agent_id
+    assert saved.status_code == 200
+    assert saved.json()["data"]["config_version"] == 2
+
+    invalid = client.patch(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={"event_frequency": "invalid", "event_impact": "medium"},
     )
-    assert restored_state["stress"] == 42
-    assert restored["simulation"]["id"] == str(simulation_id)
-
-
-def test_restore_does_not_write_to_database(acceptance_context) -> None:
-    """시점 복원은 DB에 새로운 레코드를 기록하지 않는다."""
-    session_factory, owner_id, simulation_id = acceptance_context
-    service = SimulationSnapshotService()
+    assert invalid.status_code == 400
+    assert invalid.json()["error"]["code"] == "INVALID_REPLAY_REQUEST"
 
     with session_factory.begin() as session:
-        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
-        snapshot_id = snapshot.id
+        session.get(Simulation, simulation_id).status = "running"
+    locked = client.put(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "medium",
+            "event_impact": "medium",
+            "magic_enabled": True,
+        },
+    )
+    assert locked.status_code == 409
+    assert locked.json()["error"]["code"] == "INITIAL_SETTINGS_LOCKED"
 
-    with session_factory() as session:
-        sim_count_before = session.scalar(select(func.count()).select_from(Simulation))
+    runtime_result_ids, snapshot_id = _persist_recorded_tick(
+        session_factory, simulation_id
+    )
+    state_before = _database_state(session_factory, simulation_id)
 
-    with session_factory() as session:
-        service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
-        assert not session.new
-        assert not session.dirty
-        assert not session.deleted
+    snapshot = client.get(
+        f"/v1/simulations/{simulation_id}/snapshots/1", headers=owner_headers
+    )
+    assert snapshot.status_code == 200
+    snapshot_data = snapshot.json()["data"]
+    assert snapshot_data["snapshot_id"] == str(snapshot_id)
+    assert snapshot_data["tick_number"] == 1
+    assert snapshot_data["config"]["event_frequency"] == "high"
+    assert snapshot_data["config"]["event_impact"] == "low"
+    assert snapshot_data["config"]["magic_enabled"] is False
 
-    with session_factory() as session:
-        assert session.scalar(select(func.count()).select_from(Simulation)) == sim_count_before
+    missing_snapshot = client.get(
+        f"/v1/simulations/{simulation_id}/snapshots/999", headers=owner_headers
+    )
+    assert missing_snapshot.status_code == 404
+    denied_snapshot = client.get(
+        f"/v1/simulations/{simulation_id}/snapshots/1", headers=other_headers
+    )
+    assert denied_snapshot.status_code == 403
 
+    reset_counters()
+    replay_list = client.get(
+        f"/v1/simulations/{simulation_id}/replay", headers=owner_headers
+    )
+    assert replay_list.status_code == 200
+    assert [row["tick_number"] for row in replay_list.json()["data"]] == [0, 1]
 
-# ── 복원 불가·오류 시나리오 ─────────────────────────────────────────────────
-
-
-def test_restore_rejects_nonexistent_snapshot_id(acceptance_context) -> None:
-    """존재하지 않는 Snapshot ID로 복원 시도 시 SnapshotNotFoundError가 발생한다."""
-    session_factory, owner_id, _ = acceptance_context
-    service = SimulationSnapshotService()
-
-    with session_factory() as session:
-        with pytest.raises(SnapshotNotFoundError):
-            service.restore_snapshot(session, uuid7(), owner_id=owner_id)
-
-
-def test_restore_rejects_unauthorized_owner(acceptance_context) -> None:
-    """소유자가 아닌 사용자의 복원 시도는 SnapshotAccessDeniedError를 발생시킨다."""
-    session_factory, _, simulation_id = acceptance_context
-    service = SimulationSnapshotService()
-
-    with session_factory.begin() as session:
-        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
-        snapshot_id = snapshot.id
-
-    with session_factory() as session:
-        with pytest.raises(SnapshotAccessDeniedError):
-            service.restore_snapshot(session, snapshot_id, owner_id=uuid7())
-
-
-def test_restore_rejects_unsupported_schema_version(acceptance_context) -> None:
-    """지원하지 않는 schema_version의 Snapshot 복원은 UnsupportedSnapshotSchemaError를 발생시킨다."""
-    session_factory, owner_id, simulation_id = acceptance_context
-    service = SimulationSnapshotService()
-
-    with session_factory.begin() as session:
-        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
-        snapshot.payload = {**snapshot.payload, "schema_version": "legacy-v0"}
-        snapshot_id = snapshot.id
-
-    with session_factory() as session:
-        with pytest.raises(UnsupportedSnapshotSchemaError, match="unsupported snapshot schema"):
-            service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
-
-
-# ── Slice 0~5 누적 회귀 기준 ─────────────────────────────────────────────────
-
-
-def test_slice_0_to_5_regression_baseline_passes() -> None:
-    """Slice 0~5 인수·계약 테스트가 Slice 6 base 위에서 모두 통과한다."""
-    slice_test_files = [
-        "tests/test_slice0_acceptance.py",
-        "tests/test_slice1_acceptance.py",
-        "tests/test_slice2_policy_engine.py",
-        "tests/test_slice3_acceptance.py",
+    replay_detail = client.get(
+        f"/v1/simulations/{simulation_id}/replay/1", headers=owner_headers
+    )
+    assert replay_detail.status_code == 200
+    replay_data = replay_detail.json()["data"]
+    assert replay_data["snapshot_id"] == str(snapshot_id)
+    assert replay_data["tick_number"] == 1
+    assert [row["id"] for row in replay_data["runtime_results"]] == [
+        str(result_id) for result_id in runtime_result_ids
     ]
-    result = subprocess.run(
-        ["python", "-m", "pytest", "-q", "--tb=short", *slice_test_files],
-        capture_output=True,
-        text=True,
+    assert [row["run_id"] for row in replay_data["runtime_results"]] == [
+        f"slice6-acceptance-run:{simulation_id}",
+        f"slice6-acceptance-run:{simulation_id}",
+    ]
+    assert [row["tick_number"] for row in replay_data["runtime_results"]] == [1, 1]
+    assert len({row["agent_id"] for row in replay_data["runtime_results"]}) == 2
+    assert get_counts() == {"tick_calls": 0, "runtime_calls": 0, "llm_calls": 0}
+
+    restored = client.post(
+        f"/v1/simulations/{simulation_id}/restore",
+        headers=owner_headers,
+        json={"snapshot_id": str(snapshot_id)},
     )
-    assert result.returncode == 0, (
-        f"Slice 0~5 회귀 실패:\n{result.stdout}\n{result.stderr}"
+    assert restored.status_code == 200
+    assert restored.json()["data"]["simulation"]["id"] == str(simulation_id)
+    assert _database_state(session_factory, simulation_id) == state_before
+
+
+def test_http_auth_ownership_and_restore_errors(acceptance_context) -> None:
+    client, session_factory = acceptance_context
+    owner_headers = _register(client, "slice6-errors-owner")
+    other_headers = _register(client, "slice6-errors-other")
+    simulation_id = _create_simulation(client, owner_headers, "Error source")
+    other_simulation_id = _create_simulation(client, owner_headers, "Mismatch source")
+    _, snapshot_id = _persist_recorded_tick(session_factory, simulation_id)
+    _, other_snapshot_id = _persist_recorded_tick(session_factory, other_simulation_id)
+
+    unauthenticated = client.get(f"/v1/simulations/{simulation_id}/replay")
+    assert unauthenticated.status_code == 401
+    assert unauthenticated.json()["error"]["code"] == "AUTHENTICATION_REQUIRED"
+
+    denied = client.get(
+        f"/v1/simulations/{simulation_id}/replay", headers=other_headers
     )
+    assert denied.status_code == 403
+    assert denied.json()["error"]["code"] == "SIMULATION_ACCESS_DENIED"
+
+    missing = client.get(
+        f"/v1/simulations/{uuid4()}/replay", headers=owner_headers
+    )
+    assert missing.status_code == 404
+    assert missing.json()["error"]["code"] == "REPLAY_RESOURCE_NOT_FOUND"
+
+    mismatch = client.post(
+        f"/v1/simulations/{simulation_id}/restore",
+        headers=owner_headers,
+        json={"snapshot_id": str(other_snapshot_id)},
+    )
+    assert mismatch.status_code == 409
+    assert mismatch.json()["error"]["code"] == "SNAPSHOT_MISMATCH"
+
+    state_before = _database_state(session_factory, simulation_id)
+    with session_factory.begin() as session:
+        stored = session.get(SimulationSnapshot, snapshot_id)
+        stored.payload = {**stored.payload, "schema_version": "unsupported"}
+    state_after_fixture_change = _database_state(session_factory, simulation_id)
+    unsupported = client.post(
+        f"/v1/simulations/{simulation_id}/restore",
+        headers=owner_headers,
+        json={"snapshot_id": str(snapshot_id)},
+    )
+    assert unsupported.status_code == 409
+    assert unsupported.json()["error"]["code"] == "UNSUPPORTED_SNAPSHOT_SCHEMA"
+    assert _database_state(session_factory, simulation_id) == state_after_fixture_change
+    assert state_after_fixture_change == state_before

--- a/backend/tests/test_slice6_acceptance.py
+++ b/backend/tests/test_slice6_acceptance.py
@@ -1,0 +1,315 @@
+"""
+Slice 6 인수 조건 — Replay·시점 복원
+
+완료 기준:
+- 저장된 설정·Snapshot을 기준으로 Replay 시나리오가 통과한다.
+- Snapshot을 식별자와 시점으로 조회할 수 있다.
+- 시점 복원은 원본 DB를 수정하지 않고 payload를 반환한다.
+- Replay payload의 runtime_results는 원본 기록 순서와 일치한다.
+- 복원 불가·기록 없음·권한 오류 상태를 명시적 예외로 처리한다.
+- Slice 0~5 누적 회귀 기준이 통과한다.
+"""
+import os
+import subprocess
+
+import pytest
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.orm import sessionmaker
+
+from app.domain.models import (
+    Agent,
+    AgentState,
+    RuntimeResult,
+    Simulation,
+    SimulationSnapshot,
+    User,
+)
+from app.repositories.simulation_snapshots import SimulationSnapshotRepository
+from app.services.fixtures import seed_slice_zero
+from app.services.simulation_snapshots import (
+    SimulationConfigInput,
+    SimulationSnapshotService,
+    SnapshotAccessDeniedError,
+    SnapshotNotFoundError,
+    UnsupportedSnapshotSchemaError,
+)
+from uuid6 import uuid7
+
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required"
+)
+
+
+@pytest.fixture()
+def acceptance_context():
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
+
+    owner_id = uuid7()
+    simulation_id = uuid7()
+    with session_factory.begin() as session:
+        session.add(
+            User(
+                id=owner_id,
+                username="slice6-acceptance",
+                display_name="Slice 6 Acceptance",
+                password_hash="not-a-real-password-hash",
+                roles=["USER"],
+            )
+        )
+        session.flush()
+        session.add(
+            Simulation(
+                id=simulation_id,
+                owner_id=owner_id,
+                name="Slice 6 Replay Source",
+            )
+        )
+        session.flush()
+        seed_slice_zero(session, simulation_id)
+    try:
+        yield session_factory, owner_id, simulation_id
+    finally:
+        engine.dispose()
+
+
+# ── Replay 대표 시나리오 ───────────────────────────────────────────────────────
+
+
+def test_replay_returns_runtime_results_in_recorded_order(acceptance_context) -> None:
+    """Replay payload의 runtime_results는 tick_number·created_at·id 순으로 원본 기록과 일치한다."""
+    session_factory, owner_id, simulation_id = acceptance_context
+    service = SimulationSnapshotService()
+
+    with session_factory.begin() as session:
+        agent_id = session.scalar(
+            select(Agent.id).where(
+                Agent.simulation_id == simulation_id,
+                Agent.fixture_key == "student-01",
+            )
+        )
+        for tick, run_id in enumerate(["run-a", "run-b", "run-c"]):
+            session.add(
+                RuntimeResult(
+                    id=uuid7(),
+                    run_id=run_id,
+                    tick_number=tick,
+                    agent_id=agent_id,
+                    status="PROPOSED",
+                    action_type="IDLE",
+                    intent={},
+                    retry_count=0,
+                    model="test-model",
+                    prompt_version="test-prompt-v1",
+                    idempotency_key=f"{run_id}:{tick}:student-01",
+                    result_fingerprint="a" * 64,
+                )
+            )
+        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
+
+    run_ids = [row["run_id"] for row in restored["runtime_results"]]
+    tick_numbers = [row["tick_number"] for row in restored["runtime_results"]]
+    assert run_ids == ["run-a", "run-b", "run-c"]
+    assert tick_numbers == [0, 1, 2]
+
+
+def test_replay_with_no_runtime_results_returns_empty_list(acceptance_context) -> None:
+    """실행 기록이 없는 Simulation의 Replay는 빈 runtime_results를 반환한다."""
+    session_factory, owner_id, simulation_id = acceptance_context
+    service = SimulationSnapshotService()
+
+    with session_factory.begin() as session:
+        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
+
+    assert restored["runtime_results"] == []
+
+
+# ── 설정 저장 후 Replay 시나리오 ─────────────────────────────────────────────
+
+
+def test_replay_snapshot_includes_saved_config(acceptance_context) -> None:
+    """설정 저장 후 생성된 Snapshot은 config 정보를 payload에 포함한다."""
+    session_factory, owner_id, simulation_id = acceptance_context
+    service = SimulationSnapshotService()
+
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        service.save_config(
+            session,
+            simulation,
+            SimulationConfigInput("high", "low", True, {"agent_id": "student-02"}),
+        )
+        snapshot = service.create_snapshot(session, simulation)
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
+
+    assert restored["config"]["event_frequency"] == "high"
+    assert restored["config"]["event_impact"] == "low"
+    assert restored["config"]["magic_enabled"] is True
+    assert restored["config"]["user_persona_settings"] == {"agent_id": "student-02"}
+
+
+# ── Snapshot 조회 시나리오 ───────────────────────────────────────────────────
+
+
+def test_snapshot_query_by_tick_number_returns_correct_snapshot(acceptance_context) -> None:
+    """tick_number로 Snapshot을 조회하면 해당 시점의 Snapshot이 반환된다."""
+    session_factory, _, simulation_id = acceptance_context
+    service = SimulationSnapshotService()
+    repo = SimulationSnapshotRepository()
+
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        snapshot = service.create_snapshot(session, simulation)
+        snapshot_id = snapshot.id
+        tick = simulation.current_tick
+
+    with session_factory() as session:
+        found = repo.get_at_tick(session, simulation_id, tick)
+        assert found is not None
+        assert found.id == snapshot_id
+        assert found.tick_number == tick
+
+
+def test_snapshot_query_for_missing_tick_returns_none(acceptance_context) -> None:
+    """기록이 없는 tick의 Snapshot 조회는 None을 반환한다."""
+    session_factory, _, simulation_id = acceptance_context
+    repo = SimulationSnapshotRepository()
+
+    with session_factory() as session:
+        assert repo.get_at_tick(session, simulation_id, 999) is None
+
+
+# ── 지정 시점 복원 시나리오 ─────────────────────────────────────────────────
+
+
+def test_restore_at_specified_tick_returns_agent_states(acceptance_context) -> None:
+    """지정 시점 복원은 해당 시점의 에이전트 상태를 반환한다."""
+    session_factory, owner_id, simulation_id = acceptance_context
+    service = SimulationSnapshotService()
+
+    with session_factory.begin() as session:
+        source_state = session.scalar(
+            select(AgentState)
+            .join(Agent, Agent.id == AgentState.agent_id)
+            .where(
+                Agent.fixture_key == "student-01",
+                Agent.simulation_id == simulation_id,
+            )
+        )
+        source_state.stress = 42
+        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        restored = service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
+
+    target_agent_id = next(
+        a["id"] for a in restored["agents"] if a["fixture_key"] == "student-01"
+    )
+    restored_state = next(
+        s for s in restored["agent_states"] if s["agent_id"] == target_agent_id
+    )
+    assert restored_state["stress"] == 42
+    assert restored["simulation"]["id"] == str(simulation_id)
+
+
+def test_restore_does_not_write_to_database(acceptance_context) -> None:
+    """시점 복원은 DB에 새로운 레코드를 기록하지 않는다."""
+    session_factory, owner_id, simulation_id = acceptance_context
+    service = SimulationSnapshotService()
+
+    with session_factory.begin() as session:
+        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        sim_count_before = session.scalar(select(func.count()).select_from(Simulation))
+
+    with session_factory() as session:
+        service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
+        assert not session.new
+        assert not session.dirty
+        assert not session.deleted
+
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(Simulation)) == sim_count_before
+
+
+# ── 복원 불가·오류 시나리오 ─────────────────────────────────────────────────
+
+
+def test_restore_rejects_nonexistent_snapshot_id(acceptance_context) -> None:
+    """존재하지 않는 Snapshot ID로 복원 시도 시 SnapshotNotFoundError가 발생한다."""
+    session_factory, owner_id, _ = acceptance_context
+    service = SimulationSnapshotService()
+
+    with session_factory() as session:
+        with pytest.raises(SnapshotNotFoundError):
+            service.restore_snapshot(session, uuid7(), owner_id=owner_id)
+
+
+def test_restore_rejects_unauthorized_owner(acceptance_context) -> None:
+    """소유자가 아닌 사용자의 복원 시도는 SnapshotAccessDeniedError를 발생시킨다."""
+    session_factory, _, simulation_id = acceptance_context
+    service = SimulationSnapshotService()
+
+    with session_factory.begin() as session:
+        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        with pytest.raises(SnapshotAccessDeniedError):
+            service.restore_snapshot(session, snapshot_id, owner_id=uuid7())
+
+
+def test_restore_rejects_unsupported_schema_version(acceptance_context) -> None:
+    """지원하지 않는 schema_version의 Snapshot 복원은 UnsupportedSnapshotSchemaError를 발생시킨다."""
+    session_factory, owner_id, simulation_id = acceptance_context
+    service = SimulationSnapshotService()
+
+    with session_factory.begin() as session:
+        snapshot = service.create_snapshot(session, session.get(Simulation, simulation_id))
+        snapshot.payload = {**snapshot.payload, "schema_version": "legacy-v0"}
+        snapshot_id = snapshot.id
+
+    with session_factory() as session:
+        with pytest.raises(UnsupportedSnapshotSchemaError, match="unsupported snapshot schema"):
+            service.restore_snapshot(session, snapshot_id, owner_id=owner_id)
+
+
+# ── Slice 0~5 누적 회귀 기준 ─────────────────────────────────────────────────
+
+
+def test_slice_0_to_5_regression_baseline_passes() -> None:
+    """Slice 0~5 인수·계약 테스트가 Slice 6 base 위에서 모두 통과한다."""
+    slice_test_files = [
+        "tests/test_slice0_acceptance.py",
+        "tests/test_slice1_acceptance.py",
+        "tests/test_slice2_policy_engine.py",
+        "tests/test_slice3_acceptance.py",
+    ]
+    result = subprocess.run(
+        ["python", "-m", "pytest", "-q", "--tb=short", *slice_test_files],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Slice 0~5 회귀 실패:\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
## 작업 개요

최신 Slice 6 base의 실제 FastAPI HTTP 엔드포인트를 통해 설정 저장 → Snapshot 조회 → Replay → 읽기 전용 복원의 Golden Path와 오류 계약을 검증합니다.

## 관련 Issue

Closes #119

## 변경 내용

- 최신 `feature/issue-116-slice6-base`와 PR #187 Backend API 통합
- `TestClient`로 설정 PUT/PATCH, Snapshot GET, Restore POST, Replay list/detail 검증
- 같은 Tick의 여러 Agent RuntimeResult 식별자·저장 순서·run_id·tick_number·agent_id 일치 검증
- Replay instrumentation으로 Runtime·LLM·Tick 호출 0 검증
- Replay/restore 전후 Simulation·RuntimeResult·SimulationSnapshot·Event row count와 current_tick 불변 검증
- 401·403·404·409 및 잘못된 설정값 오류 계약 검증

## 결정 사항 및 이유

- Task 2 인수 테스트는 service/repository 직접 호출 대신 실제 사용자 접근 경계인 FastAPI HTTP 경로를 사용합니다.
- 저장 기록 fixture만 DB에 준비하고, 조회·Replay·복원 동작은 모두 공개 API로 실행합니다.
- Slice 0~5 회귀는 인수 테스트 내부 subprocess가 아니라 동일 검증 tree의 backend 전체 suite로 실행했습니다.

## 테스트 / 확인 내용

- [x] 격리 `pgvector/pgvector:0.8.5-pg16` DB에서 `CREATE EXTENSION vector`
- [x] `alembic upgrade head`
- [x] Slice 6 집중: `22 passed`
- [x] Backend 전체: `291 passed`, skip 0
- [x] Frontend: `6 files / 48 tests passed`
- [x] Frontend production build 성공
- [x] Replay Runtime calls: 0
- [x] Replay LLM calls: 0
- [x] Replay Tick calls: 0
- [x] Replay/restore DB write: 0
- [x] `git diff --check`

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: 인수 시나리오 갱신, 테스트 실행, diff 자기 리뷰
- 사람이 검토한 내용: 기존 리뷰 MUST, Slice 6 계약, API/UI 경로, 실행 결과

## 리뷰어가 봐야 할 부분

- `test_settings_snapshot_replay_restore_http_golden_path`의 실제 HTTP 연결 흐름
- 같은 Tick RuntimeResult 순서·식별자 보존과 Replay 무실행 검증
- restore/replay 전후 DB row count 및 current_tick 불변 검증
