### PR TITLE
[Feature] 브랜딩 화면 및 온보딩 흐름 구현

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { apiRequest } from "./api/client.js";
 import RelationshipFlow from "./components/RelationshipFlow.jsx";
 import PersonaSelectPage from "./pages/PersonaSelectPage.jsx";
 import PersonaSetupPage from "./pages/PersonaSetupPage.jsx";
+import BrandingPage from "./pages/BrandingPage.jsx";
 import "./App.css";
 
 function AuthPanel({ onLogin, notice }) {
@@ -86,12 +87,12 @@ function classifyTickError(requestError) {
 
 export default function App() {
   const [auth, setAuth] = useState(null);
+  const [simulationId, setSimulationId] = useState(null);
   const [personaId, setPersonaId] = useState(null);
   const [personaSetupDone, setPersonaSetupDone] = useState(false);
   const [simulation, setSimulation] = useState(null);
   const [agents, setAgents] = useState([]);
   const [selectedAgent, setSelectedAgent] = useState(null);
-  const [name, setName] = useState("Slice 0 Simulation");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -102,6 +103,7 @@ export default function App() {
   const [authNotice, setAuthNotice] = useState("");
   function resetSession(notice = "") {
     setAuth(null);
+    setSimulationId(null);
     setSimulation(null);
     setAgents([]);
     setSelectedAgent(null);
@@ -111,10 +113,18 @@ export default function App() {
     setAuthNotice(notice);
   }
 
+  function handleEnroll(id) {
+    setSimulationId(id);
+    setSimulation({ id, name: 'Magic Academy Simulation' });
+    loadAgents(id);
+  }
+
   if (!auth) return <AuthPanel onLogin={setAuth} notice={authNotice} />;
-  if (!personaId) return <PersonaSelectPage onConfirm={setPersonaId} />;
+  if (!simulationId) return <BrandingPage auth={auth} onEnroll={handleEnroll} />;
+  if (!personaId) return <PersonaSelectPage simulationId={simulationId} onConfirm={setPersonaId} />;
   if (!personaSetupDone) return (
     <PersonaSetupPage
+      simulationId={simulationId}
       charId={personaId}
       onBack={() => setPersonaId(null)}
       onStart={async (_charId, _config) => setPersonaSetupDone(true)}
@@ -130,29 +140,6 @@ export default function App() {
       });
       setAgents(agentList);
       setSelectedAgent(agentList[0] ?? null);
-    } catch (requestError) {
-      if (requestError.status === 401) {
-        resetSession();
-        return;
-      }
-      setError(requestError.message);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function createSimulation(event) {
-    event.preventDefault();
-    setLoading(true);
-    setError("");
-    try {
-      const created = await apiRequest("/v1/simulations", {
-        token: auth.access_token,
-        method: "POST",
-        body: JSON.stringify({ name }),
-      });
-      setSimulation(created);
-      await loadAgents(created.id);
     } catch (requestError) {
       if (requestError.status === 401) {
         resetSession();
@@ -229,15 +216,7 @@ export default function App() {
     <div className="app-shell">
       <header><strong>Magic Academy</strong><div className="profile"><span>{auth.user.display_name}</span><small>@{auth.user.username}</small></div></header>
       <main>
-        {!simulation ? (
-          <form className="panel create-panel" onSubmit={createSimulation}>
-            <h1>Simulation 생성</h1>
-            <label>이름<input required value={name} onChange={(e) => setName(e.target.value)} /></label>
-            {error && <p className="message error" role="alert">{error}</p>}
-            <button disabled={loading}>{loading ? "Simulation과 Agent를 생성하는 중..." : "Simulation 생성"}</button>
-          </form>
-        ) : (
-          <section className="workspace">
+        <section className="workspace">
             <div className="panel agent-list">
               <h1>{simulation.name}</h1><p>Agent {agents.length}명</p>
               {loading && <p className="message">Agent를 불러오는 중...</p>}
@@ -344,7 +323,6 @@ export default function App() {
               )}
             </div>
           </section>
-        )}
       </main>
     </div>
   );

--- a/frontend/src/App.mock.test.jsx
+++ b/frontend/src/App.mock.test.jsx
@@ -33,8 +33,10 @@ describe('Mock 모드 통합 흐름', () => {
     await userEvent.type(screen.getByLabelText('비밀번호'), 'mock-password')
     await userEvent.click(screen.getByRole('button', { name: '로그인' }))
 
-    expect(await screen.findByText('아카데미 수석 마법사')).toBeInTheDocument()
-    await userEvent.click(screen.getByRole('button', { name: 'Simulation 생성' }))
+    expect(await screen.findByRole('heading', { name: /마법이 살아 숨쉬는/ })).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: '입학하기' }))
+    await userEvent.click(await screen.findByRole('button', { name: '이 Persona로 시작하기 →' }))
+    await userEvent.click(await screen.findByRole('button', { name: /시뮬레이션 시작/ }))
 
     expect(await screen.findByText('Agent 6명')).toBeInTheDocument()
     expect(document.querySelectorAll('[data-agent-id]')).toHaveLength(6)
@@ -42,5 +44,5 @@ describe('Mock 모드 통합 흐름', () => {
     expect(screen.getByRole('heading', { name: '에단' })).toBeInTheDocument()
     expect(screen.getByText('교실')).toBeInTheDocument()
     expect(fetchSpy).not.toHaveBeenCalled()
-  })
+  }, 10000)
 })

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -35,7 +35,7 @@ async function setupSimulationWithAgents(fetchMock) {
     .mockImplementationOnce(() => response(agents))
   render(<App />)
   await login()
-  await userEvent.click(screen.getByRole('button', { name: 'Simulation 생성' }))
+  await completeOnboarding()
   await screen.findByText('Agent 6명')
 }
 
@@ -54,21 +54,52 @@ async function login() {
   await userEvent.click(screen.getByRole('button', { name: '로그인' }))
 }
 
+async function completeOnboarding() {
+  await userEvent.click(await screen.findByRole('button', { name: '입학하기' }))
+  await userEvent.click(await screen.findByRole('button', { name: '이 Persona로 시작하기 →' }))
+  await userEvent.click(await screen.findByRole('button', { name: /시뮬레이션 시작/ }))
+}
+
 describe('Slice 0 UI', () => {
-  it('logs in, creates a simulation, and renders six API agents', async () => {
+  it('logs in, enrolls, completes persona setup, and renders six API agents', async () => {
     vi.spyOn(globalThis, 'fetch')
       .mockImplementationOnce(() => response({ access_token: 'token', token_type: 'bearer', user }))
       .mockImplementationOnce(() => response(simulation, 201))
       .mockImplementationOnce(() => response(agents))
     render(<App />)
     await login()
-    expect(await screen.findByText('Owner A')).toBeInTheDocument()
-    await userEvent.click(screen.getByRole('button', { name: 'Simulation 생성' }))
+    expect(await screen.findByRole('heading', { name: /마법이 살아 숨쉬는/ })).toBeInTheDocument()
+    await completeOnboarding()
     expect(await screen.findByText('Agent 6명')).toBeInTheDocument()
     expect(document.querySelectorAll('[data-agent-id]')).toHaveLength(6)
     await userEvent.click(screen.getByRole('button', { name: /아델/ }))
     expect(screen.getByRole('heading', { name: '아델' })).toBeInTheDocument()
     expect(screen.getByText('기숙사')).toBeInTheDocument()
+  }, 10000)
+
+  it('shows a disabled loading button while enrolling', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockImplementationOnce(() => response({ access_token: 'token', token_type: 'bearer', user }))
+      .mockImplementationOnce(() => new Promise(() => {}))
+
+    render(<App />)
+    await login()
+    await userEvent.click(await screen.findByRole('button', { name: '입학하기' }))
+
+    expect(screen.getByRole('button', { name: '입학 중...' })).toBeDisabled()
+  })
+
+  it('shows an inline error when enrollment fails', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockImplementationOnce(() => response({ access_token: 'token', token_type: 'bearer', user }))
+      .mockImplementationOnce(() => response({}, 500))
+
+    render(<App />)
+    await login()
+    await userEvent.click(await screen.findByRole('button', { name: '입학하기' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('서버 오류가 발생했습니다.')
+    expect(screen.getByRole('button', { name: '입학하기' })).toBeEnabled()
   })
 
   it('shows the basic 401 message', async () => {
@@ -85,7 +116,7 @@ describe('Slice 0 UI', () => {
       .mockImplementationOnce(() => response([]))
     render(<App />)
     await login()
-    await userEvent.click(screen.getByRole('button', { name: 'Simulation 생성' }))
+    await completeOnboarding()
     expect(await screen.findByText('표시할 Agent가 없습니다.')).toBeInTheDocument()
   })
 
@@ -98,9 +129,9 @@ describe('Slice 0 UI', () => {
 
     render(<App />)
     await login()
-    await userEvent.click(screen.getByRole('button', { name: 'Simulation 생성' }))
+    await completeOnboarding()
 
-    expect(await screen.findByRole('heading', { name: simulation.name })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Magic Academy Simulation' })).toBeInTheDocument()
     expect(screen.getByRole('alert')).toHaveTextContent('서버 오류가 발생했습니다.')
     await userEvent.click(screen.getByRole('button', { name: 'Agent 다시 불러오기' }))
 
@@ -121,14 +152,13 @@ describe('Slice 0 UI', () => {
 
     render(<App />)
     await login()
-    await userEvent.click(document.querySelector('.create-panel button'))
+    await userEvent.click(await screen.findByRole('button', { name: '입학하기' }))
 
     expect(await screen.findByRole('main')).toHaveClass('auth-shell')
     await login()
 
-    expect(await screen.findByText('Owner B')).toBeInTheDocument()
-    expect(document.querySelector('.create-panel')).toBeInTheDocument()
-    expect(screen.queryByRole('heading', { name: simulation.name })).not.toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: /마법이 살아 숨쉬는/ })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Magic Academy Simulation' })).not.toBeInTheDocument()
     expect(document.querySelectorAll('[data-agent-id]')).toHaveLength(0)
   })
   it('shows loading state while a tick is running', async () => {

--- a/frontend/src/pages/BrandingPage.css
+++ b/frontend/src/pages/BrandingPage.css
@@ -1,0 +1,69 @@
+.branding-page {
+  min-height: 100vh;
+  background-color: var(--c-bg);
+  background-image: url('/assets/character/character.png');
+  background-position: right center;
+  background-size: contain;
+  background-repeat: no-repeat;
+  display: flex;
+  align-items: center;
+}
+
+.branding-page__content {
+  max-width: 480px;
+  padding: var(--s-12) var(--s-10);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-5);
+}
+
+.branding-page__label {
+  font-family: var(--f-serif-en);
+  font-size: var(--t-sm);
+  color: var(--c-cream);
+  letter-spacing: 0.15em;
+  margin: 0;
+}
+
+.branding-page__title {
+  font-family: var(--f-serif-ko);
+  font-size: var(--t-2xl);
+  color: var(--c-text);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.branding-page__desc {
+  font-size: var(--t-base);
+  color: var(--c-text-2);
+  margin: 0;
+  line-height: 1.75;
+}
+
+.branding-page__error {
+  font-size: var(--t-sm);
+  color: var(--c-critical);
+  margin: 0;
+}
+
+.branding-page__btn {
+  width: fit-content;
+  padding: var(--s-3) var(--s-8);
+  background-color: var(--c-primary);
+  color: var(--c-text);
+  border: none;
+  border-radius: var(--r-md);
+  font-size: var(--t-md);
+  font-family: var(--f-ui);
+  cursor: pointer;
+  transition: background-color var(--tr-fast);
+}
+
+.branding-page__btn:hover:not(:disabled) {
+  background-color: var(--c-primary-hover);
+}
+
+.branding-page__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/BrandingPage.jsx
+++ b/frontend/src/pages/BrandingPage.jsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { apiRequest } from '../api/client.js';
+import './BrandingPage.css';
+
+export default function BrandingPage({ auth, onEnroll }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleEnroll() {
+    setLoading(true);
+    setError('');
+    try {
+      const simulation = await apiRequest('/v1/simulations', {
+        token: auth.access_token,
+        method: 'POST',
+        body: JSON.stringify({ name: 'Magic Academy Simulation' }),
+      });
+      onEnroll(simulation.id);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="branding-page">
+      <div className="branding-page__content">
+        <p className="branding-page__label">MAGIC ACADEMY</p>
+        <h1 className="branding-page__title">
+          마법이 살아 숨쉬는<br />마법 대학교
+        </h1>
+        <p className="branding-page__desc">
+          마법사들이 관계를 맺고, 사건을 만들며, 세계를 변화시키는<br />
+          멀티 에이전트 시뮬레이션에 오신 것을 환영합니다.
+        </p>
+        {error && (
+          <p className="branding-page__error" role="alert">{error}</p>
+        )}
+        <button
+          className="branding-page__btn"
+          onClick={handleEnroll}
+          disabled={loading}
+        >
+          {loading ? '입학 중...' : '입학하기'}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 개요

Magic Academy 세계관을 소개하는 브랜딩 화면을 추가하고, 로그인 이후의 앱 흐름을 MVP 명세에 맞게 재구성합니다.

## 관련 Issue

관련 Issue 없음

## 변경 내용

- 세계관 소개, 배경 이미지, 입학 버튼을 포함한 `BrandingPage` 추가
- 입학 요청의 로딩 상태와 인라인 오류 처리 추가
- 앱 흐름을 인증 → 브랜딩 → Persona 선택 → 초기 설정 → workspace로 변경
- 기존 Simulation 생성 폼 제거
- `simulationId`를 Persona 선택·초기 설정 화면에 전달
- 새 온보딩 흐름과 입학 로딩·오류 케이스 테스트 추가

## 결정 사항 및 이유

시뮬레이션 생성 책임을 기존 workspace 폼에서 브랜딩 화면의 입학 동작으로 이동했습니다. 사용자가 세계관을 확인한 뒤 시뮬레이션을 생성하고 Persona 설정으로 진입하도록 MVP 사용자 흐름과 일치시키기 위함입니다.

기존 Agent 조회와 workspace 로직은 유지해 변경 범위를 라우팅과 브랜딩 화면에 한정했습니다.

## 테스트 / 확인 내용

- [ ] 로컬 브라우저 시각 확인 — 연결 가능한 브라우저가 없어 미완료
- [x] 주요 기능 동작 확인 — 전체 테스트 38개 통과
- [x] 에러 케이스 확인 — 입학 요청 실패 및 인증 오류 테스트 통과
- [x] 빌드 확인 — `npm run build` 통과
- [x] lint 확인 — 종료 코드 0, 기존 미사용 변수 경고 4건
- [x] 관련 문서 업데이트 확인 — 기존 MVP 명세 범위 내 변경으로 문서 수정 없음

## AI 사용 여부

사용 여부: 사용함  
사용한 작업: 브랜딩 컴포넌트 구현, App 흐름 재구성, 테스트 수정 및 검증  
사람이 검토한 내용: staged diff, 커밋 및 push 실행을 사용자 승인 후 진행

## 리뷰어가 봐야 할 부분

- 입학 성공 직후 `simulationId`를 설정하고 Agent 조회를 시작하는 흐름
- Persona 선택 및 초기 설정 이후 기존 workspace로 전환되는 상태 구성
- 브랜딩 화면이 기존 design-system 변수와 이미지 자산을 사용하는 방식
- 실제 브라우저 시각 검증이 완료되지 않은 점