### PR TITLE
[Feature] Slice 5 Task 3 Event·Memory·상태 저장 구현

### DIFF
--- a/backend/alembic/versions/20260827_0103_add_event_persistence.py
+++ b/backend/alembic/versions/20260827_0103_add_event_persistence.py
@@ -1,0 +1,47 @@
+"""Task 3 Event results and persistent curse expiration.
+
+Revision ID: 20260827_0103
+Revises: 20260812_0047
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260827_0103"
+down_revision = "20260812_0047"
+branch_labels = None
+depends_on = None
+
+REGULAR = "'class', 'group_project', 'exam', 'meeting', 'mt', 'festival', 'student_council', 'random_incident'"
+MAGIC = "'student_missing', 'curse_spread', 'magic_explosion', 'ritual_failure', 'magical_discovery'"
+
+
+def upgrade():
+    """Extend the existing schema without rewriting previously applied revisions."""
+    op.add_column("agents", sa.Column("cursed_until_tick", sa.BigInteger(), nullable=True))
+    op.create_check_constraint("ck_agents_cursed_until_tick", "agents", "cursed_until_tick IS NULL OR cursed_until_tick >= 0")
+    op.drop_constraint("ck_events_type", "events", type_="check")
+    op.create_check_constraint("ck_events_type", "events", f"event_type IN ({REGULAR}, {MAGIC})")
+    op.create_table(
+        "event_batch_results",
+        sa.Column("simulation_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("simulations.id", ondelete="RESTRICT"), primary_key=True),
+        sa.Column("tick_number", sa.BigInteger(), primary_key=True),
+        sa.Column("input_payload", postgresql.JSONB(), nullable=False),
+        sa.Column("result_payload", postgresql.JSONB(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint("tick_number >= 1", name="ck_event_batch_results_tick"),
+    )
+
+
+def downgrade():
+    """Refuse to discard persisted results or live curse state silently."""
+    connection = op.get_bind()
+    if connection.scalar(sa.text(f"SELECT EXISTS(SELECT 1 FROM events WHERE event_type IN ({MAGIC})) OR EXISTS(SELECT 1 FROM event_batch_results) OR EXISTS(SELECT 1 FROM agents WHERE cursed_until_tick IS NOT NULL)")):
+        raise RuntimeError("Task 3 data requires an approved backfill before downgrade")
+    op.drop_table("event_batch_results")
+    op.drop_constraint("ck_events_type", "events", type_="check")
+    op.create_check_constraint("ck_events_type", "events", f"event_type IN ({REGULAR})")
+    op.drop_constraint("ck_agents_cursed_until_tick", "agents", type_="check")
+    op.drop_column("agents", "cursed_until_tick")

--- a/backend/app/api/simulations.py
+++ b/backend/app/api/simulations.py
@@ -1,15 +1,31 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, Path, status
 from sqlalchemy.orm import Session
 
 from app.api.schemas import AgentResponse, SimulationCreateRequest, SimulationResponse
 from app.core.database import get_db
 from app.core.security import require_user_role
 from app.domain.models import User
+from app.repositories.event_results import get_event_result
 from app.services.simulations import create_simulation, get_agent_responses, require_owned_simulation
 
 router = APIRouter(prefix="/simulations", tags=["simulations"])
+
+
+@router.get("/{simulation_id}/event-results/{tick_number}")
+def read_event_result(
+    simulation_id: UUID,
+    tick_number: int = Path(ge=1),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> dict:
+    """Return the stored Tick result only after enforcing ownership."""
+    require_owned_simulation(db, simulation_id, current_user)
+    result = get_event_result(db, simulation_id, tick_number)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Event result not found")
+    return result
 
 
 @router.post("", response_model=SimulationResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/domain/event_persistence.py
+++ b/backend/app/domain/event_persistence.py
@@ -1,0 +1,107 @@
+"""Internal Task 3 input: final Event/Memory/State results, never LLM previews."""
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+MAGIC_TYPES = {"STUDENT_MISSING", "CURSE_SPREAD", "MAGIC_EXPLOSION", "RITUAL_FAILURE", "MAGICAL_DISCOVERY"}
+
+
+class Contract(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class EventWrite(Contract):
+    id: UUID
+    event_type: Literal["CLASS", "GROUP_PROJECT", "EXAM", "MEETING", "MT", "FESTIVAL", "STUDENT_COUNCIL", "RANDOM_INCIDENT", "STUDENT_MISSING", "CURSE_SPREAD", "MAGIC_EXPLOSION", "RITUAL_FAILURE", "MAGICAL_DISCOVERY"]
+    event_subtype: str | None = None
+    title: str = Field(min_length=1, max_length=100)
+    description: str
+    participant_agent_ids: tuple[UUID, ...] = Field(min_length=1)
+    location_id: UUID
+    source: Literal["event_master", "magic_layer"]
+    impact_level: Literal["low", "medium", "high"]
+    importance: int
+    expected_effects: dict = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_event(self):
+        """Preserve separate special-event semantics and the importance mapping."""
+        if self.importance != {"low": 30, "medium": 50, "high": 80}[self.impact_level]:
+            raise ValueError("impact_level/importance mismatch")
+        if self.event_type in MAGIC_TYPES and self.source != "magic_layer":
+            raise ValueError("special Event must come from magic_layer")
+        if self.event_type == "RANDOM_INCIDENT" and not self.event_subtype:
+            raise ValueError("RANDOM_INCIDENT needs event_subtype")
+        if len(set(self.participant_agent_ids)) != len(self.participant_agent_ids):
+            raise ValueError("duplicate Event participant")
+        return self
+
+
+class StateDelta(Contract):
+    target_type: Literal["AGENT_STATE"] = "AGENT_STATE"
+    source_agent_id: UUID
+    target_agent_id: None = None
+    metric: Literal["hunger", "fatigue", "stress", "satisfaction", "mood"]
+    before: int = Field(strict=True)
+    requested_total: int = Field(strict=True)
+    applied_delta: int = Field(strict=True)
+    after: int = Field(strict=True)
+    effect_ids: tuple[str, ...] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_arithmetic(self):
+        """Check final clamp arithmetic without using after_preview."""
+        minimum = -100 if self.metric == "mood" else 0
+        if not minimum <= self.before <= 100:
+            raise ValueError("invalid before")
+        if self.after != max(minimum, min(100, self.before + self.requested_total)):
+            raise ValueError("invalid resolved after")
+        if self.after - self.before != self.applied_delta:
+            raise ValueError("invalid applied_delta")
+        if any(not effect_id for effect_id in self.effect_ids) or len(set(self.effect_ids)) != len(self.effect_ids):
+            raise ValueError("invalid effect_ids")
+        return self
+
+
+class MemoryWrite(Contract):
+    agent_id: UUID
+    event_id: UUID
+    content: str = Field(min_length=1)
+    memory_type: Literal["observation", "conversation", "reflection", "plan"]
+    importance: int = Field(ge=0, le=100)
+    occurred_at: datetime
+
+    @model_validator(mode="after")
+    def validate_time(self):
+        """Require an absolute timestamp for reproducible serialization."""
+        if self.occurred_at.tzinfo is None:
+            raise ValueError("occurred_at must include timezone")
+        return self
+
+
+class EventBatch(Contract):
+    simulation_id: UUID
+    run_id: str = Field(min_length=1)
+    tick_number: int = Field(ge=1)
+    policy_version: str = Field(min_length=1)
+    resolver_version: str = Field(min_length=1)
+    resolution_id: str = Field(min_length=1)
+    events: tuple[EventWrite, ...] = ()
+    resolved_effects: tuple[StateDelta, ...] = ()
+    memories: tuple[MemoryWrite, ...] = ()
+    missing_agent_ids: tuple[UUID, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_unique_targets(self):
+        """The Resolver must have combined each target/metric before storage."""
+        pairs = [(item.source_agent_id, item.metric) for item in self.resolved_effects]
+        if len(set(pairs)) != len(pairs):
+            raise ValueError("duplicate resolved target/metric")
+        if len({item.id for item in self.events}) != len(self.events):
+            raise ValueError("duplicate Event ID")
+        if len(set(self.missing_agent_ids)) != len(self.missing_agent_ids):
+            raise ValueError("duplicate missing Agent")
+        return self

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -101,6 +101,7 @@ class Agent(TimestampMixin, Base):
         CheckConstraint("agreeableness BETWEEN -50 AND 50 AND agreeableness % 5 = 0", name="ck_agents_agreeableness"),
         CheckConstraint("emotional_stability BETWEEN -50 AND 50 AND emotional_stability % 5 = 0", name="ck_agents_emotional_stability"),
         CheckConstraint("inactive_until_tick IS NULL OR inactive_until_tick >= 0", name="ck_agents_inactive_until_tick"),
+        CheckConstraint("cursed_until_tick IS NULL OR cursed_until_tick >= 0", name="ck_agents_cursed_until_tick"),
         Index("uq_agents_active_user_persona", "simulation_id", unique=True, postgresql_where=text("agent_type = 'user_persona' AND deleted_at IS NULL")),
         Index("idx_agents_simulation_id", "simulation_id", "id"),
         Index("idx_agents_runtime_active", "simulation_id", "active_status", "inactive_until_tick"),
@@ -123,6 +124,7 @@ class Agent(TimestampMixin, Base):
     role_description: Mapped[str | None] = mapped_column(Text)
     active_status: Mapped[str] = mapped_column(String(30), nullable=False, server_default="active")
     inactive_until_tick: Mapped[int | None] = mapped_column(BigInteger)
+    cursed_until_tick: Mapped[int | None] = mapped_column(BigInteger)
     persona_locked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
@@ -213,7 +215,7 @@ class Event(TimestampMixin, Base):
     __tablename__ = "events"
     __table_args__ = (
         ForeignKeyConstraint(["simulation_id", "location_id"], ["locations.simulation_id", "locations.id"], ondelete="SET NULL (location_id)", onupdate="RESTRICT", name="fk_events_location"),
-        CheckConstraint("event_type IN ('class', 'group_project', 'exam', 'meeting', 'mt', 'festival', 'student_council', 'random_incident')", name="ck_events_type"),
+        CheckConstraint("event_type IN ('class', 'group_project', 'exam', 'meeting', 'mt', 'festival', 'student_council', 'random_incident', 'student_missing', 'curse_spread', 'magic_explosion', 'ritual_failure', 'magical_discovery')", name="ck_events_type"),
         CheckConstraint("status IN ('scheduled', 'ongoing', 'completed', 'cancelled')", name="ck_events_status"),
         CheckConstraint("simulation_day >= 1", name="ck_events_simulation_day"),
         Index("idx_events_simulation_started", "simulation_id", text("started_at DESC"), text("id DESC")),
@@ -230,6 +232,18 @@ class Event(TimestampMixin, Base):
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     event_metadata: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+
+
+class EventBatchResult(TimestampMixin, Base):
+    """Immutable Task 3 result used by REST and post-commit WS publication."""
+
+    __tablename__ = "event_batch_results"
+    __table_args__ = (CheckConstraint("tick_number >= 1", name="ck_event_batch_results_tick"),)
+
+    simulation_id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT"), primary_key=True)
+    tick_number: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    input_payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    result_payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
 
 
 class EventParticipant(TimestampMixin, Base):

--- a/backend/app/repositories/event_results.py
+++ b/backend/app/repositories/event_results.py
@@ -1,0 +1,14 @@
+"""Read the persisted result, not a recomputed live-world representation."""
+
+from copy import deepcopy
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.domain.models import EventBatchResult
+
+
+def get_event_result(session: Session, simulation_id: UUID, tick_number: int) -> dict | None:
+    """Callers must first enforce Simulation ownership."""
+    row = session.get(EventBatchResult, (simulation_id, tick_number))
+    return None if row is None else deepcopy(row.result_payload)

--- a/backend/app/services/event_persistence.py
+++ b/backend/app/services/event_persistence.py
@@ -1,0 +1,137 @@
+"""Task 3 persistence; the caller owns the complete Tick transaction."""
+
+from copy import deepcopy
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from uuid6 import uuid7
+
+from app.domain.event_persistence import EventBatch
+from app.domain.models import Agent, AgentMemory, AgentState, Event, EventBatchResult, EventParticipant, Location, Simulation
+from app.repositories.memory_repository import MemoryCreateInput, MemoryRepository
+
+DURATION_TICKS = 3
+
+
+def persist_event_batch(session: Session, batch: EventBatch) -> dict:
+    """Flush final results atomically with caller writes; never commit or rollback.
+
+    The caller MUST roll back its whole Tick on any error. The returned payload
+    is not publishable until that enclosing transaction has committed.
+    """
+    batch = EventBatch.model_validate(batch.model_dump())
+    session.flush()
+    simulation = session.scalar(select(Simulation).where(
+        Simulation.id == batch.simulation_id, Simulation.deleted_at.is_(None)
+    ).with_for_update().execution_options(populate_existing=True))
+    if simulation is None:
+        raise ValueError("Simulation not found")
+    payload = batch.model_dump(mode="json")
+    existing = session.get(EventBatchResult, (batch.simulation_id, batch.tick_number))
+    if existing is not None:
+        if existing.input_payload != payload:
+            raise ValueError("different result already stored for this Tick")
+        return deepcopy(existing.result_payload)
+    if batch.tick_number != simulation.current_tick + 1:
+        raise ValueError("stale or out-of-order Tick")
+
+    agents = {agent.id: agent for agent in session.scalars(select(Agent).where(
+        Agent.simulation_id == batch.simulation_id, Agent.deleted_at.is_(None)
+    ).order_by(Agent.id).with_for_update().execution_options(populate_existing=True))}
+    locations = {location.id: location for location in session.scalars(select(Location).where(
+        Location.simulation_id == batch.simulation_id
+    ))}
+    states = {state.agent_id: state for state in session.scalars(select(AgentState).where(
+        AgentState.simulation_id == batch.simulation_id
+    ).order_by(AgentState.agent_id).with_for_update().execution_options(populate_existing=True))}
+    events = {event.id: event for event in batch.events}
+    for event in batch.events:
+        if not set(event.participant_agent_ids) <= agents.keys():
+            raise ValueError("Event Agent is outside Simulation")
+        if event.location_id not in locations:
+            raise ValueError("Event Location is outside Simulation")
+        if session.get(Event, event.id) is not None:
+            raise ValueError("Event ID already exists")
+    for memory in batch.memories:
+        event = events.get(memory.event_id)
+        if event is None or memory.agent_id not in event.participant_agent_ids:
+            raise ValueError("Memory must reference a participating Event Agent")
+    missing_candidates = {agent_id for event in batch.events if event.event_type == "STUDENT_MISSING" for agent_id in event.participant_agent_ids}
+    if not set(batch.missing_agent_ids) <= missing_candidates:
+        raise ValueError("missing status requires STUDENT_MISSING Event")
+    if any(agents[agent_id].agent_type not in ("student", "user_persona") for agent_id in batch.missing_agent_ids):
+        raise ValueError("STUDENT_MISSING requires a Student")
+    for effect in batch.resolved_effects:
+        state = states.get(effect.source_agent_id)
+        if effect.source_agent_id not in agents or state is None:
+            raise ValueError("State Agent is outside Simulation")
+        if getattr(state, effect.metric) != effect.before:
+            raise ValueError("stale State delta")
+
+    # Expiration runs before new effects. No LLM or probability is involved.
+    for agent in agents.values():
+        if agent.active_status == "inactive_temporary" and agent.inactive_until_tick is not None and agent.inactive_until_tick <= batch.tick_number:
+            expiry = agent.inactive_until_tick
+            agent.active_status = "active"
+            agent.inactive_until_tick = None
+            agent.cursed_until_tick = expiry + DURATION_TICKS
+        if agent.cursed_until_tick is not None and agent.cursed_until_tick <= batch.tick_number:
+            agent.cursed_until_tick = None
+    for agent_id in batch.missing_agent_ids:
+        agent = agents[agent_id]
+        if agent.active_status != "active":
+            raise ValueError("missing Agent is not active")
+        agent.active_status = "inactive_temporary"
+        agent.inactive_until_tick = batch.tick_number + DURATION_TICKS
+
+    saved_events = []
+    for event in batch.events:
+        data = event.model_dump(mode="json")
+        data.update(tick=batch.tick_number, location=locations[event.location_id].name)
+        session.add(Event(
+            id=event.id, simulation_id=batch.simulation_id, location_id=event.location_id,
+            event_type=event.event_type.lower(), title=event.title, description=event.description,
+            status="completed", simulation_day=(batch.tick_number - 1) // 3 + 1,
+            event_metadata=data,
+        ))
+        saved_events.append(data)
+    session.flush()
+    for event in batch.events:
+        for agent_id in event.participant_agent_ids:
+            session.add(EventParticipant(id=uuid7(), event_id=event.id, agent_id=agent_id))
+    for effect in batch.resolved_effects:
+        setattr(states[effect.source_agent_id], effect.metric, effect.after)
+    session.flush()
+
+    repository = MemoryRepository()
+    saved_memories = []
+    for memory in batch.memories:
+        row = repository.create(session, MemoryCreateInput(
+            **memory.model_dump(), created_tick=batch.tick_number,
+        ))
+        saved_memories.append({**memory.model_dump(mode="json"), "id": str(row.id), "created_tick": batch.tick_number})
+    for agent_id in {memory.agent_id for memory in batch.memories}:
+        repository.enforce_cap(session, agent_id)
+    retained_ids = {str(value) for value in session.scalars(select(AgentMemory.id).where(
+        AgentMemory.event_id.in_(events)
+    ))}
+    saved_memories = [memory for memory in saved_memories if memory["id"] in retained_ids]
+
+    result = {
+        "simulation_id": str(batch.simulation_id), "run_id": batch.run_id,
+        "tick_number": batch.tick_number,
+        "block": ("morning", "afternoon", "evening")[(batch.tick_number - 1) % 3],
+        "policy_version": batch.policy_version, "resolver_version": batch.resolver_version,
+        "resolution_id": batch.resolution_id, "events": saved_events,
+        "resolved_effects": [effect.model_dump(mode="json") for effect in batch.resolved_effects],
+        "memories": saved_memories,
+        "agent_statuses": [{"agent_id": str(agent.id), "active_status": agent.active_status,
+                            "inactive_until_tick": agent.inactive_until_tick,
+                            "cursed_until_tick": agent.cursed_until_tick} for agent in agents.values()],
+    }
+    session.add(EventBatchResult(simulation_id=batch.simulation_id, tick_number=batch.tick_number,
+                                 input_payload=payload, result_payload=result))
+    session.flush()
+    # TODO(#105): invoke inside the fenced Tick commit alongside Runtime/relationships;
+    # advance current_tick there, and publish get_event_result() only after commit.
+    return deepcopy(result)

--- a/backend/tests/test_event_persistence.py
+++ b/backend/tests/test_event_persistence.py
@@ -1,0 +1,283 @@
+"""Task 3 uses a migrated, dedicated PostgreSQL database; never truncates data."""
+
+import os
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session
+
+from app.domain.models import Agent, AgentMemory, AgentState, Event, Simulation, User
+from app.services.fixtures import seed_slice_zero
+from app.services.event_persistence import persist_event_batch
+from app.domain.event_persistence import EventBatch
+from app.repositories.event_results import get_event_result
+
+
+@pytest.fixture
+def db():
+    """Isolate every test in an outer transaction, including explicit commit tests."""
+    url = os.getenv("TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("TEST_DATABASE_URL required")
+    engine = create_engine(url)
+    with engine.connect() as connection:
+        outer = connection.begin()
+        with Session(connection, join_transaction_mode="create_savepoint") as session:
+            yield session
+        outer.rollback()
+    engine.dispose()
+
+
+def setup_simulation(db):
+    """Create unique owned fixtures without touching existing rows."""
+    user = User(id=uuid4(), username=str(uuid4()), display_name="test", password_hash="test", roles=["USER"])
+    db.add(user)
+    db.flush()
+    simulation = Simulation(id=uuid4(), owner_id=user.id, name="Task3")
+    db.add(simulation)
+    db.flush()
+    seed_slice_zero(db, simulation.id)
+    state = db.scalar(select(AgentState).join(Agent, Agent.id == AgentState.agent_id).where(
+        AgentState.simulation_id == simulation.id, Agent.fixture_key == "student-01"
+    ))
+    db.commit()
+    return simulation.id, state.agent_id, state.location_id
+
+
+def make_batch(db, simulation_id, agent_id, location_id, **changes):
+    """Build a resolved result, not an expected_effects preview."""
+    state = db.scalar(select(AgentState).where(AgentState.agent_id == agent_id))
+    data = dict(
+        simulation_id=simulation_id, run_id="test-run", tick_number=1,
+        policy_version="test-policy", resolver_version="test-resolver", resolution_id="test-resolution",
+        events=[dict(id=uuid4(), event_type="CLASS", title="Class", description="Lesson",
+                     participant_agent_ids=[agent_id], location_id=location_id, source="event_master",
+                     impact_level="high", importance=80)],
+        resolved_effects=[dict(source_agent_id=agent_id, metric="stress", before=state.stress,
+                               requested_total=1, applied_delta=1, after=state.stress + 1, effect_ids=["e1"])],
+    )
+    data.update(changes)
+    return EventBatch.model_validate(data)
+
+
+def test_rejects_preview_and_invalid_delta():
+    """Unknown preview and arithmetic mismatch must not reach SQL."""
+    from app.domain.event_persistence import StateDelta
+    with pytest.raises(ValidationError):
+        StateDelta(source_agent_id=uuid4(), metric="stress", before=1, after=3,
+                   requested_total=1, applied_delta=1, effect_ids=["x"])
+    with pytest.raises(ValidationError):
+        StateDelta(source_agent_id=uuid4(), metric="stress", before=1, after=2,
+                   requested_total=1, applied_delta=1, effect_ids=["x"], after_preview=2)
+
+
+def test_save_read_and_idempotency(db):
+    """Event, Memory and State survive commit and duplicate delivery is a no-op."""
+    ids = setup_simulation(db)
+    batch = make_batch(db, *ids)
+    batch = EventBatch.model_validate({**batch.model_dump(), "memories": [dict(
+        agent_id=ids[1], event_id=batch.events[0].id, content="Remember class",
+        memory_type="observation", importance=80, occurred_at=datetime.now(UTC))]})
+    saved = persist_event_batch(db, batch)
+    db.commit()
+    assert get_event_result(db, ids[0], 1) == saved
+    assert persist_event_batch(db, batch) == saved
+    assert db.scalar(select(func.count()).select_from(Event).where(Event.id == batch.events[0].id)) == 1
+    assert db.scalar(select(func.count()).select_from(AgentMemory).where(AgentMemory.event_id == batch.events[0].id)) == 1
+    assert saved["resolved_effects"][0]["after"] == batch.resolved_effects[0].after
+    with pytest.raises(ValueError, match="different"):
+        persist_event_batch(db, batch.model_copy(update={"resolution_id": "changed"}))
+
+
+def test_failure_after_flush_rolls_back_entire_batch(db):
+    """The caller's rollback restores Event, Memory, State and result together."""
+    ids = setup_simulation(db)
+    batch = make_batch(db, *ids)
+    batch = EventBatch.model_validate({**batch.model_dump(), "memories": [dict(
+        agent_id=ids[1], event_id=batch.events[0].id, content="rollback memory",
+        memory_type="observation", importance=80, occurred_at=datetime.now(UTC))]})
+    before = batch.resolved_effects[0].before
+    persist_event_batch(db, batch)
+    db.get(Simulation, ids[0]).current_tick = 1
+    db.flush()
+    db.rollback()  # Simulate a subsequent Tick stage failing after persistence flush.
+    assert db.get(Event, batch.events[0].id) is None
+    assert get_event_result(db, ids[0], 1) is None
+    assert db.scalar(select(func.count()).select_from(AgentMemory).where(AgentMemory.event_id == batch.events[0].id)) == 0
+    assert db.get(Simulation, ids[0]).current_tick == 0
+    assert db.scalar(select(AgentState.stress).where(AgentState.agent_id == ids[1])) == before
+
+
+def test_rejects_cross_simulation_and_stale_state(db):
+    """Cross-simulation references and stale snapshots never become committed data."""
+    ids = setup_simulation(db)
+    other = setup_simulation(db)
+    batch = make_batch(db, *ids)
+    foreign = batch.events[0].model_copy(update={"location_id": other[2]})
+    with pytest.raises(ValueError, match="Location"):
+        persist_event_batch(db, batch.model_copy(update={"events": (foreign,)}))
+    db.rollback()
+    state = db.scalar(select(AgentState).where(AgentState.agent_id == ids[1]))
+    state.stress += 2
+    db.flush()
+    with pytest.raises(ValueError, match="stale"):
+        persist_event_batch(db, batch)
+    db.rollback()
+    assert db.get(Event, batch.events[0].id) is None
+
+
+def test_missing_and_curse_expire_at_exact_tick(db):
+    """Missing N -> active/cursed N+3 -> curse expires N+6."""
+    ids = setup_simulation(db)
+    batch = make_batch(db, *ids, missing_agent_ids=[ids[1]])
+    special = batch.events[0].model_copy(update={"event_type": "STUDENT_MISSING", "source": "magic_layer"})
+    batch = batch.model_copy(update={"events": (special,)})
+    persist_event_batch(db, batch)
+    agent = db.get(Agent, ids[1])
+    assert (agent.active_status, agent.inactive_until_tick) == ("inactive_temporary", 4)
+    for tick in range(2, 8):
+        db.get(Simulation, ids[0]).current_tick = tick - 1
+        db.flush()
+        empty = batch.model_copy(update={"tick_number": tick, "events": (), "resolved_effects": (), "missing_agent_ids": ()})
+        persist_event_batch(db, empty)
+        if tick == 3:
+            assert agent.active_status == "inactive_temporary"
+        if tick == 4:
+            assert agent.active_status == "active"
+            assert agent.cursed_until_tick == 7
+        if tick == 7:
+            assert agent.cursed_until_tick is None
+
+
+def test_memory_failure_after_event_and_state_flush(db, monkeypatch):
+    """A later repository failure must leave no earlier Event or State writes."""
+    from app.repositories.memory_repository import MemoryRepository
+    ids = setup_simulation(db)
+    batch = make_batch(db, *ids)
+    batch = EventBatch.model_validate({**batch.model_dump(), "memories": [dict(
+        agent_id=ids[1], event_id=batch.events[0].id, content="failure",
+        memory_type="observation", importance=80, occurred_at=datetime.now(UTC))]})
+
+    def fail(*args, **kwargs):
+        """Inject failure only after verifying earlier writes reached the DB."""
+        assert db.get(Event, batch.events[0].id) is not None
+        assert db.scalar(select(AgentState.stress).where(AgentState.agent_id == ids[1])) == batch.resolved_effects[0].after
+        raise RuntimeError("Memory storage failed")
+
+    monkeypatch.setattr(MemoryRepository, "create", fail)
+    with pytest.raises(RuntimeError, match="Memory storage"):
+        persist_event_batch(db, batch)
+    db.rollback()
+    assert db.get(Event, batch.events[0].id) is None
+    assert db.scalar(select(AgentState.stress).where(AgentState.agent_id == ids[1])) == batch.resolved_effects[0].before
+
+
+def test_rest_matches_committed_result_and_ownership(db):
+    """The registered route uses actual JWT verification and owner checks."""
+    from fastapi.testclient import TestClient
+    from app.core.database import get_db
+    from app.core.security import create_access_token
+    from app.main import app
+
+    ids = setup_simulation(db)
+    other = setup_simulation(db)
+    batch = make_batch(db, *ids)
+    saved = persist_event_batch(db, batch)
+    db.commit()
+    owner = db.get(User, db.get(Simulation, ids[0]).owner_id)
+    stranger = db.get(User, db.get(Simulation, other[0]).owner_id)
+    headers = {"Authorization": "Bearer " + create_access_token(owner)}
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        with TestClient(app) as client:
+            path = f"/v1/simulations/{ids[0]}/event-results/1"
+            assert client.get(path).status_code == 401
+            assert client.get(path, headers={"Authorization": "Bearer invalid"}).status_code == 401
+            response = client.get(path, headers=headers)
+            assert response.status_code == 200
+            assert response.json() == saved
+            assert client.get(path, headers={"Authorization": "Bearer " + create_access_token(stranger)}).status_code == 403
+            assert client.get(f"/v1/simulations/{uuid4()}/event-results/1", headers=headers).status_code == 404
+            assert client.get(f"/v1/simulations/{ids[0]}/event-results/2", headers=headers).status_code == 404
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def test_rejects_foreign_memory_and_duplicate_state_target(db):
+    """Cross-simulation Memory and unresolved duplicate targets are rejected."""
+    ids = setup_simulation(db)
+    other = setup_simulation(db)
+    batch = make_batch(db, *ids)
+    foreign = EventBatch.model_validate({**batch.model_dump(), "memories": [dict(
+        agent_id=other[1], event_id=batch.events[0].id, content="foreign",
+        memory_type="observation", importance=50, occurred_at=datetime.now(UTC))]})
+    with pytest.raises(ValueError, match="participating"):
+        persist_event_batch(db, foreign)
+    with pytest.raises(ValidationError, match="duplicate"):
+        EventBatch.model_validate({**batch.model_dump(), "resolved_effects": [batch.resolved_effects[0]] * 2})
+
+
+def test_memory_cap_and_magic_type_preserved(db):
+    """New memories respect the existing cap; Magic is not RANDOM_INCIDENT."""
+    ids = setup_simulation(db)
+    batch = make_batch(db, *ids)
+    event = batch.events[0].model_copy(update={"event_type": "MAGIC_EXPLOSION", "source": "magic_layer"})
+    batch = EventBatch.model_validate({**batch.model_dump(), "events": [event], "memories": [dict(
+        agent_id=ids[1], event_id=event.id, content=f"memory {index}",
+        memory_type="observation", importance=80, occurred_at=datetime.now(UTC)) for index in range(12)]})
+    saved = persist_event_batch(db, batch)
+    db.commit()
+    assert db.get(Event, event.id).event_type == "magic_explosion"
+    assert db.scalar(select(func.count()).select_from(AgentMemory).where(AgentMemory.agent_id == ids[1])) == 10
+    assert len(saved["memories"]) == 10
+
+
+def test_concurrent_delivery_is_applied_once():
+    """Two real transactions serialize on the Simulation row and reuse results."""
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+    url = os.getenv("TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("TEST_DATABASE_URL required")
+    engine = create_engine(url)
+    try:
+        with Session(engine) as session:
+            ids = setup_simulation(session)
+            batch = make_batch(session, *ids)
+        barrier = Barrier(2)
+
+        def deliver():
+            """Commit a batch with Tick progress in the caller's transaction."""
+            with Session(engine) as session, session.begin():
+                barrier.wait(timeout=10)
+                result = persist_event_batch(session, batch)
+                session.get(Simulation, ids[0]).current_tick = 1
+                return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _: deliver(), range(2)))
+        assert results[0] == results[1]
+        with Session(engine) as session:
+            assert session.scalar(select(AgentState.stress).where(AgentState.agent_id == ids[1])) == batch.resolved_effects[0].after
+            assert session.scalar(select(func.count()).select_from(Event).where(Event.id == batch.events[0].id)) == 1
+            assert get_event_result(session, ids[0], 1) == results[0]
+    finally:
+        engine.dispose()
+
+
+def test_database_failure_rolls_back_prior_writes(db):
+    """A real constraint failure aborts State, Event and result persistence."""
+    from sqlalchemy.exc import IntegrityError
+    ids = setup_simulation(db)
+    batch = make_batch(db, *ids)
+    persist_event_batch(db, batch)
+    db.get(Simulation, ids[0]).current_tick = -1
+    with pytest.raises(IntegrityError):
+        db.flush()
+    db.rollback()
+    assert db.get(Event, batch.events[0].id) is None
+    assert get_event_result(db, ids[0], 1) is None
+    assert db.scalar(select(AgentState.stress).where(AgentState.agent_id == ids[1])) == batch.resolved_effects[0].before

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sqlalchemy import CheckConstraint
+from sqlalchemy import BigInteger, CheckConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from pgvector.sqlalchemy import Vector
 
