### PR TITLE
[Feature] Slice 5 Task 1 — Event Master·Magic 조건 기반 Event 구현

### DIFF
--- a/backend/app/services/event_magic_phase.py
+++ b/backend/app/services/event_magic_phase.py
@@ -1,0 +1,83 @@
+"""Slice 5 Task 1 — Event Master -> Magic Layer -> Policy/Resolver bridge.
+
+Wires the three components through their existing typed contracts so the
+pipeline is not a dead implementation (Issue #101 §7). This module performs
+no DB writes and does not call ``persist_event_batch``: turning its result
+into a Task 3 ``EventBatch`` and committing it inside the fenced Tick
+transaction is Task 5's job (slice-5-integration.md §5,
+"TODO(#101/#105): ... lease/fence 검증·Tick 진행·WS 발행을 상위 통합 경계에서 수행한다").
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from app.simulation.event_master import (
+    AgentSummary as EventMasterAgentSummary,
+    Event,
+    EventMaster,
+    RelationshipSummary as EventMasterRelationshipSummary,
+    ScheduledEventInput,
+)
+from app.simulation.magic_layer import (
+    AgentSnapshot as MagicAgentSnapshot,
+    MagicLayer,
+    SpecialEvent,
+)
+from app.simulation.policy.conflict import resolve_conflicts
+from app.simulation.policy.models import AgentSnapshot, EffectCandidate, RelationshipSnapshot
+from app.simulation.policy.registries.event_policy import (
+    build_event_effect_candidates,
+    build_magic_effect_candidates,
+)
+
+
+@dataclass(frozen=True)
+class EventAndMagicResult:
+    events: tuple[Event, ...]
+    special_events: tuple[SpecialEvent, ...]
+    resolved_effects: tuple[EffectCandidate, ...]
+
+
+def run_event_and_magic_phase(
+    *,
+    run_id: str,
+    tick: int,
+    agent_summaries: Sequence[EventMasterAgentSummary],
+    agent_state_snapshots: Mapping[str, AgentSnapshot],
+    magic_agent_snapshots: Sequence[MagicAgentSnapshot],
+    scheduled_events: Sequence[ScheduledEventInput] = (),
+    event_master_relationship_summaries: Sequence[EventMasterRelationshipSummary] = (),
+    magic_relationship_snapshots: Sequence[RelationshipSnapshot] = (),
+    lab_location_ids: frozenset[str] = frozenset(),
+) -> EventAndMagicResult:
+    events = EventMaster().generate(
+        tick=tick,
+        agent_summaries=agent_summaries,
+        scheduled_events=scheduled_events,
+        relationship_summaries=event_master_relationship_summaries,
+    )
+    magic_result = MagicLayer().evaluate(
+        tick=tick,
+        regular_events=events,
+        agent_snapshots=magic_agent_snapshots,
+        relationship_snapshots=magic_relationship_snapshots,
+        lab_location_ids=lab_location_ids,
+    )
+    event_candidates = [
+        candidate
+        for event in magic_result.converted_events
+        for candidate in build_event_effect_candidates(
+            event, run_id=run_id, agent_snapshots=agent_state_snapshots
+        )
+    ]
+    magic_candidates = build_magic_effect_candidates(
+        magic_result.special_events, run_id=run_id, agent_snapshots=agent_state_snapshots
+    )
+    resolved = resolve_conflicts([*event_candidates, *magic_candidates])
+    return EventAndMagicResult(
+        events=magic_result.converted_events,
+        special_events=magic_result.special_events,
+        resolved_effects=tuple(resolved),
+    )

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -32,6 +33,8 @@ from app.simulation.agent_runtime import (
 from app.simulation.event_master import (
     AgentSummary as EventMasterAgentSummary,
     RelationshipSummary as EventMasterRelationshipSummary,
+    SCHEDULED_EVENT_TYPES,
+    ScheduledEventInput,
 )
 from app.simulation.magic_layer import STUDENT_MISSING_STREAK_TICKS, AgentSnapshot as MagicAgentSnapshot
 from app.simulation.policy.models import (
@@ -156,6 +159,26 @@ def _reconstruct_recent_stress(
     return history
 
 
+def _to_scheduled_event_input(event: Event, participants: list[EventParticipant]) -> ScheduledEventInput | None:
+    """DB의 현재 Event/EventParticipant를 Event Master의 ScheduledEventInput 계약으로 변환한다.
+
+    새 Event 모델이나 새 규칙을 만들지 않는다 — 기존 DB 값의 event_type만
+    Event Master 계약(대문자)에 맞게 정규화한다. event_type이 Event Master의
+    예정 Event 타입(SCHEDULED_EVENT_TYPES)이 아니면 변환하지 않는다.
+    """
+    event_type = event.event_type.upper()
+    if event_type not in SCHEDULED_EVENT_TYPES or event.location_id is None:
+        return None
+    return ScheduledEventInput(
+        event_id=str(event.id),
+        event_type=event_type,
+        location_id=str(event.location_id),
+        participant_agent_ids=tuple(str(p.agent_id) for p in participants),
+        title=event.title,
+        description=event.description or "",
+    )
+
+
 def _run_event_and_magic_phase(
     db: Session,
     *,
@@ -163,6 +186,7 @@ def _run_event_and_magic_phase(
     run_id: UUID,
     tick: int,
     agents: list[Agent],
+    scheduled_events: Sequence[ScheduledEventInput] = (),
 ) -> EventAndMagicResult:
     """Event Master -> Magic Layer -> Policy/Resolver 최소 wiring (Issue #101).
 
@@ -276,6 +300,7 @@ def _run_event_and_magic_phase(
         agent_summaries=agent_summaries,
         agent_state_snapshots=agent_state_snapshots,
         magic_agent_snapshots=magic_snapshots,
+        scheduled_events=scheduled_events,
         event_master_relationship_summaries=event_master_relationship_summaries,
         magic_relationship_snapshots=magic_relationship_snapshots,
     )
@@ -333,12 +358,16 @@ async def advance_manual_tick(
             .order_by(Agent.fixture_key)
         )
     )
+    scheduled_event_input = _to_scheduled_event_input(event, participants)
     event_and_magic_result = _run_event_and_magic_phase(
         db,
         simulation_id=simulation.id,
         run_id=run_id,
         tick=current_tick,
         agents=agents,
+        scheduled_events=(
+            (scheduled_event_input,) if scheduled_event_input is not None else ()
+        ),
     )
     participant_ids = {participant.agent_id for participant in participants}
     preselected_ids = [

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -5,8 +5,18 @@ from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 from uuid6 import uuid7
 
-from app.domain.models import Agent, Event, EventParticipant, Simulation
+from app.domain.models import (
+    Agent,
+    AgentState,
+    Event,
+    EventParticipant,
+    Relationship,
+    RuntimeResult,
+    Simulation,
+    StudentProfile,
+)
 from app.services.database_runtime_results import DatabaseRuntimeResultSink
+from app.services.event_magic_phase import EventAndMagicResult, run_event_and_magic_phase
 from app.services.policy_commit import PolicyCommitResult, evaluate_and_apply_policy
 from app.services.runtime_input_adapter import RuntimeInputAdapter
 from app.services.runtime_orchestrator import RuntimeOrchestrator
@@ -16,7 +26,19 @@ from app.simulation.agent_runtime import (
     AgentRuntimeResult,
     Block,
     ScheduleSummary,
+    SignalIntensity,
+    StateSignalType,
 )
+from app.simulation.event_master import (
+    AgentSummary as EventMasterAgentSummary,
+    RelationshipSummary as EventMasterRelationshipSummary,
+)
+from app.simulation.magic_layer import STUDENT_MISSING_STREAK_TICKS, AgentSnapshot as MagicAgentSnapshot
+from app.simulation.policy.models import (
+    AgentSnapshot as PolicyAgentSnapshot,
+    RelationshipSnapshot,
+)
+from app.simulation.policy.registries.signal_policy import get_state_delta
 from app.simulation.tick_engine import (
     AgentType,
     MemoryItem,
@@ -42,6 +64,7 @@ class ManualTickResult:
     policy_result: PolicyCommitResult
     retrieval_traces: dict[str, list[str]]
     retrieved_memories: dict[str, tuple[MemoryItem, ...]]
+    event_and_magic_result: EventAndMagicResult
 
 
 def tick_position(tick_number: int) -> tuple[int, Block]:
@@ -52,6 +75,210 @@ def tick_position(tick_number: int) -> tuple[int, Block]:
         (tick_number - 1) % 3
     ]
     return current_day, block
+
+
+def _reaction_stress_delta(intent: dict) -> int:
+    """RuntimeResult.intent에 이미 저장된 Reaction stress signal의 합산 delta.
+
+    registries.signal_policy.get_state_delta와 동일한 규칙을 재사용한다 —
+    새 계산 규칙이 아니라 evaluate_and_apply_policy가 실제로 적용한 것과
+    같은 함수를 그대로 호출해 역산 정확도를 보장한다.
+    """
+    total = 0
+    for signal in intent.get("reaction", {}).get("state_signals", []):
+        signal_type_value = signal.get("signal_type")
+        if signal_type_value not in (
+            StateSignalType.STRESS_UP.value,
+            StateSignalType.STRESS_DOWN.value,
+        ):
+            continue
+        total += get_state_delta(
+            StateSignalType(signal_type_value), SignalIntensity(signal["intensity"])
+        )
+    return total
+
+
+def _reconstruct_recent_stress(
+    db: Session,
+    *,
+    agent_ids: list[UUID],
+    current_tick: int,
+    current_stress_by_agent: dict[UUID, int],
+    window: int = STUDENT_MISSING_STREAK_TICKS,
+) -> dict[UUID, tuple[int, ...]]:
+    """최근 window tick의 stress 값을 기존 RuntimeResult 기록에서 역산한다.
+
+    새 history 저장소나 migration을 추가하지 않는다 — RuntimeResult.intent는
+    Task2 Runtime batch가 매 tick 이미 저장하는 값이며, 그 안의 Reaction
+    stress signal은 evaluate_and_apply_policy가 실제로 적용한 delta와 동일한
+    규칙(get_state_delta)으로 재현 가능하다. 현재 Tick 흐름에서 stress를
+    바꾸는 유일한 경로가 이 Runtime Reaction이므로(§Event/Magic 효과는 아직
+    커밋되지 않음, Task 5(#105) 이후 반영) 역산 결과가 실제 DB 값과 일치한다.
+
+    tick 연속성이 끊기면(그 tick에 RuntimeResult가 없음) 그 지점에서 멈춘다 —
+    불확실한 값을 추정하지 않는다. 결과가 window보다 짧으면 호출부의
+    "10/10" 스트릭 조건을 자연히 만족하지 못해 안전한 방향(미발생)으로
+    동작한다.
+    """
+    if not agent_ids:
+        return {}
+    earliest_tick = max(current_tick - window, 0)
+    rows = list(
+        db.scalars(
+            select(RuntimeResult)
+            .where(
+                RuntimeResult.agent_id.in_(agent_ids),
+                RuntimeResult.tick_number >= earliest_tick,
+                RuntimeResult.tick_number < current_tick,
+            )
+            .order_by(RuntimeResult.agent_id, RuntimeResult.tick_number.desc())
+        )
+    )
+    rows_by_agent: dict[UUID, list[RuntimeResult]] = {}
+    for row in rows:
+        rows_by_agent.setdefault(row.agent_id, []).append(row)
+
+    history: dict[UUID, tuple[int, ...]] = {}
+    for agent_id in agent_ids:
+        current = current_stress_by_agent.get(agent_id)
+        if current is None:
+            continue
+        values = [current]
+        running = current
+        expected_tick = current_tick - 1
+        for row in rows_by_agent.get(agent_id, []):
+            if row.tick_number != expected_tick:
+                break
+            running -= _reaction_stress_delta(row.intent)
+            values.append(running)
+            expected_tick -= 1
+        history[agent_id] = tuple(reversed(values))
+    return history
+
+
+def _run_event_and_magic_phase(
+    db: Session,
+    *,
+    simulation_id: UUID,
+    run_id: UUID,
+    tick: int,
+    agents: list[Agent],
+) -> EventAndMagicResult:
+    """Event Master -> Magic Layer -> Policy/Resolver 최소 wiring (Issue #101).
+
+    Task 3의 실종/저주 상태 전이는 여기서 적용하지 않는다 (missing_agent_ids만
+    special_events에 담겨 Task 5가 EventBatch로 변환한다). STUDENT_MISSING
+    판정용 recent_stress는 새 history 저장소 없이 기존 RuntimeResult 기록에서
+    역산한다 (``_reconstruct_recent_stress``).
+    """
+    agent_ids = [agent.id for agent in agents]
+    states = list(
+        db.scalars(select(AgentState).where(AgentState.agent_id.in_(agent_ids)))
+    )
+    states_by_agent_id = {state.agent_id: state for state in states}
+    student_profiles = {
+        profile.agent_id: profile
+        for profile in db.scalars(
+            select(StudentProfile).where(StudentProfile.agent_id.in_(agent_ids))
+        )
+    }
+    relationships = list(
+        db.scalars(
+            select(Relationship).where(Relationship.simulation_id == simulation_id)
+        )
+    )
+    recent_stress_by_agent = _reconstruct_recent_stress(
+        db,
+        agent_ids=agent_ids,
+        current_tick=tick,
+        current_stress_by_agent={
+            agent_id: state.stress for agent_id, state in states_by_agent_id.items()
+        },
+    )
+
+    agent_summaries: list[EventMasterAgentSummary] = []
+    magic_snapshots: list[MagicAgentSnapshot] = []
+    agent_state_snapshots: dict[str, PolicyAgentSnapshot] = {}
+    for agent in agents:
+        state = states_by_agent_id.get(agent.id)
+        if state is None:
+            continue
+        is_active = agent.active_status == "active"
+        major_id = None
+        year = None
+        if agent.id in student_profiles:
+            major_id = student_profiles[agent.id].interest_field
+            year = student_profiles[agent.id].grade
+        agent_summaries.append(
+            EventMasterAgentSummary(
+                agent_id=str(agent.id),
+                name=agent.name,
+                role=agent.agent_type,
+                major_id=major_id,
+                year=year,
+                active_status=is_active,
+                current_location_id=(
+                    str(state.location_id) if state.location_id else None
+                ),
+                mood=state.mood,
+                stress=state.stress,
+                fatigue=state.fatigue,
+            )
+        )
+        magic_snapshots.append(
+            MagicAgentSnapshot(
+                agent_id=str(agent.id),
+                agent_type=agent.agent_type,
+                active_status=is_active,
+                current_location_id=(
+                    str(state.location_id) if state.location_id else None
+                ),
+                fatigue=state.fatigue,
+                is_cursed=agent.cursed_until_tick is not None,
+                recent_stress=recent_stress_by_agent.get(agent.id, (state.stress,)),
+            )
+        )
+        agent_state_snapshots[str(agent.id)] = PolicyAgentSnapshot(
+            agent_id=str(agent.id),
+            hunger=state.hunger,
+            fatigue=state.fatigue,
+            stress=state.stress,
+            satisfaction=state.satisfaction,
+            mood=state.mood,
+        )
+
+    magic_relationship_snapshots = [
+        RelationshipSnapshot(
+            source_agent_id=str(relationship.source_agent_id),
+            target_agent_id=str(relationship.target_agent_id),
+            trust=relationship.trust,
+            tension=relationship.tension,
+            affection=relationship.affection,
+            closeness=relationship.closeness,
+            rivalry=relationship.rivalry,
+            dependency=relationship.dependency,
+        )
+        for relationship in relationships
+    ]
+    event_master_relationship_summaries = [
+        EventMasterRelationshipSummary(
+            source_agent_id=str(relationship.source_agent_id),
+            target_agent_id=str(relationship.target_agent_id),
+            affection=relationship.affection,
+            closeness=relationship.closeness,
+        )
+        for relationship in relationships
+    ]
+
+    return run_event_and_magic_phase(
+        run_id=str(run_id),
+        tick=tick,
+        agent_summaries=agent_summaries,
+        agent_state_snapshots=agent_state_snapshots,
+        magic_agent_snapshots=magic_snapshots,
+        event_master_relationship_summaries=event_master_relationship_summaries,
+        magic_relationship_snapshots=magic_relationship_snapshots,
+    )
 
 
 async def advance_manual_tick(
@@ -105,6 +332,13 @@ async def advance_manual_tick(
             )
             .order_by(Agent.fixture_key)
         )
+    )
+    event_and_magic_result = _run_event_and_magic_phase(
+        db,
+        simulation_id=simulation.id,
+        run_id=run_id,
+        tick=current_tick,
+        agents=agents,
     )
     participant_ids = {participant.agent_id for participant in participants}
     preselected_ids = [
@@ -212,4 +446,5 @@ async def advance_manual_tick(
             agent_id: tuple(memories)
             for agent_id, memories in snapshot.data.get("memories", {}).items()
         },
+        event_and_magic_result=event_and_magic_result,
     )

