### PR TITLE
[Fix] Persona 저장과 Simulation 시작 분리

### DIFF
--- a/frontend/src/components/UserPersonaSetup.jsx
+++ b/frontend/src/components/UserPersonaSetup.jsx
@@ -132,7 +132,7 @@ export default function UserPersonaSetup({
 
   function selectMbti(nextMbti) {
     setMbtiType(nextMbti);
-
+    setPersonaSaved(false);
     if (!nextMbti || !config) {
       setBigFive(null);
       return;
@@ -154,6 +154,7 @@ export default function UserPersonaSetup({
 
       return { ...prev, [key]: next };
     });
+    setPersonaSaved(false);
   }
 
   // Persona 저장만 수행한다. Simulation 시작은 별도 액션(handleStart)에서 담당한다.
@@ -278,7 +279,10 @@ export default function UserPersonaSetup({
                 name="persona-student"
                 value={student.id}
                 checked={selectedAgentId === student.id}
-                onChange={() => setSelectedAgentId(student.id)}
+                onChange={() => {
+                  setSelectedAgentId(student.id);
+                  setPersonaSaved(false);
+                }}
               />
               {student.name}
             </label>

--- a/frontend/src/components/UserPersonaSetup.jsx
+++ b/frontend/src/components/UserPersonaSetup.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getUserPersonaConfig,
   getUserPersona,
@@ -30,9 +30,11 @@ export default function UserPersonaSetup({
 }) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [starting, setStarting] = useState(false);
   const [error, setError] = useState("");
   const [config, setConfig] = useState(null);
   const [locked, setLocked] = useState(false);
+  const [personaSaved, setPersonaSaved] = useState(false);
   const [selectedAgentId, setSelectedAgentId] = useState("");
   const [mbtiType, setMbtiType] = useState("");
   const [bigFive, setBigFive] = useState(null);
@@ -44,6 +46,54 @@ export default function UserPersonaSetup({
   useEffect(() => {
     onSavedRef.current = onSaved;
   }, [onSaved]);
+
+  // 서버에 저장된 Persona 상태를 조회해 폼/잠금 상태에 반영한다.
+  // 최초 로딩과, Simulation 시작 시 409 충돌 발생 후 재동기화에 모두 쓰인다.
+  const loadPersona = useCallback(
+    async ({ isCancelled } = {}) => {
+      const cancelled = isCancelled ?? (() => false);
+
+      try {
+        const persona = await getUserPersona(simulationId, { token });
+
+        if (cancelled()) return persona;
+
+        setSelectedAgentId(persona.agent_id);
+        setMbtiType(persona.mbti_type);
+
+        setBigFive(
+          BIG_FIVE_TRAITS.reduce((acc, trait) => {
+            acc[trait.key] = persona[trait.key];
+            return acc;
+          }, {})
+        );
+
+        setPersonaSaved(true);
+        setLocked(Boolean(persona.locked));
+
+        // 이미 설정된 Persona를 발견한 경우 상위 컴포넌트에도 알린다.
+        onSavedRef.current?.(persona);
+
+        return persona;
+      } catch (personaError) {
+        if (personaError.status !== 404) {
+          throw personaError;
+        }
+
+        // 404 = 아직 User Persona가 설정되지 않음.
+        if (!cancelled()) {
+          setSelectedAgentId("");
+          setMbtiType("");
+          setBigFive(null);
+          setPersonaSaved(false);
+          setLocked(false);
+        }
+
+        return null;
+      }
+    },
+    [simulationId, token]
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -61,36 +111,7 @@ export default function UserPersonaSetup({
 
         setConfig(configResult);
 
-        try {
-          const persona = await getUserPersona(simulationId, { token });
-
-          if (cancelled) return;
-
-          setSelectedAgentId(persona.agent_id);
-          setMbtiType(persona.mbti_type);
-
-          setBigFive(
-            BIG_FIVE_TRAITS.reduce((acc, trait) => {
-              acc[trait.key] = persona[trait.key];
-              return acc;
-            }, {})
-          );
-
-          setLocked(Boolean(persona.locked));
-
-          // 이미 설정된 Persona를 발견한 경우 상위 컴포넌트에도 알린다.
-          onSavedRef.current?.(persona);
-        } catch (personaError) {
-          if (personaError.status !== 404) {
-            throw personaError;
-          }
-
-          // 404 = 아직 User Persona가 설정되지 않음.
-          setSelectedAgentId("");
-          setMbtiType("");
-          setBigFive(null);
-          setLocked(false);
-        }
+        await loadPersona({ isCancelled: () => cancelled });
       } catch (requestError) {
         if (!cancelled) {
           setError(requestError.message);
@@ -107,7 +128,7 @@ export default function UserPersonaSetup({
     return () => {
       cancelled = true;
     };
-  }, [simulationId, token, refreshKey]);
+  }, [simulationId, token, refreshKey, loadPersona]);
 
   function selectMbti(nextMbti) {
     setMbtiType(nextMbti);
@@ -135,7 +156,8 @@ export default function UserPersonaSetup({
     });
   }
 
-  async function save() {
+  // Persona 저장만 수행한다. Simulation 시작은 별도 액션(handleStart)에서 담당한다.
+  async function savePersona() {
     setSaving(true);
     setError("");
 
@@ -151,14 +173,40 @@ export default function UserPersonaSetup({
         { token }
       );
 
-      await startSimulation(simulationId, { token });
-
-      setLocked(true);
+      setPersonaSaved(true);
       onSavedRef.current?.(result);
     } catch (requestError) {
       setError(requestError.message);
     } finally {
       setSaving(false);
+    }
+  }
+
+  // 저장된 Persona를 기준으로 Simulation을 시작하고, 성공 시에만 Persona를 잠근다.
+  async function handleStart() {
+    setStarting(true);
+    setError("");
+
+    try {
+      await startSimulation(simulationId, { token });
+      setLocked(true);
+    } catch (requestError) {
+      if (requestError.status === 409) {
+        // 이미 다른 경로로 Simulation이 시작된 상태 — 서버 상태로 다시 동기화한다.
+        setError(
+          requestError.message || "Simulation이 이미 시작되어 있습니다."
+        );
+
+        try {
+          await loadPersona();
+        } catch (_syncError) {
+          // 동기화에 실패해도 위 충돌 메시지는 그대로 유지한다.
+        }
+      } else {
+        setError(requestError.message);
+      }
+    } finally {
+      setStarting(false);
     }
   }
 
@@ -188,7 +236,9 @@ export default function UserPersonaSetup({
   const mbtiOptions = Object.keys(config.mbti_rules);
 
   const canSave =
-    Boolean(selectedAgentId && mbtiType && bigFive) && !saving;
+    Boolean(selectedAgentId && mbtiType && bigFive) && !saving && !locked;
+
+  const canStart = personaSaved && !locked && !starting && !saving;
 
   return (
     <div className="panel persona-setup">
@@ -206,7 +256,7 @@ export default function UserPersonaSetup({
         </p>
       )}
 
-      <fieldset disabled={locked || saving}>
+      <fieldset disabled={locked || saving || starting}>
         <legend>Student 선택</legend>
 
         <div
@@ -296,13 +346,24 @@ export default function UserPersonaSetup({
       </fieldset>
 
       {!locked && (
-        <button
-          type="button"
-          onClick={save}
-          disabled={!canSave}
-        >
-          {saving ? "저장 중..." : "Persona 저장"}
-        </button>
+        <div className="persona-actions">
+          <button type="button" onClick={savePersona} disabled={!canSave}>
+            {saving ? "저장 중..." : "Persona 저장"}
+          </button>
+
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={!canStart}
+            title={
+              !personaSaved
+                ? "먼저 Persona를 저장해야 Simulation을 시작할 수 있습니다."
+                : undefined
+            }
+          >
+            {starting ? "시작 중..." : "Simulation 시작"}
+          </button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/UserPersonaSetup.test.jsx
+++ b/frontend/src/components/UserPersonaSetup.test.jsx
@@ -166,23 +166,12 @@ describe("UserPersonaSetup", () => {
     expect(screen.getByRole("group", { name: /Student 선택/ })).toBeDisabled();
     expect(screen.queryByRole("button", { name: "Persona 저장" })).not.toBeInTheDocument();
   });
-  it("Persona 저장 후 Simulation을 시작하고 locked 상태로 입력을 잠근다", async () => {
+  it("Persona를 저장해도 Simulation은 자동으로 시작되지 않는다", async () => {
     const fetchMock = mockInitialLoad();
 
     // POST /user-persona
     fetchMock.mockImplementationOnce(() =>
       response({ data: appliedPersona({ locked: false }) })
-    );
-
-    // POST /start
-    fetchMock.mockImplementationOnce(() =>
-      response({
-        data: {
-          id: "sim_01",
-          status: "RUNNING",
-          started_at: "2026-08-25T03:00:00Z",
-        },
-      })
     );
 
     const onSaved = vi.fn();
@@ -203,12 +192,11 @@ describe("UserPersonaSetup", () => {
     await user.selectOptions(screen.getByLabelText("MBTI preset"), "INFP");
     await user.click(screen.getByRole("button", { name: "Persona 저장" }));
 
-    await waitFor(() => {
-      expect(onSaved).toHaveBeenCalled();
-      expect(screen.getByText(/Simulation이 시작되어/)).toBeInTheDocument();
-    });
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
 
-    // Persona 저장 요청 확인
+    // Persona 저장 요청만 나가고 start는 호출되지 않는다.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
     const [personaUrl, personaOptions] = fetchMock.mock.calls[2];
 
     expect(personaUrl).toContain("/v1/simulations/sim_01/user-persona");
@@ -224,6 +212,55 @@ describe("UserPersonaSetup", () => {
       emotional_stability: 0,
     });
 
+    // 저장 후에도 잠기지 않고, 저장/시작 버튼이 모두 남아있어야 한다.
+    expect(screen.queryByText(/Simulation이 시작되어/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Persona 저장" })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Simulation 시작" })
+    ).toBeEnabled();
+  });
+
+  it("저장된 Persona로 Simulation 시작 버튼을 누르면 locked 상태로 입력을 잠근다", async () => {
+    const fetchMock = mockInitialLoad();
+
+    // POST /user-persona
+    fetchMock.mockImplementationOnce(() =>
+      response({ data: appliedPersona({ locked: false }) })
+    );
+
+    // POST /start
+    fetchMock.mockImplementationOnce(() =>
+      response({
+        data: {
+          id: "sim_01",
+          status: "RUNNING",
+          started_at: "2026-08-25T03:00:00Z",
+        },
+      })
+    );
+
+    const user = userEvent.setup();
+
+    render(
+      <UserPersonaSetup simulationId="sim_01" students={students} token="t" />
+    );
+
+    await screen.findByLabelText(students[0].name);
+
+    await user.click(screen.getByLabelText(students[2].name));
+    await user.selectOptions(screen.getByLabelText("MBTI preset"), "INFP");
+    await user.click(screen.getByRole("button", { name: "Persona 저장" }));
+
+    await screen.findByRole("button", { name: "Simulation 시작" });
+
+    await user.click(screen.getByRole("button", { name: "Simulation 시작" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Simulation이 시작되어/)).toBeInTheDocument();
+    });
+
     // Simulation 시작 요청 확인
     const [startUrl, startOptions] = fetchMock.mock.calls[3];
 
@@ -234,9 +271,82 @@ describe("UserPersonaSetup", () => {
     expect(
       screen.getByRole("group", { name: /Student 선택/ })
     ).toBeDisabled();
-
     expect(screen.getByLabelText("MBTI preset")).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Persona 저장" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Simulation 시작" })
+    ).not.toBeInTheDocument();
+  });
 
+  it("아직 저장하지 않은 상태에서는 Simulation 시작 버튼이 비활성화된다", async () => {
+    mockInitialLoad();
+    const user = userEvent.setup();
+
+    render(
+      <UserPersonaSetup simulationId="sim_01" students={students} token="t" />
+    );
+
+    await screen.findByLabelText(students[0].name);
+    await user.click(screen.getByLabelText(students[0].name));
+    await user.selectOptions(screen.getByLabelText("MBTI preset"), "ISTJ");
+
+    expect(screen.getByRole("button", { name: "Simulation 시작" })).toBeDisabled();
+  });
+
+  it("Simulation 시작이 409로 실패하면 서버 상태로 재동기화하고 잠긴다", async () => {
+    const fetchMock = mockInitialLoad();
+
+    // POST /user-persona
+    fetchMock.mockImplementationOnce(() =>
+      response({ data: appliedPersona({ locked: false }) })
+    );
+
+    // POST /start -> 409 (다른 경로로 이미 시작됨)
+    fetchMock.mockImplementationOnce(() =>
+      response(
+        {
+          code: "CONFLICT",
+          message: "Simulation이 이미 시작되어 있습니다.",
+        },
+        409
+      )
+    );
+
+    // 재동기화용 GET /user-persona -> 서버는 이미 locked 상태
+    fetchMock.mockImplementationOnce(() =>
+      response({ data: appliedPersona({ locked: true }) })
+    );
+
+    const user = userEvent.setup();
+
+    render(
+      <UserPersonaSetup simulationId="sim_01" students={students} token="t" />
+    );
+
+    await screen.findByLabelText(students[0].name);
+
+    await user.click(screen.getByLabelText(students[2].name));
+    await user.selectOptions(screen.getByLabelText("MBTI preset"), "INFP");
+    await user.click(screen.getByRole("button", { name: "Persona 저장" }));
+
+    await screen.findByRole("button", { name: "Simulation 시작" });
+    await user.click(screen.getByRole("button", { name: "Simulation 시작" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Simulation이 이미 시작되어 있습니다."
+    );
+
+    // 재동기화 GET 요청이 실제로 나갔는지 확인
+    const [syncUrl, syncOptions] = fetchMock.mock.calls[4];
+    expect(syncUrl).toContain("/v1/simulations/sim_01/user-persona");
+    expect(syncOptions?.method ?? "GET").toBe("GET");
+
+    // 서버 상태(locked: true)로 동기화되어 입력이 잠긴다.
+    await waitFor(() => {
+      expect(screen.getByText(/Simulation이 시작되어/)).toBeInTheDocument();
+    });
     expect(
       screen.queryByRole("button", { name: "Persona 저장" })
     ).not.toBeInTheDocument();

--- a/frontend/src/components/UserPersonaSetup.test.jsx
+++ b/frontend/src/components/UserPersonaSetup.test.jsx
@@ -408,4 +408,81 @@ describe("UserPersonaSetup", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("서버 오류가 발생했습니다.");
     expect(screen.queryByLabelText("MBTI preset")).not.toBeInTheDocument();
   });
+  it(
+    "저장 후 값을 변경하면 Simulation 시작이 비활성화되고, 재저장하면 다시 활성화된다",
+    async () => {
+      const fetchMock = mockInitialLoad();
+
+      // 첫 번째 Persona 저장
+      fetchMock.mockImplementationOnce(() =>
+        response({ data: appliedPersona({ locked: false }) })
+      );
+
+      // 두 번째 Persona 재저장
+      fetchMock.mockImplementationOnce(() =>
+        response({ data: appliedPersona({ locked: false }) })
+      );
+
+      const user = userEvent.setup();
+
+      render(
+        <UserPersonaSetup
+          simulationId="sim_01"
+          students={students}
+          token="t"
+        />
+      );
+
+      await screen.findByLabelText(students[0].name);
+
+      // Persona 저장
+      await user.click(screen.getByLabelText(students[0].name));
+      await user.selectOptions(
+        screen.getByLabelText("MBTI preset"),
+        "ISTJ"
+      );
+      await user.click(
+        screen.getByRole("button", { name: "Persona 저장" })
+      );
+
+      // 저장 후에는 Simulation 시작 가능
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Simulation 시작" })
+        ).toBeEnabled();
+      });
+
+      // 저장된 Persona의 값을 변경
+      await user.selectOptions(
+        screen.getByLabelText("MBTI preset"),
+        "INFP"
+      );
+
+      // 변경했으므로 다시 저장하기 전에는 시작 불가
+      expect(
+        screen.getByRole("button", { name: "Simulation 시작" })
+      ).toBeDisabled();
+
+      // Big Five를 직접 변경해도 시작 불가
+      await user.click(
+        screen.getByRole("button", { name: "개방성 증가" })
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Simulation 시작" })
+      ).toBeDisabled();
+
+      // 다시 저장
+      await user.click(
+        screen.getByRole("button", { name: "Persona 저장" })
+      );
+
+      // 재저장 후 다시 시작 가능
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Simulation 시작" })
+        ).toBeEnabled();
+      });
+    }
+  );
 });


### PR DESCRIPTION
## 작업 개요
UserPersonaSetup.jsx에서 Persona 저장 시 자동으로 호출되던 Simulation 시작(`startSimulation()`)을 분리했습니다. 이제 Persona 저장과 Simulation 시작은 각각 독립된 버튼/액션이며, 시작 전까지는 Persona를 몇 번이든 다시 저장할 수 있고 시작 후에는 잠깁니다.

## 관련 Issue
Closes #113

## 변경 내용
- `save()`를 `savePersona()`와 `handleStart()`로 분리 — Persona 저장 시 더 이상 `startSimulation()`을 자동 호출하지 않음
- `personaSaved` 상태 추가 — 서버에 저장된 Persona가 있어야 "Simulation 시작" 버튼이 활성화됨
- Simulation 시작 요청이 409(Conflict)로 실패하면 `getUserPersona`를 재조회해 서버의 실제 `locked` 상태로 화면을 동기화(`loadPersona`를 `useCallback`으로 분리해 최초 로딩과 재동기화에 공용으로 사용)
- 시작 요청 처리 중(`starting`)에는 입력 폼도 잠시 비활성화해 저장/시작 동시 클릭 등 경쟁 상태 방지
- `UserPersonaSetup.test.jsx`: 저장=자동시작을 검증하던 테스트를 제거하고, (1) 저장만으로는 시작되지 않음 (2) 저장 후 별도 버튼으로 시작·잠금 (3) 미저장 상태에서 시작 버튼 비활성화 (4) 시작 409 시 재동기화, 총 4개 테스트로 대체/보강

## 결정 사항 및 이유
- **저장/시작 분리**: 기존에는 Persona 저장 버튼 클릭 한 번으로 되돌릴 수 없는 Simulation 시작까지 함께 발생해, 값을 다듬어보고 확정한 뒤 별도로 시작하는 흐름이 불가능했음. 저장은 몇 번이든 반복 가능하게 하고, 시작은 명시적인 별도 동작으로 분리함.
- **시작 409 시 서버 재동기화**: 클라이언트가 마지막으로 알고 있던 상태를 그대로 신뢰하지 않고, 충돌 시 `GET /user-persona`로 서버의 진짜 상태(특히 `locked`)를 다시 가져와 화면을 맞추는 방식을 선택. 다른 경로(다른 탭/다른 사용자)로 이미 시작된 경우에도 화면이 실제 상태와 어긋나지 않도록 하기 위함.

## 테스트 / 확인 내용
- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인 (저장만 했을 때 시작 안 됨 / 저장 후 시작 버튼으로 잠금 전환 / 미저장 시 시작 버튼 비활성화)
- [x] 에러 케이스 확인 (저장 400/409 메시지 표시, 시작 409 재동기화)
- [ ] 관련 문서 업데이트 확인 (해당 없음)

**검증 결과**
- `npm test`: 3 Test Files passed, 34 Tests passed
- `npm run build` (vite v8.1.5): 19 modules transformed, 659ms — `dist/index.html` 0.47kB, `dist/assets/index-*.css` 2.85kB, `dist/assets/index-*.js` 204.78kB (gzip 64.59kB)

## AI 사용 여부
사용 여부: 사용함
사용한 작업: UserPersonaSetup.jsx의 저장/시작 분리 리팩토링 및 409 재동기화 로직 구현, UserPersonaSetup.test.jsx 테스트 케이스 분리·추가 초안 작성
사람이 검토한 내용: `npm test`, `npm run build` 테스트

## 리뷰어가 봐야 할 부분
- `handleStart()`의 409 처리 흐름 — 재동기화(`loadPersona()`) 자체가 실패해도 원래 충돌 메시지가 그대로 유지되는지
- `canStart`가 현재 폼 값이 아니라 "서버에 마지막으로 저장된 Persona" 기준이라는 점 — 폼에서 값만 바꾸고 재저장하지 않은 채 시작하면 이전 저장값 기준으로 시작됨(의도된 동작인지 확인 필요)
