### PR TITLE
[Chore] 모든 PR 대상 CodeRabbit 자동 리뷰 설정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,7 +7,9 @@ reviews:
 
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
+    base_branches:
+      - ".*"
 
   high_level_summary: true
   poem: false


### PR DESCRIPTION
## 작업 개요

CodeRabbit 자동 리뷰 대상을 모든 base 브랜치와 Draft PR로 확장합니다. 기본 브랜치 외 PR에서 자동 리뷰가 생략되는 설정을 보완합니다.

## 관련 Issue

별도 Issue 없음 — 사용자 요청에 따른 CodeRabbit 설정 변경입니다.

## 변경 내용

- `reviews.auto_review.base_branches: [".*"]` 추가: develop 및 Slice base를 포함한 모든 대상 브랜치 허용
- `reviews.auto_review.drafts: true` 변경: Draft PR 포함
- 기존 `enabled: true`, 한국어 리뷰 지침 및 리뷰 프로필 유지

## 결정 사항 및 이유

공식 설정에서 base_branches는 정규식을 지원하며 `.*`는 모든 대상 브랜치를 포함합니다. 브랜치마다 목록을 추가하지 않고 새 Slice base도 포함하도록 설정했습니다.

main 기준 설정 전용 브랜치이며 애플리케이션 코드는 변경하지 않습니다. PR 생성만으로 설정이 전체 PR에 적용되는 것은 아니며, 병합 이후 각 PR에 실제 사용되는 설정도 확인해야 합니다.

CodeRabbit 봇이 일부 PR에서 별 10개 미만으로 자동 리뷰가 제한된다고 안내했습니다. 이 서비스 측 제한은 YAML 변경으로 해제되지 않습니다.

참고: https://docs.coderabbit.ai/configuration/auto-review

## 테스트 / 확인 내용

- [x] 로컬 변경 확인: `.coderabbit.yaml` 1개 파일만 수정
- [x] `git diff --check` 통과
- [x] 공식 문서의 base_branches 및 drafts 설정 대조
- [ ] 주요 기능 동작 확인: 병합 및 설정 적용 후 새 PR에서 자동 리뷰 확인 필요
- [ ] 에러 케이스 확인: CodeRabbit 서비스 측 자동 리뷰 제한 확인 필요
- [ ] 관련 문서 업데이트: 별도 문서 변경 없음

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: 설정 확인, 최소 YAML 수정, diff 검사, PR 초안 작성
- 사람이 검토한 내용: 모든 PR 및 Draft 포함 요청, 커밋·푸시·PR 생성 승인. 설정의 실제 동작은 리뷰 및 적용 후 확인 필요

## 리뷰어가 봐야 할 부분

- 모든 base 브랜치 및 Draft PR을 포함하는 범위
- 기존 한국어 리뷰 지침이 유지되었는지
- 병합 후 기존 Slice 브랜치의 설정 적용 여부와 CodeRabbit 서비스 측 제한