--- a/backend/app/simulation/event_master.py
+++ b/backend/app/simulation/event_master.py
@@ -1,0 +1,288 @@
+"""Slice 5 Task 1 — Event Master: deterministic general Event generation.
+
+Contract source: docs/04-feature-specs/slice-5-integration.md §1, §3 (Task 0
+confirmed). The LLM-narration design in docs/03-system-design/event-master.md
+is superseded for Task 1 by the integration doc's deterministic requirement
+(Issue #101: "동일 입력/seed/상태에서 결과가 흔들리면 안 됩니다") — Event Master
+here is pure system logic, no LLM call.
+
+Event Master's L1 ``AgentSummary`` is a distinct contract from Agent Runtime's
+``nearby_agents`` (``app.simulation.agent_runtime.AgentSummary``): this one is
+the full participant-candidate snapshot used to pick Event participants, not a
+per-observer visibility subset.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+# 예정 Event(schedule 기반)와 동적 Event(조건 기반) 구분. RANDOM_INCIDENT는
+# 동적 Event의 한 형태로, event_subtype이 실제 효과를 결정한다 (§1).
+SCHEDULED_EVENT_TYPES: frozenset[str] = frozenset(
+    {"CLASS", "EXAM", "MT", "FESTIVAL", "STUDENT_COUNCIL"}
+)
+
+
+class ImpactLevel(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+# 확정된 매핑 (slice-5-integration.md §1). 반드시 이 값만 사용한다.
+IMPACT_LEVEL_TO_IMPORTANCE: dict[ImpactLevel, int] = {
+    ImpactLevel.LOW: 30,
+    ImpactLevel.MEDIUM: 50,
+    ImpactLevel.HIGH: 80,
+}
+
+
+@dataclass(frozen=True)
+class AgentSummary:
+    """Event Master L1 참여 후보 snapshot (§3 L1 필드).
+
+    Agent Runtime의 nearby_agents(관찰 가능한 부분집합)와 혼동하지 말 것 — 이
+    summary는 전체 Event 참여 후보 목록이다.
+    """
+
+    agent_id: str
+    name: str
+    role: str  # "student" | "professor" | "user_persona"
+    major_id: str | None
+    year: int | None
+    active_status: bool
+    current_location_id: str | None
+    mood: int
+    stress: int
+    fatigue: int
+
+
+@dataclass(frozen=True)
+class RelationshipSummary:
+    """MEETING 후보 선정 전용 관계 요약 (§3: MEETING 후보 선정에만 사용)."""
+
+    source_agent_id: str
+    target_agent_id: str
+    affection: int
+    closeness: int
+
+
+@dataclass(frozen=True)
+class ScheduledEventInput:
+    """기존 Schedule/Event 구조에서 이미 활성화된 예정 Event를 그대로 재사용하는 입력.
+
+    Event Master는 예정 Event를 새로 생성하지 않고 변환만 한다.
+    """
+
+    event_id: str
+    event_type: str  # SCHEDULED_EVENT_TYPES 중 하나
+    location_id: str
+    participant_agent_ids: tuple[str, ...]
+    title: str = ""
+    description: str = ""
+    impact_level: ImpactLevel = ImpactLevel.MEDIUM
+
+
+@dataclass(frozen=True)
+class Event:
+    """Event Master 출력 계약 (§1)."""
+
+    event_key: str  # 결정론적 canonical 식별자 (effect_id 생성용, DB UUID 아님)
+    event_type: str
+    participant_agent_ids: tuple[str, ...]
+    location_id: str
+    tick: int
+    impact_level: ImpactLevel
+    importance: int
+    title: str
+    description: str
+    source: str = "event_master"
+    event_subtype: str | None = None
+    expected_effects: dict = field(default_factory=dict)
+
+
+def _importance_for(impact_level: ImpactLevel) -> int:
+    return IMPACT_LEVEL_TO_IMPORTANCE[impact_level]
+
+
+class EventMaster:
+    """Tick당 예정/동적 일반 Event를 결정론적으로 생성한다."""
+
+    def generate(
+        self,
+        *,
+        tick: int,
+        agent_summaries: Sequence[AgentSummary],
+        scheduled_events: Sequence[ScheduledEventInput] = (),
+        relationship_summaries: Sequence[RelationshipSummary] = (),
+    ) -> list[Event]:
+        active_by_id = {
+            summary.agent_id: summary for summary in agent_summaries if summary.active_status
+        }
+
+        events: list[Event] = []
+        events.extend(self._convert_scheduled(tick, active_by_id, scheduled_events))
+        events.extend(self._generate_group_project(tick, active_by_id))
+        events.extend(self._generate_meeting(tick, active_by_id, relationship_summaries))
+        return events
+
+    def build_random_incident(
+        self,
+        *,
+        tick: int,
+        event_subtype: str,
+        participant_agent_ids: Sequence[str],
+        location_id: str,
+        impact_level: ImpactLevel = ImpactLevel.MEDIUM,
+        title: str = "돌발 사건",
+        description: str = "",
+    ) -> Event:
+        """RANDOM_INCIDENT는 반드시 event_subtype을 가진다 (§1).
+
+        실제 효과는 Event Policy Registry의 event_subtype 규칙으로 결정되며,
+        Magic Layer의 special_events(마법 특수 사건)와는 별도 경로다.
+        """
+        if not event_subtype:
+            raise ValueError("RANDOM_INCIDENT requires event_subtype")
+        participant_ids = tuple(sorted(dict.fromkeys(participant_agent_ids)))
+        if not participant_ids:
+            raise ValueError("RANDOM_INCIDENT requires at least one participant")
+        return Event(
+            event_key=f"random_incident:{event_subtype}:{location_id}:{tick}",
+            event_type="RANDOM_INCIDENT",
+            event_subtype=event_subtype,
+            participant_agent_ids=participant_ids,
+            location_id=location_id,
+            tick=tick,
+            impact_level=impact_level,
+            importance=_importance_for(impact_level),
+            title=title,
+            description=description,
+        )
+
+    # ------------------------------------------------------------------
+    # 예정 Event 변환
+    # ------------------------------------------------------------------
+    def _convert_scheduled(
+        self,
+        tick: int,
+        active_by_id: dict[str, AgentSummary],
+        scheduled_events: Sequence[ScheduledEventInput],
+    ) -> list[Event]:
+        events: list[Event] = []
+        for scheduled in sorted(scheduled_events, key=lambda item: item.event_id):
+            if scheduled.event_type not in SCHEDULED_EVENT_TYPES:
+                continue
+            participant_ids = tuple(
+                sorted(
+                    agent_id
+                    for agent_id in scheduled.participant_agent_ids
+                    if agent_id in active_by_id
+                )
+            )
+            if not participant_ids:
+                continue
+            events.append(
+                Event(
+                    event_key=f"scheduled:{scheduled.event_id}",
+                    event_type=scheduled.event_type,
+                    participant_agent_ids=participant_ids,
+                    location_id=scheduled.location_id,
+                    tick=tick,
+                    impact_level=scheduled.impact_level,
+                    importance=_importance_for(scheduled.impact_level),
+                    title=scheduled.title or scheduled.event_type,
+                    description=scheduled.description,
+                )
+            )
+        return events
+
+    # ------------------------------------------------------------------
+    # 동적 Event: GROUP_PROJECT (같은 major_id 수강 Agent 우선, 2~4명)
+    # ------------------------------------------------------------------
+    def _generate_group_project(
+        self, tick: int, active_by_id: dict[str, AgentSummary]
+    ) -> list[Event]:
+        groups: dict[tuple[str, str], list[AgentSummary]] = {}
+        for summary in active_by_id.values():
+            if summary.role != "student" or not summary.major_id or not summary.current_location_id:
+                continue
+            key = (summary.major_id, summary.current_location_id)
+            groups.setdefault(key, []).append(summary)
+
+        events: list[Event] = []
+        for (major_id, location_id), members in sorted(groups.items()):
+            if len(members) < 2:
+                continue
+            participant_ids = tuple(
+                sorted(member.agent_id for member in members)[:4]
+            )
+            events.append(
+                Event(
+                    event_key=f"group_project:{major_id}:{location_id}:{tick}",
+                    event_type="GROUP_PROJECT",
+                    participant_agent_ids=participant_ids,
+                    location_id=location_id,
+                    tick=tick,
+                    impact_level=ImpactLevel.MEDIUM,
+                    importance=_importance_for(ImpactLevel.MEDIUM),
+                    title="조별 과제",
+                    description=f"{major_id} 전공 Student들이 조별 과제를 진행한다.",
+                )
+            )
+        return events
+
+    # ------------------------------------------------------------------
+    # 동적 Event: MEETING (같은 위치 + 기존 우호 관계, 2~5명)
+    # ------------------------------------------------------------------
+    def _generate_meeting(
+        self,
+        tick: int,
+        active_by_id: dict[str, AgentSummary],
+        relationship_summaries: Sequence[RelationshipSummary],
+    ) -> list[Event]:
+        # 우호적인 관계(affection+closeness 평균 > 0)만 MEETING 후보로 인정한다.
+        friendly_pairs = {
+            (rel.source_agent_id, rel.target_agent_id)
+            for rel in relationship_summaries
+            if (rel.affection + rel.closeness) / 2 > 0
+            and rel.source_agent_id in active_by_id
+            and rel.target_agent_id in active_by_id
+        }
+        if not friendly_pairs:
+            return []
+
+        groups: dict[str, set[str]] = {}
+        for source_id, target_id in friendly_pairs:
+            source = active_by_id[source_id]
+            target = active_by_id[target_id]
+            if (
+                source.current_location_id is None
+                or source.current_location_id != target.current_location_id
+            ):
+                continue
+            groups.setdefault(source.current_location_id, set()).update(
+                {source_id, target_id}
+            )
+
+        events: list[Event] = []
+        for location_id, members in sorted(groups.items()):
+            if len(members) < 2:
+                continue
+            participant_ids = tuple(sorted(members)[:5])
+            events.append(
+                Event(
+                    event_key=f"meeting:{location_id}:{tick}",
+                    event_type="MEETING",
+                    participant_agent_ids=participant_ids,
+                    location_id=location_id,
+                    tick=tick,
+                    impact_level=ImpactLevel.MEDIUM,
+                    importance=_importance_for(ImpactLevel.MEDIUM),
+                    title="친목 모임",
+                    description="친한 Agent들이 함께 모인다.",
+                )
+            )
+        return events

--- a/backend/app/simulation/magic_layer.py
+++ b/backend/app/simulation/magic_layer.py
@@ -1,0 +1,368 @@
+"""Slice 5 Task 1 — Magic Layer: deterministic special-Event condition judgment.
+
+Contract source: docs/04-feature-specs/slice-5-integration.md §2 (Task 0
+confirmed thresholds/priority) and docs/03-system-design/magic-layer.md §3.2.1
+(condition shape). No LLM narration in Task 1 — condition judgment is system
+logic only ("2026-07-24 확정: ... 고정 확률 기반 생성은 사용하지 않는다").
+
+Magic Layer never computes numeric deltas (magic-layer.md §2.1: "방향 정보만
+제공"). It only decides *which* special Event fires and *who/where*; the
+typed direction/intensity signals it emits are converted to canonical
+EffectCandidates by the Event Policy Registry (app.simulation.policy.registries
+.event_policy), reusing the existing Signal → Delta rules.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from app.simulation.event_master import Event
+from app.simulation.policy.models import RelationshipSnapshot
+
+# magic-layer.md §3.2.1, §3.2.2 확정 우선순위.
+STUDENT_MISSING = "STUDENT_MISSING"
+CURSE_SPREAD = "CURSE_SPREAD"
+MAGIC_EXPLOSION = "MAGIC_EXPLOSION"
+RITUAL_FAILURE = "RITUAL_FAILURE"
+MAGICAL_DISCOVERY = "MAGICAL_DISCOVERY"
+
+SPECIAL_EVENT_PRIORITY: tuple[str, ...] = (
+    STUDENT_MISSING,
+    CURSE_SPREAD,
+    MAGIC_EXPLOSION,
+    RITUAL_FAILURE,
+    MAGICAL_DISCOVERY,
+)
+
+# 확정 threshold (slice-5-integration.md §2).
+STUDENT_MISSING_STRESS_THRESHOLD = 90
+STUDENT_MISSING_STREAK_TICKS = 10
+STUDENT_MISSING_STREAK_REQUIRED = 10
+MAGIC_EXPLOSION_MIN_STUDENTS = 3
+MAGIC_EXPLOSION_FATIGUE_THRESHOLD = 80
+MAGIC_EXPLOSION_RATIO_THRESHOLD = 0.8
+RITUAL_FAILURE_MIN_PARTICIPANTS = 4
+
+# "나쁜 관계" threshold: 이 정확한 수치를 확정한 기존 문서/코드가 없어
+# (magic-layer.md §3.2.1은 "평균 trust 낮음 OR tension 높음"이라고만 서술),
+# app.domain.relationship_metrics.RELATIONSHIP_METRIC_RANGES의 기존 범위
+# (trust: -100~100, tension: 0~100) 중간값을 기준으로 결정한다. 새 수치
+# 체계를 만들지 않고 기존 range의 중립점을 그대로 재사용한 것이다.
+RITUAL_FAILURE_TRUST_THRESHOLD = 0
+RITUAL_FAILURE_TENSION_THRESHOLD = 50
+
+
+@dataclass(frozen=True)
+class AgentSnapshot:
+    """Magic Layer용 world_state Agent snapshot."""
+
+    agent_id: str
+    agent_type: str  # "student" | "professor" | "user_persona"
+    active_status: bool
+    current_location_id: str | None
+    fatigue: int
+    is_cursed: bool
+    # 최근 tick의 stress 값(오래된 → 최신 순). STUDENT_MISSING 스트릭 판정용.
+    recent_stress: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True)
+class SpecialEvent:
+    """Magic Layer 특수 Event 후보 (source=magic_layer)."""
+
+    event_subtype: str
+    participant_agent_ids: tuple[str, ...]
+    location_id: str | None
+    tick: int
+    title: str
+    description: str = ""
+    # STUDENT_MISSING 전용: 실종 후보(Student만). Task 3 persistence 입력의
+    # missing_agent_ids로 그대로 전달 가능하도록 별도 보관한다 (§2 계약).
+    missing_agent_ids: tuple[str, ...] = ()
+    # CURSE_SPREAD 전용: 저주가 새로 전파되는 대상.
+    newly_cursed_agent_ids: tuple[str, ...] = ()
+    # 주변/영향 Agent (예: STUDENT_MISSING 주변 stress 상승 대상).
+    affected_agent_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MagicLayerResult:
+    converted_events: tuple[Event, ...]
+    special_events: tuple[SpecialEvent, ...]
+
+
+def _is_missing_candidate(snapshot: AgentSnapshot) -> bool:
+    if snapshot.agent_type != "student" or not snapshot.active_status:
+        return False
+    if len(snapshot.recent_stress) < STUDENT_MISSING_STREAK_TICKS:
+        return False
+    recent = snapshot.recent_stress[-STUDENT_MISSING_STREAK_TICKS:]
+    hits = sum(1 for value in recent if value >= STUDENT_MISSING_STRESS_THRESHOLD)
+    return hits >= STUDENT_MISSING_STREAK_REQUIRED
+
+
+def _same_location_others(
+    agent_id: str, location_id: str | None, snapshots: Sequence[AgentSnapshot]
+) -> list[str]:
+    if location_id is None:
+        return []
+    return sorted(
+        snapshot.agent_id
+        for snapshot in snapshots
+        if snapshot.agent_id != agent_id
+        and snapshot.active_status
+        and snapshot.current_location_id == location_id
+    )
+
+
+class MagicLayer:
+    """converted_events + special_events를 결정론적으로 생성한다."""
+
+    def evaluate(
+        self,
+        *,
+        tick: int,
+        regular_events: Sequence[Event],
+        agent_snapshots: Sequence[AgentSnapshot],
+        relationship_snapshots: Sequence[RelationshipSnapshot] = (),
+        lab_location_ids: frozenset[str] = frozenset(),
+    ) -> MagicLayerResult:
+        converted = tuple(self._convert(event) for event in regular_events)
+        candidates = self._collect_candidates(
+            tick=tick,
+            agent_snapshots=agent_snapshots,
+            relationship_snapshots=relationship_snapshots,
+            lab_location_ids=lab_location_ids,
+        )
+        selected = self._select_by_priority(candidates)
+        return MagicLayerResult(
+            converted_events=converted,
+            special_events=tuple(selected) if selected is not None else (),
+        )
+
+    @staticmethod
+    def _convert(event: Event) -> Event:
+        # Task 1 범위에서는 세계관 텍스트 변환(LLM)을 생략하고 원본 Event를
+        # 그대로 전달한다 (magic-layer.md §4.2: LLM 실패 시 원본 반환과 동일한
+        # 형태). source/effect 계약은 event_master 그대로 유지된다.
+        return event
+
+    def _collect_candidates(
+        self,
+        *,
+        tick: int,
+        agent_snapshots: Sequence[AgentSnapshot],
+        relationship_snapshots: Sequence[RelationshipSnapshot],
+        lab_location_ids: frozenset[str],
+    ) -> dict[str, list[SpecialEvent]]:
+        by_subtype: dict[str, list[SpecialEvent]] = {}
+        by_subtype[STUDENT_MISSING] = self._student_missing_candidates(tick, agent_snapshots)
+        by_subtype[CURSE_SPREAD] = self._curse_spread_candidates(tick, agent_snapshots)
+        by_subtype[MAGIC_EXPLOSION] = self._magic_explosion_candidates(tick, agent_snapshots)
+        by_subtype[RITUAL_FAILURE] = self._ritual_failure_candidates(
+            tick, agent_snapshots, relationship_snapshots
+        )
+        by_subtype[MAGICAL_DISCOVERY] = self._magical_discovery_candidates(
+            tick, agent_snapshots, lab_location_ids
+        )
+        return by_subtype
+
+    @staticmethod
+    def _select_by_priority(
+        candidates: dict[str, list[SpecialEvent]],
+    ) -> list[SpecialEvent] | None:
+        for event_subtype in SPECIAL_EVENT_PRIORITY:
+            found = candidates.get(event_subtype) or []
+            if found:
+                return found
+        return None
+
+    # ------------------------------------------------------------------
+    # 1) STUDENT_MISSING
+    # ------------------------------------------------------------------
+    def _student_missing_candidates(
+        self, tick: int, snapshots: Sequence[AgentSnapshot]
+    ) -> list[SpecialEvent]:
+        events: list[SpecialEvent] = []
+        for snapshot in sorted(snapshots, key=lambda item: item.agent_id):
+            if not _is_missing_candidate(snapshot):
+                continue
+            affected = _same_location_others(
+                snapshot.agent_id, snapshot.current_location_id, snapshots
+            )
+            events.append(
+                SpecialEvent(
+                    event_subtype=STUDENT_MISSING,
+                    participant_agent_ids=(snapshot.agent_id,),
+                    location_id=snapshot.current_location_id,
+                    tick=tick,
+                    title="학생 실종",
+                    missing_agent_ids=(snapshot.agent_id,),
+                    affected_agent_ids=tuple(affected),
+                )
+            )
+        return events
+
+    # ------------------------------------------------------------------
+    # 2) CURSE_SPREAD
+    # ------------------------------------------------------------------
+    def _curse_spread_candidates(
+        self, tick: int, snapshots: Sequence[AgentSnapshot]
+    ) -> list[SpecialEvent]:
+        cursed_ids = {s.agent_id for s in snapshots if s.is_cursed}
+        if not cursed_ids:
+            return []
+        events: list[SpecialEvent] = []
+        for snapshot in sorted(snapshots, key=lambda item: item.agent_id):
+            if snapshot.agent_id not in cursed_ids:
+                continue
+            contacts = [
+                other_id
+                for other_id in _same_location_others(
+                    snapshot.agent_id, snapshot.current_location_id, snapshots
+                )
+                # 접촉했지만 이미 저주 상태인 대상은 새로 전파되지 않음 —
+                # CURSED source 자체와 이미 CURSED인 대상에 중복 적용하지 않는다.
+                if other_id not in cursed_ids
+            ]
+            if not contacts:
+                continue
+            events.append(
+                SpecialEvent(
+                    event_subtype=CURSE_SPREAD,
+                    participant_agent_ids=(snapshot.agent_id, *contacts),
+                    location_id=snapshot.current_location_id,
+                    tick=tick,
+                    title="저주 전파",
+                    newly_cursed_agent_ids=tuple(contacts),
+                    affected_agent_ids=tuple(contacts),
+                )
+            )
+        return events
+
+    # ------------------------------------------------------------------
+    # 3) MAGIC_EXPLOSION
+    # ------------------------------------------------------------------
+    def _magic_explosion_candidates(
+        self, tick: int, snapshots: Sequence[AgentSnapshot]
+    ) -> list[SpecialEvent]:
+        by_location: dict[str, list[AgentSnapshot]] = {}
+        for snapshot in snapshots:
+            if (
+                snapshot.agent_type != "student"
+                or not snapshot.active_status
+                or snapshot.current_location_id is None
+            ):
+                continue
+            by_location.setdefault(snapshot.current_location_id, []).append(snapshot)
+
+        events: list[SpecialEvent] = []
+        for location_id, students in sorted(by_location.items()):
+            if len(students) < MAGIC_EXPLOSION_MIN_STUDENTS:
+                continue
+            high_fatigue = sum(
+                1 for s in students if s.fatigue >= MAGIC_EXPLOSION_FATIGUE_THRESHOLD
+            )
+            if high_fatigue / len(students) < MAGIC_EXPLOSION_RATIO_THRESHOLD:
+                continue
+            participant_ids = tuple(sorted(s.agent_id for s in students))
+            events.append(
+                SpecialEvent(
+                    event_subtype=MAGIC_EXPLOSION,
+                    participant_agent_ids=participant_ids,
+                    location_id=location_id,
+                    tick=tick,
+                    title="마법 폭발",
+                    affected_agent_ids=participant_ids,
+                )
+            )
+        return events
+
+    # ------------------------------------------------------------------
+    # 4) RITUAL_FAILURE
+    # ------------------------------------------------------------------
+    def _ritual_failure_candidates(
+        self,
+        tick: int,
+        snapshots: Sequence[AgentSnapshot],
+        relationship_snapshots: Sequence[RelationshipSnapshot],
+    ) -> list[SpecialEvent]:
+        by_location: dict[str, list[AgentSnapshot]] = {}
+        for snapshot in snapshots:
+            if not snapshot.active_status or snapshot.current_location_id is None:
+                continue
+            by_location.setdefault(snapshot.current_location_id, []).append(snapshot)
+
+        events: list[SpecialEvent] = []
+        for location_id, members in sorted(by_location.items()):
+            if len(members) < RITUAL_FAILURE_MIN_PARTICIPANTS:
+                continue
+            member_ids = {m.agent_id for m in members}
+            pair_metrics = [
+                rel
+                for rel in relationship_snapshots
+                if rel.source_agent_id in member_ids and rel.target_agent_id in member_ids
+            ]
+            if not pair_metrics:
+                continue
+            avg_trust = sum(rel.trust for rel in pair_metrics) / len(pair_metrics)
+            avg_tension = sum(rel.tension for rel in pair_metrics) / len(pair_metrics)
+            bad_relationship = (
+                avg_trust < RITUAL_FAILURE_TRUST_THRESHOLD
+                or avg_tension > RITUAL_FAILURE_TENSION_THRESHOLD
+            )
+            if not bad_relationship:
+                continue
+            participant_ids = tuple(sorted(member_ids))
+            events.append(
+                SpecialEvent(
+                    event_subtype=RITUAL_FAILURE,
+                    participant_agent_ids=participant_ids,
+                    location_id=location_id,
+                    tick=tick,
+                    title="의식 실패",
+                    affected_agent_ids=participant_ids,
+                )
+            )
+        return events
+
+    # ------------------------------------------------------------------
+    # 5) MAGICAL_DISCOVERY (다른 후보가 전혀 없을 때만 — 우선순위로 선택되므로
+    #    여기서는 후보 존재 여부만 판정한다)
+    # ------------------------------------------------------------------
+    def _magical_discovery_candidates(
+        self,
+        tick: int,
+        snapshots: Sequence[AgentSnapshot],
+        lab_location_ids: frozenset[str],
+    ) -> list[SpecialEvent]:
+        if not lab_location_ids:
+            return []
+        by_location: dict[str, list[AgentSnapshot]] = {}
+        for snapshot in snapshots:
+            if (
+                not snapshot.active_status
+                or snapshot.current_location_id not in lab_location_ids
+            ):
+                continue
+            by_location.setdefault(snapshot.current_location_id, []).append(snapshot)
+
+        events: list[SpecialEvent] = []
+        for location_id, members in sorted(by_location.items()):
+            has_professor = any(m.agent_type == "professor" for m in members)
+            has_student = any(m.agent_type == "student" for m in members)
+            if not (has_professor and has_student):
+                continue
+            participant_ids = tuple(sorted(m.agent_id for m in members))
+            events.append(
+                SpecialEvent(
+                    event_subtype=MAGICAL_DISCOVERY,
+                    participant_agent_ids=participant_ids,
+                    location_id=location_id,
+                    tick=tick,
+                    title="마법 발견",
+                    affected_agent_ids=participant_ids,
+                )
+            )
+        return events