@@ -27,12 +27,16 @@ class SchemaModelTests(unittest.TestCase):
                 "organization_memberships",
                 "events",
                 "event_participants",
+                "event_batch_results",
             },
         )
 
     def test_primary_and_foreign_keys_use_postgresql_uuid(self) -> None:
         for table in Base.metadata.tables.values():
             for primary_key in table.primary_key.columns:
+                if table.name == "event_batch_results" and primary_key.name == "tick_number":
+                    self.assertIsInstance(primary_key.type, BigInteger)
+                    continue
                 self.assertIsInstance(primary_key.type, UUID)
             for foreign_key in table.foreign_keys:
                 self.assertIsInstance(foreign_key.parent.type, UUID)

--- a/docs/04-feature-specs/slice-5-integration.md
+++ b/docs/04-feature-specs/slice-5-integration.md
@@ -194,6 +194,40 @@ Frontend는 §1 Event 계약을 기준으로 구현한다.
 3. 버전 필드 포함: `policy_version`, `resolver_version`, `resolution_id` 를 REST/WS 모두에 포함한다.
 4. WebSocket은 알림 채널이며 진실의 원천은 REST 저장 결과이다.
 
+### Task 3 저장 경계 (#103)
+
+- 참여 Agent ID는 실제 DB와 동일한 UUID를 사용한다 (위 정수 예시는 설명용).
+- CURSED 기간은 Task 0의 3 Tick 계약을 따른다. 이전 Policy snapshot의 미확정 표기보다 이 계약을 적용한다.
+- `persist_event_batch(session, batch)`는 내부 서버용 저장 인터페이스다. HTTP 쓰기 API로 노출하지 않는다.
+- 일반 Event와 Magic 특수 Event를 구분해 `events`/`event_participants`에 저장한다. Magic은 `random_incident`로 변환하지 않는다.
+- 확정 State delta만 받으며 `before`, `requested_total`, `applied_delta`, `after`, 기여 effect ID와 버전을 저장한다. preview로 수치를 계산하지 않는다.
+- Memory는 생성된 후보를 저장할 뿐 새 내용을 생성하지 않는다. Event·Agent·Location은 같은 Simulation이어야 하고 Memory 작성자는 해당 Event 참여자여야 한다.
+- `(simulation_id, tick_number)`당 동일 입력은 재저장하지 않는다. 다른 입력의 재사용과 stale State는 오류다.
+- 저장 함수는 flush만 수행한다. 상위 Tick transaction이 Runtime·관계·현재 Tick과 함께 commit/rollback한다. 실패 예외를 삼키고 commit하면 안 된다.
+- `GET /v1/simulations/{simulation_id}/event-results/{tick_number}`는 저장된 결과를 반환한다. JWT 401, 비소유자 403, 없는 Simulation/결과 404.
+- 응답의 `events`, `resolved_effects`, `memories`, `agent_statuses`는 해당 Tick의 저장 snapshot이다. WS 발행은 commit 성공 후 이 저장값을 사용한다.
+- TODO(#101/#105): Event Master/Magic 및 Resolver 결과를 이 입력 계약에 연결하고, lease/fence 검증·Tick 진행·WS 발행을 상위 통합 경계에서 수행한다. Task 3은 Scheduler/Runtime 선택 로직을 변경하지 않는다.
+
+#### 호출 순서 및 검증 증적 (2026-08-27)
+
+1. 상위 Commit 경계에서 lease/fence 검증 후 `persist_event_batch(session, EventBatch(...))` 호출.
+2. `tick_number`는 DB의 `current_tick + 1`. State는 아직 적용하지 않은 확정 delta를 전달한다. 기존 `evaluate_and_apply_policy`와 같은 delta를 두 번 적용하지 않는다.
+3. 같은 transaction 안에서 나머지 Runtime/Relationship 저장과 `current_tick` 진행 후 commit. 어느 단계든 예외면 전체 rollback.
+4. 성공 후 새 Session에서 `get_event_result`를 읽어 WS에 전달. 반환 payload를 commit 전에 외부로 발행하지 않는다.
+
+Event ID는 배치에 저장할 신규 Event UUID이며, 기존 fixture Event 행을 덮어쓰지 않는다. 지속 일정을 재사용하는 상위 로직은 해당 Tick의 발생 Event를 별도로 식별해야 한다.
+`missing_agent_ids`는 Policy/Resolver가 승인한 실종 대상만 전달하며, STUDENT_MISSING 참여자 중 Student여야 한다. 저장 계층은 발생 조건을 재계산하지 않는다.
+만료 상태는 Commit 시점에 저장된다. Task 5는 동일 만료 규칙을 Runtime 대상 선정용 snapshot에도 반영해야 하며, Task 3만으로 해당 선정 로직이 연결되지는 않는다.
+
+검증 환경: 개발 DB와 분리된 로컬 PostgreSQL `magic_academy_slice5_task3`.
+
+- `alembic upgrade head`: 빈 DB부터 `20260827_0103`까지 성공.
+- `alembic check`: 모델/migration drift 없음.
+- `pytest -q -p no:cacheprovider tests/test_event_persistence.py tests/test_schema_models.py`: 21 passed.
+- DB 환경변수 없이 전체 `pytest -q -p no:cacheprovider`: 229 passed, 65 skipped (DB 연동 테스트 등; 전체 DB 검증 완료를 의미하지 않음).
+- 신규 PostgreSQL 검증: 실제 JWT REST 조회·401/403/404, 동일 입력 재시도, 동시 transaction, State stale 및 타 Simulation 참조 거부, Memory 10개 제한, repository 실패·DB 제약 실패·후속 단계 실패 rollback, 실종/저주 만료.
+- migration downgrade는 실행하지 않음. Task 1/5 연결·WS 정합성 및 Slice 5 E2E/PASS는 미검증.
+
 ---
 
 ## 6. Tick 10 E2E 검증 시나리오 및 완료 기준


### PR DESCRIPTION
## 작업 개요

Slice 5 Task 3의 Event·Memory·Agent State 저장 계층과 저장 결과 조회 API를 구현했습니다. 일반 Event와 Magic 특수 Event를 구분해 저장하고, 상위 Tick transaction 안에서 중복 저장 방지와 전체 rollback이 가능하도록 구성했습니다.

실제 Event Master·Resolver·Tick·WebSocket 연결은 Task 1/5의 통합 작업으로 남아 있으며, 이 PR만으로 Slice 5 E2E 완료를 의미하지 않습니다.

## 관련 Issue

Refs #103
Refs #88

통합 검증이 남아 있으므로 #103을 자동 종료하지 않습니다.

## 변경 내용

- 내부 EventBatch 계약과 persist_event_batch(session, batch) 저장 서비스 추가
- Event·참여자·Memory·확정 State delta 및 policy/resolver/resolution 추적 정보 저장
- Simulation/Tick별 동일 입력 재시도는 no-op, 다른 입력 재사용과 stale State는 거부
- Simulation 행 잠금으로 동시 저장 직렬화 및 Agent·Location·Memory의 Simulation 경계 검사
- 실종 N → N+3 재활성화/CURSED 부여 → N+6 저주 만료, 기존 Memory 10개 제한 적용
- cursed_until_tick, Magic Event 타입, event_batch_results 후속 migration 추가
- GET /v1/simulations/{simulation_id}/event-results/{tick_number} 추가: JWT·소유권 검사 및 401/403/404 처리
- PostgreSQL 저장/rollback/API 테스트와 저장·통합 경계 문서 추가

## 결정 사항 및 이유

- 확인받은 Task 0의 CURSED 3 Tick 규칙과 실제 DB의 UUID 계약을 적용했습니다.
- 저장 계층은 preview를 계산에 사용하지 않고 Resolver의 before/requested_total/applied_delta/after를 검증합니다.
- commit/rollback은 상위 Tick이 소유합니다. 이 서비스는 flush만 수행하므로 Runtime·Relationship·Tick 진행과 같은 transaction에 포함할 수 있습니다.
- REST와 향후 WS가 같은 저장 결과를 사용하도록 Tick별 payload를 보존합니다. commit 전 반환값을 외부에 발행하면 안 됩니다.
- 기존 migration은 수정하지 않고 20260812_0047 다음에 20260827_0103을 추가했습니다.

## 테스트 / 확인 내용

- [x] 로컬 PostgreSQL 저장 계층 및 TestClient API 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [x] 관련 문서 업데이트 확인
- [ ] 실제 Tick → Event Master/Resolver → 저장 → WebSocket E2E (Task 1/5 통합 후)

개발 DB와 분리된 magic_academy_slice5_task3에서 검증했습니다.

- alembic upgrade head: 빈 DB부터 신규 revision까지 성공
- alembic check: No new upgrade operations detected
- pytest -q -p no:cacheprovider tests/test_event_persistence.py tests/test_schema_models.py: 21 passed
- DB 환경변수 없이 전체 pytest: 229 passed, 65 skipped (전체 DB 통합 테스트 통과를 의미하지 않음)
- 검증 범위: 동일 입력 재시도, 동시 transaction, stale State·교차 Simulation 참조 거부, Memory 상한, 저장 도중 repository 실패·DB 제약 실패·후속 단계 실패 rollback, 지속 상태 만료, 실제 JWT 기반 API 조회 및 401/403/404
- migration downgrade와 기존 개발 DB 변경은 실행하지 않았습니다.

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 계약·코드 조사, migration·저장 서비스·조회 API·테스트 작성, 로컬 검증 및 PR 초안 작성
사람이 검토한 내용: UUID와 CURSED 3 Tick 기준 및 작업·업로드 승인. 코드 상세 검토는 이번 PR 리뷰에서 요청드립니다.

## 리뷰어가 봐야 할 부분

- transaction 소유권과 동시 요청/재시도 처리
- Magic Event 별도 저장 및 실종·저주 만료 경계
- EventBatch는 Task 3 내부 입력입니다. Task 1/5 연결 시 Event 발생별 신규 UUID, State delta 단일 적용, current_tick 진행 전 호출 순서를 맞춰야 합니다.
- Runtime 대상 선정용 snapshot의 상태 만료 반영, lease/fence 검사, Runtime/Relationship 저장과 WS 발행은 상위 통합 책임이며 TODO로 명시했습니다.
- Event·Memory·State 저장 범위의 PR입니다. UI, Event 생성 규칙, Runtime 대상 선정은 수정하지 않았습니다.
