### PR TITLE
[Test] slice6 task 4

### DIFF
--- a/backend/app/simulation/agent_runtime.py
+++ b/backend/app/simulation/agent_runtime.py
@@ -534,6 +534,12 @@ class AgentRuntime:
     def _decide(self, state: RuntimeGraphState) -> dict[str, object]:
         attempt_count = state["attempt_count"] + 1
         try:
+            # Block LLM invocation during replay mode and instrument the call
+            from app.simulation.replay_guard import assert_not_replay
+            from app.simulation.instrumentation import increment_llm
+
+            assert_not_replay("LLM generation attempted during replay")
+            increment_llm()
             response = self._llm_client.generate(state["runtime_input"])
         except LLMInvocationError as exc:
             return {

--- a/backend/app/simulation/instrumentation.py
+++ b/backend/app/simulation/instrumentation.py
@@ -1,0 +1,34 @@
+import threading
+
+_lock = threading.Lock()
+_counters = {
+    "llm_calls": 0,
+    "runtime_calls": 0,
+    "tick_calls": 0,
+}
+
+
+def reset_counters() -> None:
+    with _lock:
+        for k in _counters:
+            _counters[k] = 0
+
+
+def increment_llm() -> None:
+    with _lock:
+        _counters["llm_calls"] += 1
+
+
+def increment_runtime() -> None:
+    with _lock:
+        _counters["runtime_calls"] += 1
+
+
+def increment_tick() -> None:
+    with _lock:
+        _counters["tick_calls"] += 1
+
+
+def get_counts() -> dict:
+    with _lock:
+        return dict(_counters)

--- a/backend/app/simulation/replay_guard.py
+++ b/backend/app/simulation/replay_guard.py
@@ -1,0 +1,40 @@
+import threading
+from contextlib import contextmanager
+
+
+class ReplayModeError(RuntimeError):
+    """Raised when a forbidden operation is attempted during replay."""
+
+
+_state = threading.local()
+_state.in_replay = False
+
+
+def is_replay_mode() -> bool:
+    return getattr(_state, "in_replay", False)
+
+
+def set_replay_mode(value: bool) -> None:
+    _state.in_replay = bool(value)
+
+
+def assert_not_replay(message: str = "Operation forbidden during replay") -> None:
+    if is_replay_mode():
+        raise ReplayModeError(message)
+
+
+@contextmanager
+def ReplayGuard():
+    """Context manager to enable replay mode within the block.
+
+    Usage:
+        with ReplayGuard():
+            # replay-mode active
+            ...
+    """
+    prev = is_replay_mode()
+    set_replay_mode(True)
+    try:
+        yield
+    finally:
+        set_replay_mode(prev)

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -12,6 +12,8 @@ from app.simulation.agent_runtime import (
     StateSignal,
     StateSignalType,
 )
+from app.simulation.replay_guard import assert_not_replay
+from app.simulation.instrumentation import increment_tick, increment_runtime
 
 
 class AgentType(str, Enum):
@@ -154,8 +156,16 @@ class TickEngine:
                     retrieval_traces[agent.id] = [m.id for m in memories]
                 snapshot.data["memories"] = all_memories
 
+            # Prevent runtime invocation and tick creation during replay, and instrument when allowed
+            from app.simulation.replay_guard import assert_not_replay
+
             runtime_outputs: dict[str, AgentRuntimeResult] = {}
             if participants:
+                # If replay mode is active, abort before creating or running ticks
+                assert_not_replay("Runtime invocation attempted during replay")
+                # instrument tick and runtime only when not in replay
+                increment_tick()
+                increment_runtime()
                 runtime_outputs = await self._runtime(participants, event, snapshot)
 
             if self._policy and runtime_outputs:

--- a/backend/app/simulation/tick_engine.py
+++ b/backend/app/simulation/tick_engine.py
@@ -139,6 +139,12 @@ class TickEngine:
         if simulation_id in self._running:
             raise TickConflictError(f"Tick is already running for simulation {simulation_id}")
 
+        # Replay mode must block Tick execution at this entry boundary — before
+        # participant selection, Memory query, or Runtime invocation — regardless
+        # of whether participants exist.
+        assert_not_replay("Tick execution attempted during replay")
+        increment_tick()
+
         self._running.add(simulation_id)
         try:
             participants = self._select_participants(
@@ -156,15 +162,8 @@ class TickEngine:
                     retrieval_traces[agent.id] = [m.id for m in memories]
                 snapshot.data["memories"] = all_memories
 
-            # Prevent runtime invocation and tick creation during replay, and instrument when allowed
-            from app.simulation.replay_guard import assert_not_replay
-
             runtime_outputs: dict[str, AgentRuntimeResult] = {}
             if participants:
-                # If replay mode is active, abort before creating or running ticks
-                assert_not_replay("Runtime invocation attempted during replay")
-                # instrument tick and runtime only when not in replay
-                increment_tick()
                 increment_runtime()
                 runtime_outputs = await self._runtime(participants, event, snapshot)
 

--- a/backend/tests/test_slice6_replay_no_rerun.py
+++ b/backend/tests/test_slice6_replay_no_rerun.py
@@ -1,93 +1,514 @@
-import asyncio
-import pytest
+import os
+from uuid import UUID
 
+import pytest
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.orm import sessionmaker
+from uuid6 import uuid7
+
+from app.domain.models import Agent, RuntimeResult, Simulation, SimulationSnapshot, User
+from app.services.fixtures import seed_slice_zero
+from app.services.simulation_snapshots import (
+    SimulationSnapshotService,
+    SnapshotNotFoundError,
+    UnsupportedSnapshotSchemaError,
+)
+from app.simulation.agent_runtime import (
+    AgentContext,
+    AgentRuntime,
+    AgentRuntimeInput,
+    AgentStateContext,
+    BigFiveContext,
+    Block,
+    EventSummary,
+    MockLLMClient,
+    ScheduleSummary,
+)
+from app.simulation.instrumentation import get_counts, reset_counters
 from app.simulation.replay_guard import ReplayGuard, ReplayModeError
-from app.simulation.instrumentation import reset_counters, get_counts
 from app.simulation.tick_engine import (
     AgentType,
     TickAgent,
-    TickEvent,
     TickEngine,
+    TickEvent,
     WorldSnapshot,
 )
 from tests.runtime_factories import make_runtime_result
 
 
-async def make_student(agent_id: str, *, is_active: bool = True) -> TickAgent:
-    return TickAgent(id=agent_id, agent_type=AgentType.STUDENT, is_active=is_active)
+# ─── 6: Tick guard — participants 유무와 무관하게 replay mode에서 진입 자체가 차단되는지 ──
 
 
-async def make_event(participant_ids: list[str]) -> TickEvent:
-    return TickEvent(id="evt-1", event_type="class", participant_ids=set(participant_ids))
+async def test_replay_blocks_tick_regardless_of_participant_count():
+    """Replay mode must block TickEngine.run_tick() at the entry boundary,
+    whether or not any participant was selected for the tick."""
+    call_log: list[str] = []
 
-
-async def make_snapshot() -> WorldSnapshot:
-    return WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
-
-
-async def test_replay_blocks_runtime_llm_and_tick():
-    """Ensure replay mode prevents new Tick creation, runtime and LLM invocations.
-
-    - In normal mode a tick run increments tick/runtime instrumentation.
-    - In replay mode attempting to run a tick raises and instrumentation stays at zero.
-    """
-    # runtime that would normally be used during a tick
     async def runtime(agents, event, snapshot):
+        call_log.append("runtime-called")
         return {a.id: make_runtime_result(a.id) for a in agents}
 
     engine = TickEngine(runtime=runtime)
-
     student = TickAgent(id="s-1", agent_type=AgentType.STUDENT, is_active=True)
-    event = TickEvent(id="evt-1", event_type="class", participant_ids={"s-1"})
-    snapshot = WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
+    event_with_participant = TickEvent(id="evt-1", event_type="class", participant_ids={"s-1"})
+    event_without_participant = TickEvent(id="evt-2", event_type="class", participant_ids=set())
 
-    # Normal run should instrument tick and runtime
+    # Normal mode with a participant: a real tick instruments tick + runtime.
     reset_counters()
-    await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+    snapshot = WorldSnapshot(simulation_id="sim-guard-1", current_tick=0, data={})
+    await engine.run_tick(agents=[student], event=event_with_participant, snapshot=snapshot)
     counts = get_counts()
     assert counts["tick_calls"] == 1
     assert counts["runtime_calls"] == 1
-    # We didn't call AgentRuntime/LLM here, so llm_calls may be 0
+    assert call_log == ["runtime-called"]
 
-    # Now exercise replay guard: operations that would create new work must be blocked
+    # Replay mode with a participant present: must block before the runtime callback.
+    call_log.clear()
     reset_counters()
     with pytest.raises(ReplayModeError):
         with ReplayGuard():
-            # Attempting to run a tick during replay should be explicitly rejected
-            await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+            await engine.run_tick(
+                agents=[student],
+                event=event_with_participant,
+                snapshot=WorldSnapshot(simulation_id="sim-guard-1", current_tick=0, data={}),
+            )
+    counts = get_counts()
+    assert counts["tick_calls"] == 0
+    assert counts["runtime_calls"] == 0
+    assert counts["llm_calls"] == 0
+    assert call_log == []
 
-    counts_after = get_counts()
-    # No ticks or runtime invocations must have occurred during replay
-    assert counts_after["tick_calls"] == 0
-    assert counts_after["runtime_calls"] == 0
-    assert counts_after["llm_calls"] == 0
+    # Replay mode with ZERO participants: entry itself must still be blocked.
+    # This is the fix for the bug where assert_not_replay() only ran inside
+    # `if participants:`, so an empty-participant tick slipped through replay mode.
+    reset_counters()
+    with pytest.raises(ReplayModeError):
+        with ReplayGuard():
+            await engine.run_tick(
+                agents=[],
+                event=event_without_participant,
+                snapshot=WorldSnapshot(simulation_id="sim-guard-2", current_tick=0, data={}),
+            )
+    counts = get_counts()
+    assert counts["tick_calls"] == 0
+    assert counts["runtime_calls"] == 0
+    assert counts["llm_calls"] == 0
+    assert call_log == []
 
 
-async def test_replay_uses_only_stored_records_and_snapshot():
-    """Simulate a replay flow that reads stored results and snapshots and never invokes runtime/LLM/Tick.
+# ─── 6: Runtime/LLM guard — AgentRuntime의 실제 LLM 호출 직전에 replay guard가 동작하는지 ──
 
-    This test uses a saved record and ensures that 'replaying' by reading it doesn't touch runtime/LLM counters.
-    """
-    # Simulate a saved runtime output list
-    saved_runtime_outputs = [{"agent_id": "s-1", "result": "ok"}]
-    saved_snapshot = WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
+
+@pytest.fixture()
+def runtime_input() -> AgentRuntimeInput:
+    agent_id = UUID("00000000-0000-0000-0000-000000000001")
+    location_id = UUID("10000000-0000-0000-0000-000000000001")
+    event_id = UUID("20000000-0000-0000-0000-000000000001")
+    return AgentRuntimeInput(
+        run_id="issue121-llm-guard-run",
+        tick_number=0,
+        block=Block.MORNING,
+        agent=AgentContext(
+            agent_id=agent_id,
+            fixture_key="student-01",
+            agent_type="student",
+            name="아델",
+            mbti="ISTJ",
+            big_five=BigFiveContext(
+                openness=-25,
+                conscientiousness=25,
+                extraversion=-25,
+                agreeableness=-20,
+                emotional_stability=0,
+            ),
+            state=AgentStateContext(hunger=25, fatigue=15, stress=20, satisfaction=60, mood=0),
+            current_location_id=location_id,
+            active_status=True,
+        ),
+        nearby_agents=[],
+        relationships=[],
+        memories=[],
+        events=[
+            EventSummary(
+                event_id=event_id,
+                event_type="class",
+                location_id=location_id,
+                participant_agent_ids=[agent_id],
+                title="통합마법학",
+            )
+        ],
+        schedule=ScheduleSummary(
+            event_id=event_id,
+            schedule_type="class",
+            is_mandatory=True,
+            location_id=location_id,
+            start_tick=0,
+            end_tick=0,
+        ),
+        valid_agent_ids=[agent_id],
+        valid_location_ids=[location_id],
+    )
+
+
+class _NeverCalledLLMClient:
+    """LLM client stub that fails loudly if generate() is ever invoked."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def generate(self, runtime_input: AgentRuntimeInput) -> object:
+        self.call_count += 1
+        raise AssertionError("LLM client generate() must not be called during replay")
+
+
+class _CountingLLMClient(MockLLMClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.call_count = 0
+
+    def generate(self, runtime_input: AgentRuntimeInput) -> object:
+        self.call_count += 1
+        return super().generate(runtime_input)
+
+
+def test_replay_guard_blocks_llm_client_before_generate(runtime_input: AgentRuntimeInput) -> None:
+    spy = _NeverCalledLLMClient()
+    runtime = AgentRuntime(spy)
 
     reset_counters()
-    with ReplayGuard():
-        # Replay logic: read saved_runtime_outputs and saved_snapshot and build replay result
-        # The important property: we do not call engine.run_tick or any runtime/LLM code here.
-        replayed = {
-            "simulation_id": saved_snapshot.simulation_id,
-            "tick": saved_snapshot.current_tick,
-            "outputs": saved_runtime_outputs,
-        }
+    with pytest.raises(ReplayModeError):
+        with ReplayGuard():
+            runtime.run(runtime_input)
+
+    assert spy.call_count == 0
+    assert get_counts()["llm_calls"] == 0
+
+    # Normal mode: the same runtime input succeeds and does reach the LLM client.
+    normal_spy = _CountingLLMClient()
+    normal_runtime = AgentRuntime(normal_spy)
+    reset_counters()
+    result = normal_runtime.run(runtime_input)
+    assert normal_spy.call_count == 1
+    assert get_counts()["llm_calls"] == 1
+    assert result.status.value == "PROPOSED"
+
+
+# ─── 7~11: 실제 저장 데이터 기반 Replay 검증 (PostgreSQL integration) ──────────────
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def replay_context():
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
+
+    owner_id = uuid7()
+    simulation_id = uuid7()
+    with session_factory.begin() as session:
+        session.add(
+            User(
+                id=owner_id,
+                username="issue121-owner",
+                display_name="Issue 121 Owner",
+                password_hash="not-a-real-password-hash",
+                roles=["USER"],
+            )
+        )
+        session.flush()
+        session.add(
+            Simulation(id=simulation_id, owner_id=owner_id, name="Issue 121 Replay Source")
+        )
+        session.flush()
+        seed_slice_zero(session, simulation_id)
+    try:
+        yield session_factory, owner_id, simulation_id
+    finally:
+        engine.dispose()
+
+
+def _persist_tick(
+    session_factory,
+    simulation_id: UUID,
+    *,
+    run_id: str,
+    tick_number: int,
+    agent_fixture_key: str,
+    fingerprint_seed: str,
+) -> tuple[UUID, UUID, UUID]:
+    """Persist one real RuntimeResult row and its SimulationSnapshot for a tick,
+    mirroring what the production Runtime/persistence path would already have
+    written by the time a tick completes. Does not touch TickEngine, AgentRuntime,
+    or the LLM client."""
+    service = SimulationSnapshotService()
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        simulation.current_tick = tick_number
+        agent_id = session.scalar(
+            select(Agent.id).where(
+                Agent.simulation_id == simulation_id,
+                Agent.fixture_key == agent_fixture_key,
+            )
+        )
+        runtime_result_id = uuid7()
+        session.add(
+            RuntimeResult(
+                id=runtime_result_id,
+                run_id=run_id,
+                tick_number=tick_number,
+                agent_id=agent_id,
+                status="PROPOSED",
+                action_type="IDLE",
+                intent={},
+                retry_count=0,
+                model="test-model",
+                prompt_version="test-prompt-v1",
+                idempotency_key=f"{run_id}:{tick_number}:{agent_fixture_key}",
+                result_fingerprint=(fingerprint_seed * 64)[:64],
+            )
+        )
+        session.flush()
+        snapshot = service.create_snapshot(session, simulation)
+        snapshot_id = snapshot.id
+    return runtime_result_id, snapshot_id, agent_id
+
+
+def _replay_tick(
+    session,
+    service: SimulationSnapshotService,
+    *,
+    owner_id: UUID,
+    run_id: str,
+    tick_number: int,
+    snapshot_id: UUID,
+):
+    """Minimal read-only Replay path proving Issue #121's no-rerun contract.
+
+    Composed only of already-existing persistence code — a direct read of the
+    persisted RuntimeResult rows plus SimulationSnapshotRepository.get /
+    SimulationSnapshotService.restore_snapshot. It never invokes TickEngine,
+    AgentRuntime, or an LLM client, and never creates a new RuntimeResult or
+    SimulationSnapshot row.
+
+    NOTE: no real HTTP Replay read endpoint exists yet on this Slice 6 base —
+    see the Task 4 report's Slice 6 integration TODO. This function stands in
+    for that read path using only already-existing persistence code.
+    """
+    runtime_rows = list(
+        session.scalars(
+            select(RuntimeResult)
+            .where(RuntimeResult.run_id == run_id, RuntimeResult.tick_number == tick_number)
+            .order_by(RuntimeResult.agent_id)
+        )
+    )
+    if not runtime_rows:
+        raise SnapshotNotFoundError(
+            f"no RuntimeResult recorded for run {run_id} at tick {tick_number}"
+        )
+
+    snapshot = service.snapshots.get(session, snapshot_id)
+    if snapshot is None:
+        raise SnapshotNotFoundError(f"no snapshot recorded with id {snapshot_id}")
+
+    if snapshot.tick_number != tick_number:
+        raise UnsupportedSnapshotSchemaError(
+            "RuntimeResult.tick_number does not match SimulationSnapshot.tick_number"
+        )
+
+    restored = service.restore_snapshot(session, snapshot.id, owner_id=owner_id)
+    return runtime_rows, restored
+
+
+def test_replay_reads_persisted_runtime_results_and_snapshots_without_rerun(
+    replay_context,
+) -> None:
+    session_factory, owner_id, simulation_id = replay_context
+    run_id = "issue121-run-1"
+
+    result_id_0, snapshot_id_0, agent_id_0 = _persist_tick(
+        session_factory,
+        simulation_id,
+        run_id=run_id,
+        tick_number=0,
+        agent_fixture_key="student-01",
+        fingerprint_seed="a",
+    )
+    result_id_1, snapshot_id_1, agent_id_1 = _persist_tick(
+        session_factory,
+        simulation_id,
+        run_id=run_id,
+        tick_number=1,
+        agent_fixture_key="student-02",
+        fingerprint_seed="b",
+    )
+
+    with session_factory() as session:
+        before_runtime_count = session.scalar(select(func.count()).select_from(RuntimeResult))
+        before_snapshot_count = session.scalar(
+            select(func.count()).select_from(SimulationSnapshot)
+        )
+
+    service = SimulationSnapshotService()
+    reset_counters()
+    with session_factory() as session:
+        with ReplayGuard():
+            rows_0, restored_0 = _replay_tick(
+                session,
+                service,
+                owner_id=owner_id,
+                run_id=run_id,
+                tick_number=0,
+                snapshot_id=snapshot_id_0,
+            )
+            rows_1, restored_1 = _replay_tick(
+                session,
+                service,
+                owner_id=owner_id,
+                run_id=run_id,
+                tick_number=1,
+                snapshot_id=snapshot_id_1,
+            )
 
     counts = get_counts()
     assert counts["tick_calls"] == 0
     assert counts["runtime_calls"] == 0
     assert counts["llm_calls"] == 0
 
-    # Validate replayed content matches saved structure
-    assert replayed["simulation_id"] == "sim-1"
-    assert replayed["tick"] == 0
-    assert replayed["outputs"] == saved_runtime_outputs
+    # 저장된 기록과 Replay 결과의 순서·식별자·내용 일치
+    assert [row.id for row in rows_0] == [result_id_0]
+    assert [row.id for row in rows_1] == [result_id_1]
+    assert rows_0[0].agent_id == agent_id_0
+    assert rows_1[0].agent_id == agent_id_1
+    assert rows_0[0].run_id == run_id == rows_1[0].run_id
+    assert rows_0[0].tick_number == 0
+    assert rows_1[0].tick_number == 1
+    assert rows_0[0].action_type == "IDLE" == rows_1[0].action_type
+    assert restored_0["simulation"]["id"] == str(simulation_id) == restored_1["simulation"]["id"]
+
+    with session_factory() as session:
+        after_runtime_count = session.scalar(select(func.count()).select_from(RuntimeResult))
+        after_snapshot_count = session.scalar(select(func.count()).select_from(SimulationSnapshot))
+
+    # Replay 자체는 새 RuntimeResult/Snapshot을 만들지 않는다 (DB write 0).
+    assert after_runtime_count == before_runtime_count
+    assert after_snapshot_count == before_snapshot_count
+
+
+def test_replay_fails_explicitly_when_runtime_result_is_missing(replay_context) -> None:
+    """9-A: Runtime 기록 없음 → 재실행 금지, 명시적 오류."""
+    session_factory, owner_id, simulation_id = replay_context
+    run_id = "issue121-run-missing-runtime"
+
+    service = SimulationSnapshotService()
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        simulation.current_tick = 0
+        snapshot = service.create_snapshot(session, simulation)
+        snapshot_id = snapshot.id
+
+    reset_counters()
+    with session_factory() as session:
+        with pytest.raises(SnapshotNotFoundError, match="RuntimeResult"):
+            with ReplayGuard():
+                _replay_tick(
+                    session,
+                    service,
+                    owner_id=owner_id,
+                    run_id=run_id,
+                    tick_number=0,
+                    snapshot_id=snapshot_id,
+                )
+
+    counts = get_counts()
+    assert counts["tick_calls"] == 0
+    assert counts["runtime_calls"] == 0
+    assert counts["llm_calls"] == 0
+
+
+def test_replay_fails_explicitly_when_snapshot_is_missing(replay_context) -> None:
+    """9-B: 요청 Tick에 Snapshot 없음 → 새 Snapshot 생성 금지, 명시적 오류."""
+    session_factory, owner_id, simulation_id = replay_context
+    run_id = "issue121-run-missing-snapshot"
+    _persist_tick(
+        session_factory,
+        simulation_id,
+        run_id=run_id,
+        tick_number=0,
+        agent_fixture_key="student-01",
+        fingerprint_seed="c",
+    )
+    missing_snapshot_id = uuid7()
+
+    with session_factory() as session:
+        before_snapshot_count = session.scalar(
+            select(func.count()).select_from(SimulationSnapshot)
+        )
+
+    service = SimulationSnapshotService()
+    reset_counters()
+    with session_factory() as session:
+        with pytest.raises(SnapshotNotFoundError, match="snapshot"):
+            with ReplayGuard():
+                _replay_tick(
+                    session,
+                    service,
+                    owner_id=owner_id,
+                    run_id=run_id,
+                    tick_number=0,
+                    snapshot_id=missing_snapshot_id,
+                )
+
+    counts = get_counts()
+    assert counts["tick_calls"] == 0
+    assert counts["runtime_calls"] == 0
+    assert counts["llm_calls"] == 0
+
+    with session_factory() as session:
+        after_snapshot_count = session.scalar(select(func.count()).select_from(SimulationSnapshot))
+    assert after_snapshot_count == before_snapshot_count
+
+
+def test_replay_fails_explicitly_when_runtime_result_tick_mismatches_snapshot_tick(
+    replay_context,
+) -> None:
+    """9-C: RuntimeResult의 tick과 Snapshot tick 불일치 → fallback 금지, 명시적 오류."""
+    session_factory, owner_id, simulation_id = replay_context
+    run_id = "issue121-run-tick-mismatch"
+    service = SimulationSnapshotService()
+
+    # RuntimeResult는 tick 1에 기록되지만,
+    _persist_tick(
+        session_factory,
+        simulation_id,
+        run_id=run_id,
+        tick_number=1,
+        agent_fixture_key="student-01",
+        fingerprint_seed="d",
+    )
+    # Replay 호출에 전달되는 snapshot은 tick 0의 것 — 정합성 불일치 상황.
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        simulation.current_tick = 0
+        mismatched_snapshot = service.create_snapshot(session, simulation)
+        mismatched_snapshot_id = mismatched_snapshot.id
+
+    reset_counters()
+    with session_factory() as session:
+        with pytest.raises(UnsupportedSnapshotSchemaError, match="tick_number"):
+            with ReplayGuard():
+                _replay_tick(
+                    session,
+                    service,
+                    owner_id=owner_id,
+                    run_id=run_id,
+                    tick_number=1,
+                    snapshot_id=mismatched_snapshot_id,
+                )
+
+    counts = get_counts()
+    assert counts["tick_calls"] == 0
+    assert counts["runtime_calls"] == 0
+    assert counts["llm_calls"] == 0

--- a/backend/tests/test_slice6_replay_no_rerun.py
+++ b/backend/tests/test_slice6_replay_no_rerun.py
@@ -1,0 +1,93 @@
+import asyncio
+import pytest
+
+from app.simulation.replay_guard import ReplayGuard, ReplayModeError
+from app.simulation.instrumentation import reset_counters, get_counts
+from app.simulation.tick_engine import (
+    AgentType,
+    TickAgent,
+    TickEvent,
+    TickEngine,
+    WorldSnapshot,
+)
+from tests.runtime_factories import make_runtime_result
+
+
+async def make_student(agent_id: str, *, is_active: bool = True) -> TickAgent:
+    return TickAgent(id=agent_id, agent_type=AgentType.STUDENT, is_active=is_active)
+
+
+async def make_event(participant_ids: list[str]) -> TickEvent:
+    return TickEvent(id="evt-1", event_type="class", participant_ids=set(participant_ids))
+
+
+async def make_snapshot() -> WorldSnapshot:
+    return WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
+
+
+async def test_replay_blocks_runtime_llm_and_tick():
+    """Ensure replay mode prevents new Tick creation, runtime and LLM invocations.
+
+    - In normal mode a tick run increments tick/runtime instrumentation.
+    - In replay mode attempting to run a tick raises and instrumentation stays at zero.
+    """
+    # runtime that would normally be used during a tick
+    async def runtime(agents, event, snapshot):
+        return {a.id: make_runtime_result(a.id) for a in agents}
+
+    engine = TickEngine(runtime=runtime)
+
+    student = TickAgent(id="s-1", agent_type=AgentType.STUDENT, is_active=True)
+    event = TickEvent(id="evt-1", event_type="class", participant_ids={"s-1"})
+    snapshot = WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
+
+    # Normal run should instrument tick and runtime
+    reset_counters()
+    await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+    counts = get_counts()
+    assert counts["tick_calls"] == 1
+    assert counts["runtime_calls"] == 1
+    # We didn't call AgentRuntime/LLM here, so llm_calls may be 0
+
+    # Now exercise replay guard: operations that would create new work must be blocked
+    reset_counters()
+    with pytest.raises(ReplayModeError):
+        with ReplayGuard():
+            # Attempting to run a tick during replay should be explicitly rejected
+            await engine.run_tick(agents=[student], event=event, snapshot=snapshot)
+
+    counts_after = get_counts()
+    # No ticks or runtime invocations must have occurred during replay
+    assert counts_after["tick_calls"] == 0
+    assert counts_after["runtime_calls"] == 0
+    assert counts_after["llm_calls"] == 0
+
+
+async def test_replay_uses_only_stored_records_and_snapshot():
+    """Simulate a replay flow that reads stored results and snapshots and never invokes runtime/LLM/Tick.
+
+    This test uses a saved record and ensures that 'replaying' by reading it doesn't touch runtime/LLM counters.
+    """
+    # Simulate a saved runtime output list
+    saved_runtime_outputs = [{"agent_id": "s-1", "result": "ok"}]
+    saved_snapshot = WorldSnapshot(simulation_id="sim-1", current_tick=0, data={})
+
+    reset_counters()
+    with ReplayGuard():
+        # Replay logic: read saved_runtime_outputs and saved_snapshot and build replay result
+        # The important property: we do not call engine.run_tick or any runtime/LLM code here.
+        replayed = {
+            "simulation_id": saved_snapshot.simulation_id,
+            "tick": saved_snapshot.current_tick,
+            "outputs": saved_runtime_outputs,
+        }
+
+    counts = get_counts()
+    assert counts["tick_calls"] == 0
+    assert counts["runtime_calls"] == 0
+    assert counts["llm_calls"] == 0
+
+    # Validate replayed content matches saved structure
+    assert replayed["simulation_id"] == "sim-1"
+    assert replayed["tick"] == 0
+    assert replayed["outputs"] == saved_runtime_outputs


### PR DESCRIPTION
## 작업 개요

Replay(시점 복원) 경로에서 Runtime / LLM / Tick이 새로 실행되지 않음을 검증하기 위한 최소 가드와 계측을 추가했습니다.
재실행을 유발하는 코드 경로를 차단(assert)하며, 이를 검증하는 단위 테스트를 추가했습니다.

## 관련 Issue

Closes #121 

## 변경 내용

추가
backend/app/simulation/replay_guard.py — ReplayGuard context manager, assert_not_replay(), ReplayModeError
backend/app/simulation/instrumentation.py — thread-safe 계측 카운터 (llm_calls, runtime_calls, tick_calls), reset/get/increment 유틸
backend/tests/test_slice6_replay_no_rerun.py — Replay 관련 테스트 (2개)
수정
backend/app/simulation/agent_runtime.py — LLM 실행 직전에 assert_not_replay 호출 및 increment_llm 계측 추가
backend/app/simulation/tick_engine.py — Runtime 실행 직전에 assert_not_replay 호출 및 increment_runtime / increment_tick 계측 추가

## 결정 사항 및 이유

Replay 모드가 활성화된 경우 새로운 실행을 막는 가장 명시적인 방법으로 예외(ReplayModeError)를 발생시키도록 했습니다. 이는 재실행으로 인한 부작용(데이터 덮어쓰기, 중복 호출)을 명확히 차단하기 위함입니다.
계측은 테스트에서 검증하기 위한 최소한의 범위로 구현했고, thread-safe한 방식으로 카운터를 관리합니다.
UI/플레이백 로직(재생 화면 표시 등)은 Task 3 범위로 남겨두었습니다 — 본 PR은 테스트·방어(guard)만 담당합니다.

## 테스트 / 확인 내용

로컬(backend 폴더)에서 단일 파일 테스트 실행(권장)
python -m pytest -q tests/test_slice6_replay_no_rerun.py
결과: 2 tests passed (로컬에서 확인됨)

## AI 사용 여부

사용 여부: 사용함
사용한 작업:
Replay guard와 계측 코드 생성
Tick/AgentRuntime에 guard/계측 삽입
단위 테스트 파일 작성 및 로컬 pytest 실행(테스트 통과 확인)
사람 검토한 내용:
전체 코드 확인

## 리뷰어가 봐야 할 부분

guard 위치 및 범위
agent_runtime._decide()와 tick_engine.run_tick()에 삽입된 assert_not_replay 호출이 재실행을 충분히 차단하는지 확인하세요.
예외 처리 방식
ReplayModeError를 발생시키는 정책이 적절한지(예외 대신 에러 반환을 선호하는 경우) 의견 주세요.
계측(Instrumentation)
thread-safety, 네이밍, 테스트에서의 reset/get 사용이 적절한지 확인해주세요.
테스트 신뢰성
tests/test_slice6_replay_no_rerun.py가 CI 환경에서도 재현 가능하도록 (특히 Docker 환경) 필요한 환경 변수나 fixture가 누락되지 않았는지 확인 바랍니다.
기타
변경이 다른 부분에 부작용을 줄 가능성(특히 production runtime 경로) 검토 부탁드립니다.