--- a/backend/app/simulation/policy/registries/event_policy.py
+++ b/backend/app/simulation/policy/registries/event_policy.py
@@ -1,0 +1,191 @@
+"""Slice 5 Task 1 — Event Policy Registry.
+
+Converts Event Master's general Event effects and Magic Layer's typed
+direction/intensity signals into canonical ``EffectCandidate``s, reusing the
+existing Signal → Delta rules (``registries.signal_policy``) and Policy models
+(``policy.models``). Numbers come from docs/03-system-design/policy-signal-delta.md
+§7/§8.1, restated in docs/04-feature-specs/slice-5-integration.md §1/§2 (Task 0
+confirmed values — this module must not invent new numbers).
+
+Relationship changes are never produced here (both docs: "관계 변화는 Event
+기본 효과로 만들지 마세요" / Reaction 전용 typed RelationshipSignal 경로만 사용).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from app.simulation.agent_runtime import SignalIntensity, StateSignalType
+from app.simulation.event_master import Event
+from app.simulation.magic_layer import (
+    CURSE_SPREAD,
+    MAGIC_EXPLOSION,
+    MAGICAL_DISCOVERY,
+    RITUAL_FAILURE,
+    STUDENT_MISSING,
+    SpecialEvent,
+)
+from app.simulation.policy.models import AgentSnapshot, EffectCandidate, EffectTargetType
+from app.simulation.policy.registries.signal_policy import get_state_delta
+
+# 일반 Event Policy Registry — 참여 Agent 대상 기본 효과 (policy-signal-delta.md §7).
+EVENT_BASE_EFFECTS: dict[str, tuple[tuple[str, int], ...]] = {
+    "CLASS": (("stress", 1),),
+    "GROUP_PROJECT": (("stress", 3),),
+    "EXAM": (("stress", 8), ("fatigue", 5)),
+    "MEETING": (("satisfaction", 2),),
+    "MT": (("satisfaction", 5), ("fatigue", 5), ("hunger", 3)),
+    "FESTIVAL": (("satisfaction", 6), ("fatigue", 4), ("hunger", 3)),
+}
+
+# RANDOM_INCIDENT event_subtype별 등록 효과. 확정된 subtype 규칙이 아직 없어
+# 비워둔다 — 미등록 subtype은 효과 없이 거부한다(policy-signal-delta.md §2.2와
+# 동일 원칙: "Registry에 등록되지 않은 ... 거부하고 warning을 남긴다").
+RANDOM_INCIDENT_EFFECTS: dict[str, tuple[tuple[str, int], ...]] = {}
+
+# Magic Layer 특수 Event → typed state signal 매핑 (slice-5-integration.md §2,
+# policy-signal-delta.md §8.1). Magic Layer는 방향/강도만 주고, 실제 delta는
+# 아래 signal_policy.get_state_delta로 계산한다.
+MagicSignalRule = tuple[StateSignalType, SignalIntensity]
+
+MAGIC_AFFECTED_SIGNALS: dict[str, MagicSignalRule] = {
+    STUDENT_MISSING: (StateSignalType.STRESS_UP, SignalIntensity.MEDIUM),
+    CURSE_SPREAD: (StateSignalType.MOOD_DOWN, SignalIntensity.HIGH),
+    MAGIC_EXPLOSION: (StateSignalType.STRESS_UP, SignalIntensity.HIGH),
+    RITUAL_FAILURE: (StateSignalType.STRESS_UP, SignalIntensity.HIGH),
+    MAGICAL_DISCOVERY: (StateSignalType.MOOD_UP, SignalIntensity.MEDIUM),
+}
+
+# CURSE_SPREAD·MAGIC_EXPLOSION·MAGICAL_DISCOVERY는 확정 표에 두 번째 state 효과가 있다.
+MAGIC_SECONDARY_SIGNALS: dict[str, MagicSignalRule] = {
+    CURSE_SPREAD: (StateSignalType.SATISFACTION_DOWN, SignalIntensity.HIGH),
+    MAGIC_EXPLOSION: (StateSignalType.FATIGUE_UP, SignalIntensity.HIGH),
+    MAGICAL_DISCOVERY: (StateSignalType.SATISFACTION_UP, SignalIntensity.HIGH),
+}
+
+
+def _state_value(agent_snapshot: AgentSnapshot, metric: str) -> int:
+    return getattr(agent_snapshot, metric)
+
+
+def build_event_effect_candidates(
+    event: Event,
+    *,
+    run_id: str,
+    agent_snapshots: Mapping[str, AgentSnapshot],
+) -> list[EffectCandidate]:
+    """일반 Event(및 RANDOM_INCIDENT)의 참여 Agent 기본 효과를 EffectCandidate로 변환한다."""
+    if event.event_type == "RANDOM_INCIDENT":
+        rules = RANDOM_INCIDENT_EFFECTS.get(event.event_subtype or "", ())
+    else:
+        rules = EVENT_BASE_EFFECTS.get(event.event_type, ())
+    if not rules:
+        return []
+
+    candidates: list[EffectCandidate] = []
+    for agent_id in event.participant_agent_ids:
+        snapshot = agent_snapshots.get(agent_id)
+        if snapshot is None:
+            continue
+        for metric, delta in rules:
+            current = _state_value(snapshot, metric)
+            candidates.append(
+                EffectCandidate(
+                    effect_id=(
+                        f"{run_id}:{event.tick}:{agent_id}:event:"
+                        f"{event.event_key}:{metric}"
+                    ),
+                    target_type=EffectTargetType.AGENT_STATE,
+                    source_agent_id=agent_id,
+                    target_agent_id=None,
+                    metric=metric,
+                    delta=delta,
+                    before=current,
+                    after_preview=current,
+                    rule_id=f"EVENT_{event.event_type}",
+                    reason=f"{event.event_type} 참여 기본 효과",
+                )
+            )
+    return candidates
+
+
+def _build_magic_signal_candidate(
+    *,
+    run_id: str,
+    special_event: SpecialEvent,
+    agent_id: str,
+    signal_type: StateSignalType,
+    intensity: SignalIntensity,
+    agent_snapshots: Mapping[str, AgentSnapshot],
+) -> EffectCandidate | None:
+    snapshot = agent_snapshots.get(agent_id)
+    if snapshot is None:
+        return None
+    metric = {
+        StateSignalType.STRESS_UP: "stress",
+        StateSignalType.MOOD_DOWN: "mood",
+        StateSignalType.MOOD_UP: "mood",
+        StateSignalType.SATISFACTION_DOWN: "satisfaction",
+        StateSignalType.SATISFACTION_UP: "satisfaction",
+        StateSignalType.FATIGUE_UP: "fatigue",
+    }[signal_type]
+    current = _state_value(snapshot, metric)
+    delta = get_state_delta(signal_type, intensity)
+    origin = special_event.participant_agent_ids[0] if special_event.participant_agent_ids else "-"
+    return EffectCandidate(
+        effect_id=(
+            f"{run_id}:{special_event.tick}:{agent_id}:magic:"
+            f"{special_event.event_subtype}:{origin}:{metric}"
+        ),
+        target_type=EffectTargetType.AGENT_STATE,
+        source_agent_id=agent_id,
+        target_agent_id=None,
+        metric=metric,
+        delta=delta,
+        before=current,
+        after_preview=current,
+        rule_id=f"MAGIC_{special_event.event_subtype}_{signal_type}_{intensity}",
+        reason=f"{special_event.event_subtype} 영향",
+    )
+
+
+def build_magic_effect_candidates(
+    special_events: Sequence[SpecialEvent],
+    *,
+    run_id: str,
+    agent_snapshots: Mapping[str, AgentSnapshot],
+) -> list[EffectCandidate]:
+    """Magic Layer 특수 Event의 typed signal을 EffectCandidate로 변환한다.
+
+    STUDENT_MISSING의 MISSING 상태 자체(active_status 전이)는 EffectCandidate로
+    표현하지 않는다 — Task 3 persistence(#103)의 missing_agent_ids 경계다.
+    """
+    candidates: list[EffectCandidate] = []
+    for special_event in special_events:
+        primary_rule = MAGIC_AFFECTED_SIGNALS.get(special_event.event_subtype)
+        secondary_rule = MAGIC_SECONDARY_SIGNALS.get(special_event.event_subtype)
+        affected_ids = special_event.affected_agent_ids
+        for agent_id in affected_ids:
+            if primary_rule is not None:
+                candidate = _build_magic_signal_candidate(
+                    run_id=run_id,
+                    special_event=special_event,
+                    agent_id=agent_id,
+                    signal_type=primary_rule[0],
+                    intensity=primary_rule[1],
+                    agent_snapshots=agent_snapshots,
+                )
+                if candidate is not None:
+                    candidates.append(candidate)
+            if secondary_rule is not None:
+                candidate = _build_magic_signal_candidate(
+                    run_id=run_id,
+                    special_event=special_event,
+                    agent_id=agent_id,
+                    signal_type=secondary_rule[0],
+                    intensity=secondary_rule[1],
+                    agent_snapshots=agent_snapshots,
+                )
+                if candidate is not None:
+                    candidates.append(candidate)
+    return candidates

--- a/backend/tests/test_event_magic_policy_integration.py
+++ b/backend/tests/test_event_magic_policy_integration.py
@@ -1,0 +1,509 @@
+"""Slice 5 Task 1 — Event/Magic -> Policy/Resolver integration tests (Issue #101)."""
+
+import os
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.domain.event_persistence import EventBatch, EventWrite, StateDelta
+from app.domain.models import Agent, AgentState, Simulation, User
+from app.services.event_persistence import persist_event_batch
+from app.services.fixtures import seed_slice_zero
+from app.simulation.event_master import (
+    AgentSummary,
+    Event,
+    EventMaster,
+    ImpactLevel,
+    ScheduledEventInput,
+)
+from app.simulation.magic_layer import (
+    MagicLayer,
+    SpecialEvent,
+    STUDENT_MISSING,
+    STUDENT_MISSING_STREAK_TICKS,
+)
+from app.simulation.magic_layer import AgentSnapshot as MagicAgentSnapshot
+from app.simulation.policy.conflict import resolve_conflicts
+from app.simulation.policy.models import AgentSnapshot as PolicyAgentSnapshot, EffectTargetType
+from app.simulation.policy.registries.event_policy import (
+    build_event_effect_candidates,
+    build_magic_effect_candidates,
+)
+from app.services.event_magic_phase import run_event_and_magic_phase
+
+
+def _snapshot(agent_id: str, **overrides) -> PolicyAgentSnapshot:
+    base = dict(agent_id=agent_id, hunger=50, fatigue=10, stress=10, satisfaction=50, mood=0)
+    base.update(overrides)
+    return PolicyAgentSnapshot(**base)
+
+
+# ---------------------------------------------------------------------------
+# 15. Event 기본 effect candidate 생성
+# ---------------------------------------------------------------------------
+def test_event_base_effect_candidates_use_registered_deltas():
+    event = Event(
+        event_key="k1",
+        event_type="EXAM",
+        participant_agent_ids=("s1",),
+        location_id="classroom",
+        tick=1,
+        impact_level=ImpactLevel.HIGH,
+        importance=80,
+        title="기말고사",
+        description="",
+    )
+    candidates = build_event_effect_candidates(
+        event, run_id="run-1", agent_snapshots={"s1": _snapshot("s1", stress=10, fatigue=10)}
+    )
+    by_metric = {c.metric: c for c in candidates}
+    assert by_metric["stress"].delta == 8
+    assert by_metric["fatigue"].delta == 5
+    assert all(c.target_type == EffectTargetType.AGENT_STATE for c in candidates)
+
+
+# ---------------------------------------------------------------------------
+# 16. Magic signal -> 기존 Policy delta 변환
+# ---------------------------------------------------------------------------
+def test_magic_signal_uses_existing_signal_policy_delta():
+    special = SpecialEvent(
+        event_subtype=STUDENT_MISSING,
+        participant_agent_ids=("m1",),
+        location_id="dormitory",
+        tick=1,
+        title="학생 실종",
+        missing_agent_ids=("m1",),
+        affected_agent_ids=("neighbor1",),
+    )
+    candidates = build_magic_effect_candidates(
+        [special], run_id="run-1", agent_snapshots={"neighbor1": _snapshot("neighbor1", stress=20)}
+    )
+    assert len(candidates) == 1
+    # STRESS_UP/MEDIUM -> signal_policy.get_state_delta 값(=+5)과 동일해야 한다.
+    assert candidates[0].delta == 5
+    assert candidates[0].metric == "stress"
+    assert candidates[0].source_agent_id == "neighbor1"
+
+
+# ---------------------------------------------------------------------------
+# 17. 관계 변화가 Event 기본 효과에서 직접 생성되지 않음
+# ---------------------------------------------------------------------------
+def test_event_base_effects_never_produce_relationship_candidates():
+    event = Event(
+        event_key="k1",
+        event_type="MT",
+        participant_agent_ids=("s1", "s2"),
+        location_id="resort",
+        tick=1,
+        impact_level=ImpactLevel.MEDIUM,
+        importance=50,
+        title="MT",
+        description="",
+    )
+    candidates = build_event_effect_candidates(
+        event,
+        run_id="run-1",
+        agent_snapshots={"s1": _snapshot("s1"), "s2": _snapshot("s2")},
+    )
+    assert all(c.target_type == EffectTargetType.AGENT_STATE for c in candidates)
+    assert all(c.target_agent_id is None for c in candidates)
+
+
+# ---------------------------------------------------------------------------
+# 18. canonical effect_id dedup과 기존 Task2 resolver 호환
+# ---------------------------------------------------------------------------
+def test_duplicate_event_candidates_are_deduplicated_by_resolver():
+    event = Event(
+        event_key="k1",
+        event_type="CLASS",
+        participant_agent_ids=("s1",),
+        location_id="classroom",
+        tick=1,
+        impact_level=ImpactLevel.MEDIUM,
+        importance=50,
+        title="수업",
+        description="",
+    )
+    candidates = build_event_effect_candidates(
+        event, run_id="run-1", agent_snapshots={"s1": _snapshot("s1", stress=10)}
+    )
+    resolved = resolve_conflicts([*candidates, *candidates])  # 같은 후보가 두 경로에서 온 상황 시뮬레이션
+    assert len(resolved) == 1
+    assert resolved[0].delta == 1  # 중복 제거되어 두 배로 합산되지 않음
+
+
+# ---------------------------------------------------------------------------
+# 19. 동일 effect_id conflicting payload 거부 유지
+# ---------------------------------------------------------------------------
+def test_conflicting_payload_for_same_effect_id_is_rejected():
+    event = Event(
+        event_key="k1",
+        event_type="CLASS",
+        participant_agent_ids=("s1",),
+        location_id="classroom",
+        tick=1,
+        impact_level=ImpactLevel.MEDIUM,
+        importance=50,
+        title="수업",
+        description="",
+    )
+    candidates = build_event_effect_candidates(
+        event, run_id="run-1", agent_snapshots={"s1": _snapshot("s1", stress=10)}
+    )
+    conflicting = build_event_effect_candidates(
+        event, run_id="run-1", agent_snapshots={"s1": _snapshot("s1", stress=99)}
+    )
+    import pytest
+    from app.simulation.policy.conflict import ConflictingEffectIdError
+
+    with pytest.raises(ConflictingEffectIdError):
+        resolve_conflicts([*candidates, *conflicting])
+
+
+# ---------------------------------------------------------------------------
+# 20. Event Master -> Magic -> Policy 실제 호출 경로
+# ---------------------------------------------------------------------------
+def test_run_event_and_magic_phase_full_pipeline():
+    agent_summaries = [
+        AgentSummary(
+            agent_id="s1", name="아델", role="student", major_id="방어 마법", year=1,
+            active_status=True, current_location_id="classroom", mood=0, stress=10, fatigue=10,
+        )
+    ]
+    scheduled = [
+        ScheduledEventInput(
+            event_id="evt-1", event_type="CLASS", location_id="classroom",
+            participant_agent_ids=("s1",),
+        )
+    ]
+    result = run_event_and_magic_phase(
+        run_id="run-1",
+        tick=1,
+        agent_summaries=agent_summaries,
+        agent_state_snapshots={"s1": _snapshot("s1", stress=10)},
+        magic_agent_snapshots=[
+            MagicAgentSnapshot(
+                agent_id="s1", agent_type="student", active_status=True,
+                current_location_id="classroom", fatigue=10, is_cursed=False,
+            )
+        ],
+        scheduled_events=scheduled,
+    )
+    assert len(result.events) == 1
+    assert result.events[0].event_type == "CLASS"
+    assert len(result.resolved_effects) == 1
+    assert result.resolved_effects[0].metric == "stress"
+    assert result.resolved_effects[0].delta == 1
+
+
+# ---------------------------------------------------------------------------
+# 21. Task 3 EventBatch/persistence 입력으로 변환 가능한 결과 계약
+# ---------------------------------------------------------------------------
+def test_event_master_output_is_convertible_to_task3_event_write():
+    event = EventMaster().generate(
+        tick=1,
+        agent_summaries=[
+            AgentSummary(
+                agent_id="s1", name="아델", role="student", major_id=None, year=1,
+                active_status=True, current_location_id="c1", mood=0, stress=0, fatigue=0,
+            )
+        ],
+        scheduled_events=[
+            ScheduledEventInput(
+                event_id="evt-1", event_type="CLASS", location_id="c1",
+                participant_agent_ids=("s1",), title="수업",
+            )
+        ],
+    )[0]
+
+    # Task 5가 실제 저장 시 수행할 변환과 동일한 필드 매핑이 예외 없이 성립해야 한다.
+    write = EventWrite(
+        id=uuid4(),
+        event_type=event.event_type,
+        event_subtype=event.event_subtype,
+        title=event.title,
+        description=event.description or "-",
+        participant_agent_ids=(uuid4(),),
+        location_id=uuid4(),
+        source=event.source,
+        impact_level=event.impact_level.value,
+        importance=event.importance,
+        expected_effects=event.expected_effects,
+    )
+    assert write.event_type == "CLASS"
+
+    delta = StateDelta(
+        source_agent_id=uuid4(), metric="stress", before=10, requested_total=1,
+        applied_delta=1, after=11, effect_ids=("k1",),
+    )
+    batch = EventBatch(
+        simulation_id=uuid4(), run_id="run-1", tick_number=1,
+        policy_version="policy-mvp-0.1", resolver_version="resolver-mvp-0.1",
+        resolution_id="run-1:1", events=(write,), resolved_effects=(delta,),
+    )
+    assert batch.events[0].event_type == "CLASS"
+
+
+# ---------------------------------------------------------------------------
+# 22. STUDENT_MISSING 상태가 Task1과 Task3에서 이중 적용되지 않음
+# ---------------------------------------------------------------------------
+def test_student_missing_produces_no_active_status_effect_candidate():
+    snapshots = [
+        MagicAgentSnapshot(
+            agent_id="m1", agent_type="student", active_status=True,
+            current_location_id="dormitory", fatigue=10, is_cursed=False,
+            recent_stress=tuple([95] * 10),
+        ),
+        MagicAgentSnapshot(
+            agent_id="neighbor1", agent_type="student", active_status=True,
+            current_location_id="dormitory", fatigue=10, is_cursed=False,
+        ),
+    ]
+    magic_result = MagicLayer().evaluate(tick=11, regular_events=[], agent_snapshots=snapshots)
+    special = magic_result.special_events[0]
+    assert special.event_subtype == STUDENT_MISSING
+    assert special.missing_agent_ids == ("m1",)
+
+    candidates = build_magic_effect_candidates(
+        magic_result.special_events,
+        run_id="run-1",
+        agent_snapshots={"m1": _snapshot("m1"), "neighbor1": _snapshot("neighbor1")},
+    )
+    # EffectCandidate는 AGENT_STATE(hunger/fatigue/stress/satisfaction/mood)와
+    # RELATIONSHIP만 표현할 수 있다 — active_status 전이는 여기서 만들어질 수
+    # 없고, missing_agent_ids로만 Task 3(#103)에 전달된다.
+    assert all(c.source_agent_id != "m1" for c in candidates)
+    assert {c.source_agent_id for c in candidates} == {"neighbor1"}
+
+
+# ---------------------------------------------------------------------------
+# Task 3 handoff: Magic Layer STUDENT_MISSING candidate -> 실제
+# persist_event_batch() 호출 -> INACTIVE_TEMPORARY -> ACTIVE+CURSED -> 해제.
+# Task1은 이 전이를 직접 mutation하지 않고, Task3(#103)의 실제 서비스가
+# Task1의 산출물(missing_agent_ids)을 그대로 받아 처리함을 증명한다.
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def db():
+    url = os.getenv("TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("TEST_DATABASE_URL required")
+    engine = create_engine(url)
+    with engine.connect() as connection:
+        outer = connection.begin()
+        with Session(connection, join_transaction_mode="create_savepoint") as session:
+            yield session
+        outer.rollback()
+    engine.dispose()
+
+
+def _setup_simulation(db):
+    user = User(id=uuid4(), username=str(uuid4()), display_name="test", password_hash="test", roles=["USER"])
+    db.add(user)
+    db.flush()
+    simulation = Simulation(id=uuid4(), owner_id=user.id, name="Task1-Task3 handoff")
+    db.add(simulation)
+    db.flush()
+    seed_slice_zero(db, simulation.id)
+    db.commit()
+    return simulation.id
+
+
+def test_student_missing_candidate_drives_real_task3_transition_cycle(db):
+    """Tick N: Task1 STUDENT_MISSING 후보 -> Task3 실제 서비스로 전체 사이클 검증."""
+    simulation_id = _setup_simulation(db)
+    agents = list(
+        db.scalars(select(Agent).where(Agent.simulation_id == simulation_id).order_by(Agent.fixture_key))
+    )
+    target = next(a for a in agents if a.fixture_key == "student-02")
+    others = [a for a in agents if a.id != target.id]
+    states_by_agent = {
+        state.agent_id: state
+        for state in db.scalars(select(AgentState).where(AgentState.simulation_id == simulation_id))
+    }
+    location_id = states_by_agent[target.id].location_id
+
+    # Task1: Magic Layer가 실제로 STUDENT_MISSING 후보를 판정한다 (10/10 스트릭).
+    magic_snapshots = [
+        MagicAgentSnapshot(
+            agent_id=str(target.id), agent_type="student", active_status=True,
+            current_location_id=str(location_id), fatigue=10, is_cursed=False,
+            recent_stress=tuple([95] * 10),
+        )
+    ]
+    magic_result = MagicLayer().evaluate(tick=1, regular_events=[], agent_snapshots=magic_snapshots)
+    special = magic_result.special_events[0]
+    assert special.event_subtype == STUDENT_MISSING
+    assert special.missing_agent_ids == (str(target.id),)
+
+    # Task1 -> Task3 계약 변환: Magic 후보를 EventWrite/EventBatch로 감싸기만 한다
+    # (Task1은 여기서 active_status/inactive_until_tick을 직접 건드리지 않는다).
+    missing_write = EventWrite(
+        id=uuid4(), event_type=special.event_subtype, title="학생 실종",
+        description="Magic Layer STUDENT_MISSING 후보", participant_agent_ids=(target.id,),
+        location_id=location_id, source="magic_layer", impact_level="high", importance=80,
+    )
+    tick_1 = EventBatch(
+        simulation_id=simulation_id, run_id="run-1", tick_number=1,
+        policy_version="policy-mvp-0.1", resolver_version="resolver-mvp-0.1",
+        resolution_id="run-1:1", events=(missing_write,),
+        missing_agent_ids=tuple(UUID(agent_id) for agent_id in special.missing_agent_ids),
+    )
+
+    # Task1 코드는 여기까지만 관여한다 — 이후는 전부 Task3의 실제 서비스 호출.
+    persist_event_batch(db, tick_1)
+    db.flush()
+    assert (target.active_status, target.inactive_until_tick) == ("inactive_temporary", 4)
+
+    for tick in range(2, 8):
+        db.get(Simulation, simulation_id).current_tick = tick - 1
+        db.flush()
+        empty = EventBatch(
+            simulation_id=simulation_id, run_id="run-1", tick_number=tick,
+            policy_version="policy-mvp-0.1", resolver_version="resolver-mvp-0.1",
+            resolution_id=f"run-1:{tick}",
+        )
+        persist_event_batch(db, empty)
+        if tick == 3:
+            assert target.active_status == "inactive_temporary"
+        if tick == 4:
+            assert target.active_status == "active"
+            assert target.cursed_until_tick == 7
+        if tick == 7:
+            assert target.cursed_until_tick is None
+
+    # Task1은 다른 Agent의 state를 이중 mutation하지 않았다 (Task1은 DB에
+    # 아무것도 쓰지 않으므로, 전이 결과는 오직 Task3 persist_event_batch에서만 나온다).
+    for agent in others:
+        assert agent.cursed_until_tick is None
+        assert agent.inactive_until_tick is None
+
+
+# ---------------------------------------------------------------------------
+# production STUDENT_MISSING 발생 가능성: 새 history 저장소 없이 기존
+# RuntimeResult 기록에서 최근 10 Tick stress를 역산 가능함을 확인한다.
+# ---------------------------------------------------------------------------
+def _make_runtime_result_row(*, agent_id, tick_number, run_id, stress_signal=None):
+    from app.domain.models import RuntimeResult
+
+    state_signals = []
+    if stress_signal is not None:
+        signal_type, intensity = stress_signal
+        state_signals.append({"signal_type": signal_type, "intensity": intensity})
+    intent = {
+        "action_type": "WAIT",
+        "target_agent_id": None,
+        "target_location_id": None,
+        "related_event_id": None,
+        "utterance": None,
+        "motivation_summary": "test",
+        "reaction": {"valence": "NEUTRAL", "relationship_signals": [], "state_signals": state_signals},
+        "decision_explanation": {"alternatives": [], "influencing_factors": []},
+        "memory_candidates": [],
+    }
+    return RuntimeResult(
+        id=uuid4(), run_id=run_id, tick_number=tick_number, agent_id=agent_id,
+        status="PROPOSED", action_type="WAIT", intent=intent, retry_count=0,
+        failure_reason=None, model="test-model", prompt_version="test-prompt",
+        idempotency_key=f"{run_id}:{tick_number}:{agent_id}",
+        result_fingerprint=f"fp-{run_id}-{tick_number}-{agent_id}",
+    )
+
+
+def test_reconstruct_recent_stress_from_existing_runtime_results(db):
+    """새 history 모델/migration 없이 기존 RuntimeResult로 10 Tick stress를 역산한다."""
+    from app.services.manual_tick import _reconstruct_recent_stress
+
+    simulation_id = _setup_simulation(db)
+    agent = next(
+        db.scalars(
+            select(Agent).where(Agent.simulation_id == simulation_id, Agent.fixture_key == "student-01")
+        )
+    )
+    state = db.scalar(select(AgentState).where(AgentState.agent_id == agent.id))
+    state.stress = 90  # tick 10(현재 직전 tick)까지의 최종 stress.
+    db.flush()
+
+    # tick 2~10 각각에 STRESS_UP/HIGH(+8) Reaction을 기록해, tick 10(=current)의
+    # 90에서 9번 역산하면 tick 1의 18까지 총 10개 연속 tick 값이 나오게 구성한다.
+    for tick in range(2, 11):
+        db.add(
+            _make_runtime_result_row(
+                agent_id=agent.id, tick_number=tick, run_id="run-hist",
+                stress_signal=("STRESS_UP", "HIGH"),
+            )
+        )
+    db.flush()
+
+    history = _reconstruct_recent_stress(
+        db,
+        agent_ids=[agent.id],
+        current_tick=11,
+        current_stress_by_agent={agent.id: state.stress},
+    )
+    assert history[agent.id] == (18, 26, 34, 42, 50, 58, 66, 74, 82, 90)
+    assert len(history[agent.id]) == 10
+
+
+def test_reconstruct_recent_stress_stops_at_gap_and_stays_conservative(db):
+    """RuntimeResult 연속성이 끊기면 그 이전은 추정하지 않고 짧은 결과를 반환한다."""
+    from app.services.manual_tick import _reconstruct_recent_stress
+
+    simulation_id = _setup_simulation(db)
+    agent = next(
+        db.scalars(
+            select(Agent).where(Agent.simulation_id == simulation_id, Agent.fixture_key == "student-01")
+        )
+    )
+    state = db.scalar(select(AgentState).where(AgentState.agent_id == agent.id))
+    state.stress = 95
+    db.flush()
+    # tick 9,8,7은 연속으로 존재하지만 tick 6은 비어 있어 그 지점에서 끊긴 상황.
+    for tick in (9, 8, 7):
+        db.add(
+            _make_runtime_result_row(
+                agent_id=agent.id, tick_number=tick, run_id="run-hist",
+                stress_signal=("STRESS_UP", "MEDIUM"),
+            )
+        )
+    db.flush()
+
+    history = _reconstruct_recent_stress(
+        db,
+        agent_ids=[agent.id],
+        current_tick=10,
+        current_stress_by_agent={agent.id: state.stress},
+    )
+    # tick 7~10(4개)까지만 역산되고, tick 6 기록이 없어 그 이전은 추정하지 않고 멈춘다.
+    assert history[agent.id] == (80, 85, 90, 95)
+    assert len(history[agent.id]) < STUDENT_MISSING_STREAK_TICKS
+
+
+def test_production_wiring_actually_fires_student_missing(db):
+    """`_run_event_and_magic_phase`(실제 manual_tick.py wiring)가 충분한
+    RuntimeResult 이력이 있으면 STUDENT_MISSING을 실제로 발생시킴을 증명한다."""
+    from app.services.manual_tick import _run_event_and_magic_phase
+
+    simulation_id = _setup_simulation(db)
+    agents = list(
+        db.scalars(select(Agent).where(Agent.simulation_id == simulation_id).order_by(Agent.fixture_key))
+    )
+    target = next(a for a in agents if a.fixture_key == "student-01")
+    state = db.scalar(select(AgentState).where(AgentState.agent_id == target.id))
+    state.stress = 95
+    db.flush()
+    for tick in range(2, 11):
+        db.add(
+            _make_runtime_result_row(
+                agent_id=target.id, tick_number=tick, run_id="run-hist",
+                stress_signal=None,  # 신호 없음 -> delta 0, stress가 95로 유지됨
+            )
+        )
+    db.flush()
+
+    result = _run_event_and_magic_phase(
+        db, simulation_id=simulation_id, run_id=uuid4(), tick=11, agents=agents,
+    )
+    assert [e.event_subtype for e in result.special_events] == [STUDENT_MISSING]
+    assert result.special_events[0].missing_agent_ids == (str(target.id),)

--- a/backend/tests/test_event_magic_policy_integration.py
+++ b/backend/tests/test_event_magic_policy_integration.py
@@ -506,4 +506,56 @@ def test_production_wiring_actually_fires_student_missing(db):
         db, simulation_id=simulation_id, run_id=uuid4(), tick=11, agents=agents,
     )
     assert [e.event_subtype for e in result.special_events] == [STUDENT_MISSING]
-    assert result.special_events[0].missing_agent_ids == (str(target.id),)
+
+
+# ---------------------------------------------------------------------------
+# DB에 저장된 CLASS scheduled Event가 실제 advance_manual_tick() 경로를 통해
+# Event Master -> Magic Layer -> Policy까지 연결되는지 검증한다 (synthetic
+# run_event_and_magic_phase() 직접 호출이 아니라 real production adapter 사용).
+# ---------------------------------------------------------------------------
+def test_advance_manual_tick_wires_db_class_event_into_event_master(db):
+    import asyncio
+
+    from app.domain.models import Event as DomainEvent, EventParticipant
+    from app.services.manual_tick import advance_manual_tick
+    from app.simulation.agent_runtime import AgentRuntime, MockLLMClient
+
+    simulation_id = _setup_simulation(db)
+    simulation = db.get(Simulation, simulation_id)
+
+    class_event = db.scalar(
+        select(DomainEvent).where(
+            DomainEvent.simulation_id == simulation_id, DomainEvent.event_type == "class"
+        )
+    )
+    db_participant_ids = {
+        p.agent_id
+        for p in db.scalars(
+            select(EventParticipant).where(EventParticipant.event_id == class_event.id)
+        )
+    }
+    assert db_participant_ids  # fixture 전제: student-01 + professor-01
+
+    runtime = AgentRuntime(MockLLMClient(), model="test-event-master-wiring")
+    result = asyncio.run(advance_manual_tick(db, simulation, runtime=runtime))
+
+    event_and_magic = result.event_and_magic_result
+    class_events = [e for e in event_and_magic.events if e.event_type == "CLASS"]
+    assert len(class_events) == 1
+    wired_event = class_events[0]
+
+    # DB의 실제 EventParticipant와 정확히 일치해야 한다 (inactive 제외 규칙 유지 —
+    # 이 fixture는 전원 active이므로 그대로 전원 포함되어야 한다).
+    assert {UUID(agent_id) for agent_id in wired_event.participant_agent_ids} == db_participant_ids
+
+    # CLASS 기본 효과(stress +1)가 참여자 전원에 대해 resolved_effects까지 연결된다.
+    stress_effects = {
+        UUID(effect.source_agent_id): effect
+        for effect in event_and_magic.resolved_effects
+        if effect.metric == "stress"
+    }
+    assert set(stress_effects) == db_participant_ids
+    assert all(effect.delta == 1 for effect in stress_effects.values())
+
+    # Magic Layer로도 정상 전달된다 (converted_events에 동일 CLASS Event가 포함).
+    assert any(e.event_type == "CLASS" for e in event_and_magic.events)

--- a/backend/tests/test_event_master.py
+++ b/backend/tests/test_event_master.py
@@ -1,0 +1,226 @@
+"""Slice 5 Task 1 — Event Master unit tests (Issue #101)."""
+
+import pytest
+
+from app.simulation.event_master import (
+    AgentSummary,
+    EventMaster,
+    ImpactLevel,
+    RelationshipSummary,
+    ScheduledEventInput,
+)
+from app.simulation.policy.registries.event_policy import build_event_effect_candidates
+from app.simulation.policy.models import AgentSnapshot as PolicyAgentSnapshot
+
+
+def student(agent_id: str, *, major_id: str = "방어 마법", location: str = "dormitory", active: bool = True) -> AgentSummary:
+    return AgentSummary(
+        agent_id=agent_id,
+        name=f"학생-{agent_id}",
+        role="student",
+        major_id=major_id,
+        year=1,
+        active_status=active,
+        current_location_id=location,
+        mood=0,
+        stress=10,
+        fatigue=10,
+    )
+
+
+def professor(agent_id: str, *, location: str = "classroom") -> AgentSummary:
+    return AgentSummary(
+        agent_id=agent_id,
+        name=f"교수-{agent_id}",
+        role="professor",
+        major_id=None,
+        year=None,
+        active_status=True,
+        current_location_id=location,
+        mood=0,
+        stress=10,
+        fatigue=10,
+    )
+
+
+def test_class_scheduled_event_is_generated():
+    """1. CLASS 예정 Event 생성 — 기존 Schedule/Event 구조를 그대로 변환한다."""
+    summaries = [student("s1"), professor("p1", location="dormitory")]
+    scheduled = [
+        ScheduledEventInput(
+            event_id="evt-class-1",
+            event_type="CLASS",
+            location_id="dormitory",
+            participant_agent_ids=("s1", "p1"),
+            title="통합마법학 개론",
+            impact_level=ImpactLevel.MEDIUM,
+        )
+    ]
+    events = EventMaster().generate(tick=1, agent_summaries=summaries, scheduled_events=scheduled)
+
+    class_events = [e for e in events if e.event_type == "CLASS"]
+    assert len(class_events) == 1
+    event = class_events[0]
+    assert event.participant_agent_ids == ("p1", "s1")
+    assert event.source == "event_master"
+    assert event.tick == 1
+
+
+def test_exam_scheduled_event_is_generated():
+    """2. EXAM 예정 Event 생성."""
+    summaries = [student("s1")]
+    scheduled = [
+        ScheduledEventInput(
+            event_id="evt-exam-1",
+            event_type="EXAM",
+            location_id="classroom",
+            participant_agent_ids=("s1",),
+            impact_level=ImpactLevel.HIGH,
+        )
+    ]
+    events = EventMaster().generate(tick=5, agent_summaries=summaries, scheduled_events=scheduled)
+
+    exam_events = [e for e in events if e.event_type == "EXAM"]
+    assert len(exam_events) == 1
+    assert exam_events[0].importance == 80
+
+
+def test_group_project_dynamic_event_generated_for_same_major_same_location():
+    """3a. GROUP_PROJECT 동적 Event 생성 (같은 major_id + 같은 위치)."""
+    summaries = [
+        student("s1", major_id="고대 마법", location="library"),
+        student("s2", major_id="고대 마법", location="library"),
+    ]
+    events = EventMaster().generate(tick=3, agent_summaries=summaries)
+
+    group_events = [e for e in events if e.event_type == "GROUP_PROJECT"]
+    assert len(group_events) == 1
+    assert set(group_events[0].participant_agent_ids) == {"s1", "s2"}
+    assert group_events[0].location_id == "library"
+
+
+def test_meeting_dynamic_event_generated_for_friendly_colocated_agents():
+    """3b. MEETING 동적 Event 생성 (우호적 관계 + 같은 위치)."""
+    summaries = [
+        student("s1", location="dormitory"),
+        student("s2", location="dormitory"),
+    ]
+    relationships = [RelationshipSummary("s1", "s2", affection=10, closeness=10)]
+    events = EventMaster().generate(
+        tick=3, agent_summaries=summaries, relationship_summaries=relationships
+    )
+
+    meeting_events = [e for e in events if e.event_type == "MEETING"]
+    assert len(meeting_events) == 1
+    assert set(meeting_events[0].participant_agent_ids) == {"s1", "s2"}
+
+
+def test_meeting_not_generated_without_relationship_history():
+    """MEETING은 관계 데이터가 없는 첫 tick에는 생성되지 않는다 (회귀 방지 근거)."""
+    summaries = [student("s1", location="dormitory"), student("s2", location="dormitory")]
+    events = EventMaster().generate(tick=1, agent_summaries=summaries)
+
+    assert [e for e in events if e.event_type == "MEETING"] == []
+
+
+@pytest.mark.parametrize(
+    "impact_level,expected_importance",
+    [(ImpactLevel.LOW, 30), (ImpactLevel.MEDIUM, 50), (ImpactLevel.HIGH, 80)],
+)
+def test_impact_level_maps_to_importance(impact_level, expected_importance):
+    """4. impact_level -> importance 30/50/80 매핑."""
+    summaries = [student("s1")]
+    scheduled = [
+        ScheduledEventInput(
+            event_id="evt-1",
+            event_type="CLASS",
+            location_id="dormitory",
+            participant_agent_ids=("s1",),
+            impact_level=impact_level,
+        )
+    ]
+    events = EventMaster().generate(tick=1, agent_summaries=summaries, scheduled_events=scheduled)
+    assert events[0].importance == expected_importance
+
+
+def test_random_incident_requires_event_subtype():
+    """5. RANDOM_INCIDENT에 event_subtype 필수."""
+    with pytest.raises(ValueError):
+        EventMaster().build_random_incident(
+            tick=1,
+            event_subtype="",
+            participant_agent_ids=("s1",),
+            location_id="dormitory",
+        )
+
+    event = EventMaster().build_random_incident(
+        tick=1,
+        event_subtype="POWER_OUTAGE",
+        participant_agent_ids=("s1",),
+        location_id="dormitory",
+    )
+    assert event.event_type == "RANDOM_INCIDENT"
+    assert event.event_subtype == "POWER_OUTAGE"
+
+
+def test_inactive_agent_excluded_from_event_candidates():
+    """6. inactive Agent가 잘못된 Event 후보에 포함되지 않음."""
+    summaries = [
+        student("s1", major_id="고대 마법", location="library", active=True),
+        student("s2", major_id="고대 마법", location="library", active=False),
+    ]
+    scheduled = [
+        ScheduledEventInput(
+            event_id="evt-1",
+            event_type="CLASS",
+            location_id="library",
+            participant_agent_ids=("s1", "s2"),
+        )
+    ]
+    events = EventMaster().generate(tick=1, agent_summaries=summaries, scheduled_events=scheduled)
+
+    class_event = next(e for e in events if e.event_type == "CLASS")
+    assert class_event.participant_agent_ids == ("s1",)
+    # inactive Agent만 있으면 GROUP_PROJECT 후보 자체가 생기지 않는다.
+    assert [e for e in events if e.event_type == "GROUP_PROJECT"] == []
+
+
+def test_generation_is_deterministic_for_identical_input():
+    """7. 동일 입력에서 deterministic 결과."""
+    summaries = [
+        student("s1", major_id="고대 마법", location="library"),
+        student("s2", major_id="고대 마법", location="library"),
+    ]
+    relationships = [RelationshipSummary("s1", "s2", affection=5, closeness=5)]
+
+    first = EventMaster().generate(tick=4, agent_summaries=summaries, relationship_summaries=relationships)
+    second = EventMaster().generate(tick=4, agent_summaries=summaries, relationship_summaries=relationships)
+
+    assert first == second
+
+
+def test_general_event_effect_id_is_stable_and_distinct():
+    """8. 일반 Event canonical effect_id 안정성 — 같은 Event는 같은 effect_id, 다른 Event는 다른 effect_id."""
+    summaries = [student("s1")]
+    scheduled = [
+        ScheduledEventInput(
+            event_id="evt-1", event_type="CLASS", location_id="dormitory", participant_agent_ids=("s1",)
+        )
+    ]
+    snapshot = {"s1": PolicyAgentSnapshot(agent_id="s1", hunger=50, fatigue=10, stress=10, satisfaction=50)}
+
+    events_a = EventMaster().generate(tick=1, agent_summaries=summaries, scheduled_events=scheduled)
+    events_b = EventMaster().generate(tick=1, agent_summaries=summaries, scheduled_events=scheduled)
+    candidates_a = build_event_effect_candidates(events_a[0], run_id="run-1", agent_snapshots=snapshot)
+    candidates_b = build_event_effect_candidates(events_b[0], run_id="run-1", agent_snapshots=snapshot)
+    assert [c.effect_id for c in candidates_a] == [c.effect_id for c in candidates_b]
+    assert all(not c.effect_id.count("random") for c in candidates_a)  # UUID 아닌 canonical 문자열
+
+    other_scheduled = [
+        ScheduledEventInput(
+            event_id="evt-2", event_type="EXAM", location_id="dormitory", participant_agent_ids=("s1",)
+        )
+    ]
+    events_c = EventMaster().generate(tick=1, agent_summaries=summaries, scheduled_events=other_scheduled)
+    candidates_c = build_event_effect_candidates(events_c[0], run_id="run-1", agent_snapshots=snapshot)
+    assert {c.effect_id for c in candidates_a}.isdisjoint({c.effect_id for c in candidates_c})

--- a/backend/tests/test_magic_layer.py
+++ b/backend/tests/test_magic_layer.py
@@ -1,0 +1,247 @@
+"""Slice 5 Task 1 — Magic Layer unit tests (Issue #101)."""
+
+from app.simulation.magic_layer import (
+    CURSE_SPREAD,
+    MAGIC_EXPLOSION,
+    MAGICAL_DISCOVERY,
+    RITUAL_FAILURE,
+    STUDENT_MISSING,
+    AgentSnapshot,
+    MagicLayer,
+)
+from app.simulation.policy.models import RelationshipSnapshot
+
+
+def snap(
+    agent_id: str,
+    *,
+    agent_type: str = "student",
+    location: str | None = "dormitory",
+    fatigue: int = 10,
+    is_cursed: bool = False,
+    recent_stress: tuple[int, ...] = (),
+    active: bool = True,
+) -> AgentSnapshot:
+    return AgentSnapshot(
+        agent_id=agent_id,
+        agent_type=agent_type,
+        active_status=active,
+        current_location_id=location,
+        fatigue=fatigue,
+        is_cursed=is_cursed,
+        recent_stress=recent_stress,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. STUDENT_MISSING 조건 경계
+# ---------------------------------------------------------------------------
+def test_student_missing_fires_on_10_of_10_streak():
+    snapshots = [snap("s1", recent_stress=tuple([95] * 10))]
+    result = MagicLayer().evaluate(tick=11, regular_events=[], agent_snapshots=snapshots)
+    assert [e.event_subtype for e in result.special_events] == [STUDENT_MISSING]
+    assert result.special_events[0].missing_agent_ids == ("s1",)
+
+
+def test_student_missing_does_not_fire_on_9_of_10_streak():
+    snapshots = [snap("s1", recent_stress=tuple([95] * 9 + [10]))]
+    result = MagicLayer().evaluate(tick=11, regular_events=[], agent_snapshots=snapshots)
+    assert result.special_events == ()
+
+
+def test_student_missing_excludes_professor():
+    snapshots = [snap("p1", agent_type="professor", recent_stress=tuple([95] * 10))]
+    result = MagicLayer().evaluate(tick=11, regular_events=[], agent_snapshots=snapshots)
+    assert result.special_events == ()
+
+
+# ---------------------------------------------------------------------------
+# 10. MAGIC_EXPLOSION
+# ---------------------------------------------------------------------------
+def test_magic_explosion_fires_when_ratio_meets_threshold():
+    # 4명 중 fatigue>=80은 4명(100% >= 80%).
+    snapshots = [
+        snap("s1", location="lab", fatigue=85),
+        snap("s2", location="lab", fatigue=90),
+        snap("s3", location="lab", fatigue=80),
+        snap("s4", location="lab", fatigue=95),
+    ]
+    result = MagicLayer().evaluate(tick=1, regular_events=[], agent_snapshots=snapshots)
+    assert [e.event_subtype for e in result.special_events] == [MAGIC_EXPLOSION]
+    assert set(result.special_events[0].participant_agent_ids) == {"s1", "s2", "s3", "s4"}
+
+
+def test_magic_explosion_does_not_fire_below_ratio_threshold():
+    # 3명 중 fatigue>=80은 1명(33%) -> 80% 미달.
+    snapshots = [
+        snap("s1", location="lab", fatigue=85),
+        snap("s2", location="lab", fatigue=20),
+        snap("s3", location="lab", fatigue=20),
+    ]
+    result = MagicLayer().evaluate(tick=1, regular_events=[], agent_snapshots=snapshots)
+    assert result.special_events == ()
+
+
+def test_magic_explosion_does_not_fire_below_min_students():
+    snapshots = [snap("s1", location="lab", fatigue=90), snap("s2", location="lab", fatigue=90)]
+    result = MagicLayer().evaluate(tick=1, regular_events=[], agent_snapshots=snapshots)
+    assert result.special_events == ()
+
+
+# ---------------------------------------------------------------------------
+# 11. RITUAL_FAILURE
+# ---------------------------------------------------------------------------
+def test_ritual_failure_fires_with_enough_participants_and_bad_relationship():
+    snapshots = [snap(f"s{i}", location="hall") for i in range(1, 5)]
+    relationships = [
+        RelationshipSnapshot("s1", "s2", trust=-10, tension=10),
+        RelationshipSnapshot("s2", "s1", trust=-10, tension=10),
+    ]
+    result = MagicLayer().evaluate(
+        tick=1, regular_events=[], agent_snapshots=snapshots, relationship_snapshots=relationships
+    )
+    assert [e.event_subtype for e in result.special_events] == [RITUAL_FAILURE]
+    assert len(result.special_events[0].participant_agent_ids) == 4
+
+
+def test_ritual_failure_does_not_fire_below_min_participants():
+    snapshots = [snap(f"s{i}", location="hall") for i in range(1, 4)]
+    relationships = [RelationshipSnapshot("s1", "s2", trust=-50, tension=90)]
+    result = MagicLayer().evaluate(
+        tick=1, regular_events=[], agent_snapshots=snapshots, relationship_snapshots=relationships
+    )
+    assert result.special_events == ()
+
+
+def test_ritual_failure_does_not_fire_with_good_relationship():
+    snapshots = [snap(f"s{i}", location="hall") for i in range(1, 5)]
+    relationships = [
+        RelationshipSnapshot("s1", "s2", trust=50, tension=0),
+        RelationshipSnapshot("s2", "s1", trust=50, tension=0),
+    ]
+    result = MagicLayer().evaluate(
+        tick=1, regular_events=[], agent_snapshots=snapshots, relationship_snapshots=relationships
+    )
+    assert result.special_events == ()
+
+
+# ---------------------------------------------------------------------------
+# 12. MAGICAL_DISCOVERY
+# ---------------------------------------------------------------------------
+def test_magical_discovery_fires_when_no_prior_candidates():
+    snapshots = [
+        snap("p1", agent_type="professor", location="lab"),
+        snap("s1", location="lab"),
+    ]
+    result = MagicLayer().evaluate(
+        tick=1, regular_events=[], agent_snapshots=snapshots, lab_location_ids=frozenset({"lab"})
+    )
+    assert [e.event_subtype for e in result.special_events] == [MAGICAL_DISCOVERY]
+    assert set(result.special_events[0].participant_agent_ids) == {"p1", "s1"}
+
+
+def test_magical_discovery_blocked_when_higher_priority_candidate_exists():
+    snapshots = [
+        snap("p1", agent_type="professor", location="lab"),
+        snap("s1", location="lab"),
+        snap("m1", recent_stress=tuple([95] * 10)),  # STUDENT_MISSING candidate
+    ]
+    result = MagicLayer().evaluate(
+        tick=11, regular_events=[], agent_snapshots=snapshots, lab_location_ids=frozenset({"lab"})
+    )
+    assert [e.event_subtype for e in result.special_events] == [STUDENT_MISSING]
+
+
+def test_magical_discovery_requires_professor_and_student_together():
+    snapshots = [snap("p1", agent_type="professor", location="lab")]
+    result = MagicLayer().evaluate(
+        tick=1, regular_events=[], agent_snapshots=snapshots, lab_location_ids=frozenset({"lab"})
+    )
+    assert result.special_events == ()
+
+
+# ---------------------------------------------------------------------------
+# 13. CURSE_SPREAD
+# ---------------------------------------------------------------------------
+def test_curse_spread_fires_for_contacted_agent():
+    snapshots = [
+        snap("cursed1", location="dormitory", is_cursed=True),
+        snap("s1", location="dormitory"),
+    ]
+    result = MagicLayer().evaluate(tick=1, regular_events=[], agent_snapshots=snapshots)
+    assert [e.event_subtype for e in result.special_events] == [CURSE_SPREAD]
+    assert result.special_events[0].newly_cursed_agent_ids == ("s1",)
+
+
+def test_curse_spread_excludes_non_contacted_agent():
+    snapshots = [
+        snap("cursed1", location="dormitory", is_cursed=True),
+        snap("s1", location="classroom"),
+    ]
+    result = MagicLayer().evaluate(tick=1, regular_events=[], agent_snapshots=snapshots)
+    assert result.special_events == ()
+
+
+def test_curse_spread_does_not_reapply_to_already_cursed_contact():
+    snapshots = [
+        snap("cursed1", location="dormitory", is_cursed=True),
+        snap("cursed2", location="dormitory", is_cursed=True),
+    ]
+    result = MagicLayer().evaluate(tick=1, regular_events=[], agent_snapshots=snapshots)
+    assert result.special_events == ()
+
+
+# ---------------------------------------------------------------------------
+# 14. Magic priority
+# ---------------------------------------------------------------------------
+def test_priority_student_missing_over_curse_spread():
+    snapshots = [
+        snap("m1", recent_stress=tuple([95] * 10)),
+        snap("cursed1", location="dormitory", is_cursed=True),
+        snap("s1", location="dormitory"),
+    ]
+    result = MagicLayer().evaluate(tick=11, regular_events=[], agent_snapshots=snapshots)
+    assert [e.event_subtype for e in result.special_events] == [STUDENT_MISSING]
+
+
+def test_priority_curse_spread_over_magic_explosion():
+    snapshots = [
+        snap("cursed1", location="dormitory", is_cursed=True),
+        snap("s1", location="dormitory"),
+        snap("e1", location="lab", fatigue=90),
+        snap("e2", location="lab", fatigue=90),
+        snap("e3", location="lab", fatigue=90),
+    ]
+    result = MagicLayer().evaluate(tick=1, regular_events=[], agent_snapshots=snapshots)
+    assert [e.event_subtype for e in result.special_events] == [CURSE_SPREAD]
+
+
+def test_priority_magic_explosion_over_ritual_failure():
+    snapshots = [
+        snap("e1", location="lab", fatigue=90),
+        snap("e2", location="lab", fatigue=90),
+        snap("e3", location="lab", fatigue=90),
+        *[snap(f"r{i}", location="hall") for i in range(1, 5)],
+    ]
+    relationships = [RelationshipSnapshot("r1", "r2", trust=-50, tension=90)]
+    result = MagicLayer().evaluate(
+        tick=1, regular_events=[], agent_snapshots=snapshots, relationship_snapshots=relationships
+    )
+    assert [e.event_subtype for e in result.special_events] == [MAGIC_EXPLOSION]
+
+
+def test_priority_ritual_failure_over_magical_discovery():
+    snapshots = [
+        *[snap(f"r{i}", location="hall") for i in range(1, 5)],
+        snap("p1", agent_type="professor", location="lab"),
+        snap("s1", location="lab"),
+    ]
+    relationships = [RelationshipSnapshot("r1", "r2", trust=-50, tension=90)]
+    result = MagicLayer().evaluate(
+        tick=1,
+        regular_events=[],
+        agent_snapshots=snapshots,
+        relationship_snapshots=relationships,
+        lab_location_ids=frozenset({"lab"}),
+    )
+    assert [e.event_subtype for e in result.special_events] == [RITUAL_FAILURE]


### PR DESCRIPTION
## 작업 개요

Slice 5 통합 계약을 기준으로 Event Master와 Magic Layer의 조건 기반 Event 생성·처리 흐름을 구현했습니다.

일반 Event 생성부터 Magic 특수 Event 판정, 기존 Policy Engine의 EffectCandidate 변환까지 실제 Tick 경로에 연결했습니다.

## 관련 Issue

Closes #101

## 변경 내용

- Event Master 조건 기반 일반 Event 생성
  - CLASS / EXAM 등 예정 Event 처리
  - GROUP_PROJECT / MEETING 등 동적 Event 생성
  - inactive Agent 제외 및 impact → importance 결정론적 매핑
- Magic Layer 특수 Event 5종 구현
  - STUDENT_MISSING
  - CURSE_SPREAD
  - MAGIC_EXPLOSION
  - RITUAL_FAILURE
  - MAGICAL_DISCOVERY
- Event Master → Magic Layer → Policy Engine 흐름 연결
- 일반 Event 및 Magic Event의 EffectCandidate 생성
- 기존 RuntimeResult 기록을 이용한 최근 10 Tick stress 복원
- production Tick 경로에서 STUDENT_MISSING 실제 발생 가능하도록 연결
- Task 2의 Resolver/effect_id dedup 로직 재사용
- Task 3의 상태 persistence 및 상태 전이 로직 재사용
- STUDENT_MISSING → INACTIVE_TEMPORARY → ACTIVE+CURSED → 해제 실제 DB 통합 검증
- 관련 Event Master / Magic / Policy / persistence integration 테스트 추가

## 결정 사항 및 이유

Event Master와 Magic Layer는 동일 입력에서 재현 가능한 결과를 만들도록 결정론적으로 구현했습니다.

Event 및 Magic의 상태 효과는 기존 Policy Engine의 typed signal 및 delta 변환 경로를 재사용하며, Event Master나 Magic Layer가 직접 상태 delta를 임의 계산하지 않도록 했습니다.

`STUDENT_MISSING`의 최근 10 Tick stress 판정은 별도 history 테이블이나 migration을 추가하지 않고 기존 RuntimeResult 기록을 이용해 결정론적으로 복원하도록 했습니다.

상태 전이 자체는 Task 3의 `persist_event_batch()`가 소유하므로 Task 1에서는 중복 mutation하지 않고 실제 persistence 경로와 호환되는 후보를 생성하도록 책임을 분리했습니다.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인
- [x] 주요 기능 동작 확인
- [x] 에러 케이스 확인
- [x] 관련 문서 업데이트 확인

## AI 사용 여부

사용 여부: 사용함
사용한 작업:
- Event Master / Magic Layer 구현 보조
- Policy Engine 연결 및 테스트 작성
- 기존 RuntimeResult 기반 stress history 복원 로직 작성
