### PR TITLE
[Fix] Slice 6 설정·Snapshot·Replay Backend API 연결

### DIFF
--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter
 
 from app.api.auth import router as auth_router
+from app.api.simulation_history import router as simulation_history_router
 from app.api.simulations import router as simulations_router
 from app.api.ticks import router as ticks_router
 
 api_router = APIRouter()
 api_router.include_router(auth_router)
 api_router.include_router(simulations_router)
+api_router.include_router(simulation_history_router)
 api_router.include_router(ticks_router)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -61,6 +61,27 @@ class SimulationResponse(BaseModel):
     created_at: datetime
 
 
+class SimulationConfigPutRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_frequency: str
+    event_impact: str
+    magic_enabled: bool
+
+
+class SimulationConfigPatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_frequency: str
+    event_impact: str
+
+
+class RestoreSnapshotRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_id: UUID
+
+
 class AgentProfileResponse(BaseModel):
     openness: int
     conscientiousness: int

--- a/backend/app/api/simulation_history.py
+++ b/backend/app/api/simulation_history.py
@@ -1,0 +1,257 @@
+from collections.abc import Callable
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
+from sqlalchemy.orm import Session
+
+from app.api.schemas import (
+    RestoreSnapshotRequest,
+    SimulationConfigPatchRequest,
+    SimulationConfigPutRequest,
+)
+from app.core.database import get_db
+from app.core.security import require_user_role
+from app.domain.models import Simulation, User
+from app.repositories.simulation_snapshots import SimulationSnapshotRepository
+from app.services.simulation_replay import (
+    ReplayResourceNotFoundError,
+    SimulationReplayService,
+    SnapshotMismatchError,
+    UnsupportedReplaySnapshotSchemaError,
+)
+from app.services.simulation_snapshots import (
+    InitialSettingsLockedError,
+    InvalidSimulationConfigError,
+    SimulationConfigInput,
+    SimulationSettingsLockedError,
+    SimulationSnapshotService,
+    UnsupportedSnapshotSchemaError,
+)
+
+
+class Slice6APIError(Exception):
+    def __init__(self, status_code: int, code: str, message: str) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+
+
+def _error_response(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"code": code, "message": message}},
+    )
+
+
+class Slice6ErrorRoute(APIRoute):
+    def get_route_handler(self) -> Callable:
+        original_handler = super().get_route_handler()
+
+        async def handler(request: Request):
+            try:
+                return await original_handler(request)
+            except Slice6APIError as exc:
+                return _error_response(exc.status_code, exc.code, exc.message)
+            except RequestValidationError:
+                return _error_response(400, "INVALID_REPLAY_REQUEST", "Invalid request")
+            except HTTPException as exc:
+                codes = {
+                    401: "AUTHENTICATION_REQUIRED",
+                    403: "SIMULATION_ACCESS_DENIED",
+                    404: "REPLAY_RESOURCE_NOT_FOUND",
+                }
+                return _error_response(
+                    exc.status_code,
+                    codes.get(exc.status_code, "INVALID_REPLAY_REQUEST"),
+                    str(exc.detail),
+                )
+
+        return handler
+
+
+router = APIRouter(
+    prefix="/simulations",
+    tags=["simulation-history"],
+    route_class=Slice6ErrorRoute,
+)
+snapshot_service = SimulationSnapshotService()
+replay_service = SimulationReplayService()
+snapshot_repository = SimulationSnapshotRepository()
+
+
+def _owned_simulation(db: Session, simulation_id: UUID, user: User) -> Simulation:
+    simulation = db.get(Simulation, simulation_id)
+    if simulation is None:
+        raise Slice6APIError(404, "REPLAY_RESOURCE_NOT_FOUND", "Simulation not found")
+    if simulation.owner_id != user.id:
+        raise Slice6APIError(403, "SIMULATION_ACCESS_DENIED", "Simulation access denied")
+    return simulation
+
+
+def _config_data(config) -> dict[str, Any]:
+    return {
+        "event_frequency": config.event_frequency,
+        "event_impact": config.event_impact,
+        "magic_enabled": config.magic_enabled,
+        "config_version": config.version,
+        "changed_at": config.created_at.isoformat(),
+    }
+
+
+def _save_config(
+    db: Session,
+    simulation: Simulation,
+    config_input: SimulationConfigInput,
+) -> JSONResponse:
+    try:
+        config = snapshot_service.save_config(db, simulation, config_input)
+        db.commit()
+        db.refresh(config)
+    except SimulationSettingsLockedError as exc:
+        db.rollback()
+        raise Slice6APIError(409, "SIMULATION_SETTINGS_LOCKED", str(exc)) from exc
+    except InitialSettingsLockedError as exc:
+        db.rollback()
+        raise Slice6APIError(409, "INITIAL_SETTINGS_LOCKED", str(exc)) from exc
+    except InvalidSimulationConfigError as exc:
+        db.rollback()
+        raise Slice6APIError(400, "INVALID_REPLAY_REQUEST", str(exc)) from exc
+    return JSONResponse(content={"data": _config_data(config)})
+
+
+@router.put("/{simulation_id}/parameters")
+def put_parameters(
+    simulation_id: UUID,
+    request: SimulationConfigPutRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> JSONResponse:
+    simulation = _owned_simulation(db, simulation_id, current_user)
+    latest = snapshot_service.configs.latest(db, simulation.id)
+    return _save_config(
+        db,
+        simulation,
+        SimulationConfigInput(
+            event_frequency=request.event_frequency,
+            event_impact=request.event_impact,
+            magic_enabled=request.magic_enabled,
+            user_persona_settings=(latest.user_persona_settings if latest else {}),
+            policy_version=(latest.policy_version if latest else None),
+            resolver_version=(latest.resolver_version if latest else None),
+        ),
+    )
+
+
+@router.patch("/{simulation_id}/parameters")
+def patch_parameters(
+    simulation_id: UUID,
+    request: SimulationConfigPatchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> JSONResponse:
+    simulation = _owned_simulation(db, simulation_id, current_user)
+    latest = snapshot_service.configs.latest(db, simulation.id)
+    if latest is None:
+        raise Slice6APIError(409, "INITIAL_SETTINGS_LOCKED", "Initial settings not found")
+    return _save_config(
+        db,
+        simulation,
+        SimulationConfigInput(
+            event_frequency=request.event_frequency,
+            event_impact=request.event_impact,
+            magic_enabled=latest.magic_enabled,
+            user_persona_settings=latest.user_persona_settings,
+            policy_version=latest.policy_version,
+            resolver_version=latest.resolver_version,
+        ),
+    )
+
+
+@router.get("/{simulation_id}/snapshots/{tick_number}")
+def get_snapshot(
+    simulation_id: UUID,
+    tick_number: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> dict[str, Any]:
+    _owned_simulation(db, simulation_id, current_user)
+    snapshot = snapshot_repository.get_at_tick(db, simulation_id, tick_number)
+    if snapshot is None or snapshot.simulation_id != simulation_id:
+        raise Slice6APIError(404, "REPLAY_RESOURCE_NOT_FOUND", "Snapshot not found")
+    payload = dict(snapshot.payload)
+    return {
+        "data": {
+            "snapshot_id": str(snapshot.id),
+            "tick_number": snapshot.tick_number,
+            "simulation_day": payload.get("simulation", {}).get("current_day"),
+            **payload,
+        }
+    }
+
+
+@router.post("/{simulation_id}/restore")
+def restore_snapshot(
+    simulation_id: UUID,
+    request: RestoreSnapshotRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> dict[str, Any]:
+    _owned_simulation(db, simulation_id, current_user)
+    snapshot = snapshot_repository.get(db, request.snapshot_id)
+    if snapshot is None:
+        raise Slice6APIError(404, "REPLAY_RESOURCE_NOT_FOUND", "Snapshot not found")
+    source = db.get(Simulation, snapshot.simulation_id)
+    if source is None:
+        raise Slice6APIError(404, "REPLAY_RESOURCE_NOT_FOUND", "Simulation not found")
+    if source.owner_id != current_user.id:
+        raise Slice6APIError(403, "SIMULATION_ACCESS_DENIED", "Simulation access denied")
+    if snapshot.simulation_id != simulation_id:
+        raise Slice6APIError(409, "SNAPSHOT_MISMATCH", "Snapshot does not match simulation")
+    try:
+        payload = snapshot_service.restore_snapshot(
+            db, snapshot.id, owner_id=current_user.id
+        )
+    except UnsupportedSnapshotSchemaError as exc:
+        raise Slice6APIError(409, "UNSUPPORTED_SNAPSHOT_SCHEMA", str(exc)) from exc
+    return {"data": payload}
+
+
+@router.get("/{simulation_id}/replay")
+def get_replay_list(
+    simulation_id: UUID,
+    limit: int = Query(default=20, ge=1, le=100),
+    cursor: int | None = Query(default=None, ge=0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> dict[str, Any]:
+    _owned_simulation(db, simulation_id, current_user)
+    items, has_more = replay_service.list_ticks(
+        db, simulation_id, after_tick=cursor, limit=limit
+    )
+    next_cursor = str(items[-1]["tick_number"]) if has_more and items else None
+    return {
+        "data": items,
+        "meta": {"next_cursor": next_cursor, "has_more": has_more},
+    }
+
+
+@router.get("/{simulation_id}/replay/{tick_number}")
+def get_replay_tick(
+    simulation_id: UUID,
+    tick_number: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> dict[str, Any]:
+    _owned_simulation(db, simulation_id, current_user)
+    try:
+        return {"data": replay_service.get_tick(db, simulation_id, tick_number)}
+    except ReplayResourceNotFoundError as exc:
+        raise Slice6APIError(404, "REPLAY_RESOURCE_NOT_FOUND", str(exc)) from exc
+    except SnapshotMismatchError as exc:
+        raise Slice6APIError(409, "SNAPSHOT_MISMATCH", str(exc)) from exc
+    except UnsupportedReplaySnapshotSchemaError as exc:
+        raise Slice6APIError(409, "UNSUPPORTED_SNAPSHOT_SCHEMA", str(exc)) from exc

--- a/backend/app/repositories/simulation_snapshots.py
+++ b/backend/app/repositories/simulation_snapshots.py
@@ -112,6 +112,27 @@ class SimulationSnapshotRepository:
             )
         )
 
+    def list_by_simulation(
+        self,
+        session: Session,
+        simulation_id: UUID,
+        *,
+        after_tick: int | None = None,
+        limit: int = 20,
+    ) -> list[SimulationSnapshot]:
+        query = select(SimulationSnapshot).where(
+            SimulationSnapshot.simulation_id == simulation_id
+        )
+        if after_tick is not None:
+            query = query.where(SimulationSnapshot.tick_number > after_tick)
+        return list(
+            session.scalars(
+                query.order_by(SimulationSnapshot.tick_number, SimulationSnapshot.id).limit(
+                    limit
+                )
+            )
+        )
+
     def create(
         self,
         session: Session,

--- a/backend/app/services/simulation_replay.py
+++ b/backend/app/services/simulation_replay.py
@@ -1,0 +1,116 @@
+from copy import deepcopy
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.models import Agent, RuntimeResult, SimulationSnapshot
+from app.repositories.simulation_snapshots import SimulationSnapshotRepository
+
+
+class ReplayResourceNotFoundError(LookupError):
+    pass
+
+
+class SnapshotMismatchError(ValueError):
+    pass
+
+
+class UnsupportedReplaySnapshotSchemaError(ValueError):
+    pass
+
+
+class SimulationReplayService:
+    def __init__(self) -> None:
+        self.snapshots = SimulationSnapshotRepository()
+
+    def list_ticks(
+        self,
+        session: Session,
+        simulation_id: UUID,
+        *,
+        after_tick: int | None,
+        limit: int,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        snapshots = self.snapshots.list_by_simulation(
+            session,
+            simulation_id,
+            after_tick=after_tick,
+            limit=limit + 1,
+        )
+        has_more = len(snapshots) > limit
+        items = [self._list_item(snapshot) for snapshot in snapshots[:limit]]
+        return items, has_more
+
+    def get_tick(
+        self,
+        session: Session,
+        simulation_id: UUID,
+        tick_number: int,
+    ) -> dict[str, Any]:
+        snapshot = self.snapshots.get_at_tick(session, simulation_id, tick_number)
+        if snapshot is None:
+            raise ReplayResourceNotFoundError("Snapshot not found")
+        self._validate_snapshot(snapshot, simulation_id, tick_number)
+
+        runtime_results = list(
+            session.scalars(
+                select(RuntimeResult)
+                .join(Agent, Agent.id == RuntimeResult.agent_id)
+                .where(
+                    Agent.simulation_id == simulation_id,
+                    RuntimeResult.tick_number == tick_number,
+                )
+                .order_by(RuntimeResult.created_at, RuntimeResult.id)
+            )
+        )
+        if not runtime_results:
+            raise ReplayResourceNotFoundError("RuntimeResult not found")
+        if any(result.tick_number != snapshot.tick_number for result in runtime_results):
+            raise SnapshotMismatchError("RuntimeResult and Snapshot ticks do not match")
+
+        payload = deepcopy(snapshot.payload)
+        stored_runtime_results = payload.get("runtime_results", [])
+        stored_ids = [
+            row.get("id")
+            for row in stored_runtime_results
+            if row.get("tick_number") == tick_number
+        ]
+        result_ids = [str(result.id) for result in runtime_results]
+        if stored_ids != result_ids:
+            raise SnapshotMismatchError("Snapshot RuntimeResult history does not match")
+
+        simulation = payload.get("simulation", {})
+        return {
+            "snapshot_id": str(snapshot.id),
+            "tick_number": snapshot.tick_number,
+            "simulation_day": simulation.get("current_day"),
+            "events": payload.get("events", []),
+            "agent_snapshots": payload.get("agent_states", []),
+            "relationship_deltas": payload.get("relationship_deltas", []),
+            "runtime_results": stored_runtime_results,
+        }
+
+    @staticmethod
+    def _list_item(snapshot: SimulationSnapshot) -> dict[str, Any]:
+        simulation = snapshot.payload.get("simulation", {})
+        return {
+            "snapshot_id": str(snapshot.id),
+            "tick_number": snapshot.tick_number,
+            "simulation_day": simulation.get("current_day"),
+        }
+
+    @staticmethod
+    def _validate_snapshot(
+        snapshot: SimulationSnapshot,
+        simulation_id: UUID,
+        tick_number: int,
+    ) -> None:
+        if snapshot.simulation_id != simulation_id or snapshot.tick_number != tick_number:
+            raise SnapshotMismatchError("Snapshot does not match the requested simulation tick")
+        if snapshot.payload.get("schema_version") != "slice6-snapshot-v1":
+            raise UnsupportedReplaySnapshotSchemaError("Unsupported snapshot schema")
+        payload_simulation_id = snapshot.payload.get("simulation", {}).get("id")
+        if payload_simulation_id != str(simulation_id):
+            raise SnapshotMismatchError("Snapshot simulation does not match")

--- a/backend/tests/test_slice6_api.py
+++ b/backend/tests/test_slice6_api.py
@@ -1,0 +1,440 @@
+import os
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.orm import sessionmaker
+from uuid6 import uuid7
+
+from app.domain.models import (
+    Agent,
+    Event,
+    RuntimeResult,
+    Simulation,
+    SimulationSnapshot,
+)
+from app.services.simulation_snapshots import SimulationSnapshotService
+from app.simulation.instrumentation import get_counts, reset_counters
+
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required"
+)
+
+
+@pytest.fixture()
+def api_context():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(
+        bind=engine, autoflush=False, expire_on_commit=False
+    )
+    with engine.begin() as connection:
+        connection.execute(text("TRUNCATE users, simulations RESTART IDENTITY CASCADE"))
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client, session_factory, app
+    app.dependency_overrides.clear()
+    engine.dispose()
+
+
+def _register(client: TestClient, username: str) -> dict[str, str]:
+    password = "Slice6-password!"
+    response = client.post(
+        "/v1/auth/register",
+        json={"username": username, "display_name": username, "password": password},
+    )
+    assert response.status_code == 201
+    login = client.post(
+        "/v1/auth/login", json={"username": username, "password": password}
+    )
+    assert login.status_code == 200
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def _create_simulation(client: TestClient, headers: dict[str, str], name: str) -> UUID:
+    response = client.post("/v1/simulations", headers=headers, json={"name": name})
+    assert response.status_code == 201
+    return UUID(response.json()["id"])
+
+
+def _persist_runtime_and_snapshot(
+    session_factory,
+    simulation_id: UUID,
+    *,
+    tick_number: int,
+    run_id: str,
+    fixture_keys: tuple[str, ...] = ("student-01",),
+) -> tuple[list[UUID], UUID]:
+    result_ids = []
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        simulation.current_tick = tick_number
+        for sequence, fixture_key in enumerate(fixture_keys):
+            agent_id = session.scalar(
+                select(Agent.id).where(
+                    Agent.simulation_id == simulation_id,
+                    Agent.fixture_key == fixture_key,
+                )
+            )
+            result_id = uuid7()
+            result_ids.append(result_id)
+            session.add(
+                RuntimeResult(
+                    id=result_id,
+                    run_id=run_id,
+                    tick_number=tick_number,
+                    agent_id=agent_id,
+                    status="PROPOSED",
+                    action_type="IDLE",
+                    intent={"sequence": sequence},
+                    retry_count=0,
+                    model="test-model",
+                    prompt_version="test-prompt-v1",
+                    idempotency_key=f"{run_id}:{tick_number}:{fixture_key}",
+                    result_fingerprint=(str(sequence + 1) * 64)[:64],
+                )
+            )
+        session.flush()
+        snapshot = SimulationSnapshotService().create_snapshot(session, simulation)
+        snapshot_id = snapshot.id
+    return result_ids, snapshot_id
+
+
+def test_parameters_routes_and_error_contract(api_context) -> None:
+    client, session_factory, _ = api_context
+    owner_headers = _register(client, "slice6-api-owner")
+    other_headers = _register(client, "slice6-api-other")
+    simulation_id = _create_simulation(client, owner_headers, "Parameters")
+
+    put = client.put(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "high",
+            "event_impact": "low",
+            "magic_enabled": False,
+        },
+    )
+    assert put.status_code == 200
+    put_data = put.json()["data"]
+    assert {
+        key: value for key, value in put_data.items() if key != "changed_at"
+    } == {
+        "event_frequency": "high",
+        "event_impact": "low",
+        "magic_enabled": False,
+        "config_version": 2,
+    }
+    assert put_data["changed_at"]
+
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        simulation.status = "running"
+
+    patch = client.patch(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={"event_frequency": "low", "event_impact": "medium"},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["data"]["config_version"] == 3
+    assert patch.json()["data"]["magic_enabled"] is False
+
+    locked_initial = client.put(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "low",
+            "event_impact": "medium",
+            "magic_enabled": True,
+        },
+    )
+    assert locked_initial.status_code == 409
+    assert locked_initial.json()["error"]["code"] == "INITIAL_SETTINGS_LOCKED"
+
+    invalid = client.patch(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={"event_frequency": "extreme", "event_impact": "medium"},
+    )
+    assert invalid.status_code == 400
+    assert invalid.json()["error"]["code"] == "INVALID_REPLAY_REQUEST"
+
+    with session_factory.begin() as session:
+        session.get(Simulation, simulation_id).status = "completed"
+    locked = client.patch(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={"event_frequency": "low", "event_impact": "medium"},
+    )
+    assert locked.status_code == 409
+    assert locked.json()["error"]["code"] == "SIMULATION_SETTINGS_LOCKED"
+
+    denied = client.patch(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=other_headers,
+        json={"event_frequency": "low", "event_impact": "medium"},
+    )
+    assert denied.status_code == 403
+    assert denied.json()["error"]["code"] == "SIMULATION_ACCESS_DENIED"
+
+    unauthenticated = client.patch(
+        f"/v1/simulations/{simulation_id}/parameters",
+        json={"event_frequency": "low", "event_impact": "medium"},
+    )
+    assert unauthenticated.status_code == 401
+    assert unauthenticated.json()["error"]["code"] == "AUTHENTICATION_REQUIRED"
+
+    missing = client.patch(
+        f"/v1/simulations/{uuid4()}/parameters",
+        headers=owner_headers,
+        json={"event_frequency": "low", "event_impact": "medium"},
+    )
+    assert missing.status_code == 404
+    assert missing.json()["error"]["code"] == "REPLAY_RESOURCE_NOT_FOUND"
+
+
+def test_snapshot_restore_and_mismatch_are_read_only(api_context) -> None:
+    client, session_factory, _ = api_context
+    owner_headers = _register(client, "slice6-snapshot-owner")
+    other_headers = _register(client, "slice6-snapshot-other")
+    simulation_id = _create_simulation(client, owner_headers, "Snapshots")
+    other_simulation_id = _create_simulation(client, owner_headers, "Other source")
+    foreign_simulation_id = _create_simulation(client, other_headers, "Foreign")
+
+    with session_factory() as session:
+        snapshot = session.scalar(
+            select(SimulationSnapshot).where(
+                SimulationSnapshot.simulation_id == simulation_id
+            )
+        )
+        other_snapshot = session.scalar(
+            select(SimulationSnapshot).where(
+                SimulationSnapshot.simulation_id == other_simulation_id
+            )
+        )
+        foreign_snapshot = session.scalar(
+            select(SimulationSnapshot).where(
+                SimulationSnapshot.simulation_id == foreign_simulation_id
+            )
+        )
+        before = (
+            session.scalar(select(func.count()).select_from(Simulation)),
+            session.scalar(select(func.count()).select_from(RuntimeResult)),
+            session.scalar(select(func.count()).select_from(SimulationSnapshot)),
+            session.scalar(select(func.count()).select_from(Event)),
+        )
+
+    get_response = client.get(
+        f"/v1/simulations/{simulation_id}/snapshots/0", headers=owner_headers
+    )
+    assert get_response.status_code == 200
+    assert get_response.json()["data"]["snapshot_id"] == str(snapshot.id)
+    assert get_response.json()["data"]["tick_number"] == 0
+
+    denied_get = client.get(
+        f"/v1/simulations/{simulation_id}/snapshots/0", headers=other_headers
+    )
+    assert denied_get.status_code == 403
+
+    missing = client.get(
+        f"/v1/simulations/{simulation_id}/snapshots/99", headers=owner_headers
+    )
+    assert missing.status_code == 404
+    assert missing.json()["error"]["code"] == "REPLAY_RESOURCE_NOT_FOUND"
+
+    restored = client.post(
+        f"/v1/simulations/{simulation_id}/restore",
+        headers=owner_headers,
+        json={"snapshot_id": str(snapshot.id)},
+    )
+    assert restored.status_code == 200
+    assert restored.json()["data"]["simulation"]["id"] == str(simulation_id)
+
+    missing_restore = client.post(
+        f"/v1/simulations/{simulation_id}/restore",
+        headers=owner_headers,
+        json={"snapshot_id": str(uuid4())},
+    )
+    assert missing_restore.status_code == 404
+
+    mismatch = client.post(
+        f"/v1/simulations/{simulation_id}/restore",
+        headers=owner_headers,
+        json={"snapshot_id": str(other_snapshot.id)},
+    )
+    assert mismatch.status_code == 409
+    assert mismatch.json()["error"]["code"] == "SNAPSHOT_MISMATCH"
+
+    denied = client.post(
+        f"/v1/simulations/{simulation_id}/restore",
+        headers=owner_headers,
+        json={"snapshot_id": str(foreign_snapshot.id)},
+    )
+    assert denied.status_code == 403
+
+    with session_factory.begin() as session:
+        stored = session.get(SimulationSnapshot, snapshot.id)
+        stored.payload = {**stored.payload, "schema_version": "unsupported"}
+    unsupported = client.post(
+        f"/v1/simulations/{simulation_id}/restore",
+        headers=owner_headers,
+        json={"snapshot_id": str(snapshot.id)},
+    )
+    assert unsupported.status_code == 409
+    assert unsupported.json()["error"]["code"] == "UNSUPPORTED_SNAPSHOT_SCHEMA"
+
+    with session_factory() as session:
+        after = (
+            session.scalar(select(func.count()).select_from(Simulation)),
+            session.scalar(select(func.count()).select_from(RuntimeResult)),
+            session.scalar(select(func.count()).select_from(SimulationSnapshot)),
+            session.scalar(select(func.count()).select_from(Event)),
+        )
+    assert after == before
+
+
+def test_replay_routes_preserve_order_paginate_and_never_run_or_write(api_context) -> None:
+    client, session_factory, app = api_context
+    headers = _register(client, "slice6-replay-owner")
+    simulation_id = _create_simulation(client, headers, "Replay")
+    other_simulation_id = _create_simulation(client, headers, "Isolated")
+    result_ids, _ = _persist_runtime_and_snapshot(
+        session_factory,
+        simulation_id,
+        tick_number=1,
+        run_id="slice6-api-run",
+        fixture_keys=("student-02", "student-01"),
+    )
+    _persist_runtime_and_snapshot(
+        session_factory,
+        other_simulation_id,
+        tick_number=2,
+        run_id="other-run",
+    )
+
+    openapi_paths = app.openapi()["paths"]
+    route_paths = set(openapi_paths)
+    assert "/v1/simulations/{simulation_id}/parameters" in route_paths
+    assert set(openapi_paths["/v1/simulations/{simulation_id}/parameters"]) == {
+        "put",
+        "patch",
+    }
+    assert "/v1/simulations/{simulation_id}/snapshots/{tick_number}" in route_paths
+    assert "/v1/simulations/{simulation_id}/restore" in route_paths
+    assert "/v1/simulations/{simulation_id}/replay" in route_paths
+    assert "/v1/simulations/{simulation_id}/replay/{tick_number}" in route_paths
+
+    with session_factory() as session:
+        before = {
+            "runtime": session.scalar(select(func.count()).select_from(RuntimeResult)),
+            "snapshots": session.scalar(
+                select(func.count()).select_from(SimulationSnapshot)
+            ),
+            "events": session.scalar(select(func.count()).select_from(Event)),
+            "tick": session.get(Simulation, simulation_id).current_tick,
+        }
+
+    reset_counters()
+    first_page = client.get(
+        f"/v1/simulations/{simulation_id}/replay?limit=1", headers=headers
+    )
+    assert first_page.status_code == 200
+    assert [item["tick_number"] for item in first_page.json()["data"]] == [0]
+    assert first_page.json()["meta"] == {"next_cursor": "0", "has_more": True}
+
+    second_page = client.get(
+        f"/v1/simulations/{simulation_id}/replay?limit=1&cursor=0",
+        headers=headers,
+    )
+    assert [item["tick_number"] for item in second_page.json()["data"]] == [1]
+    assert all(item["tick_number"] != 2 for item in second_page.json()["data"])
+
+    detail = client.get(
+        f"/v1/simulations/{simulation_id}/replay/1", headers=headers
+    )
+    assert detail.status_code == 200
+    replay_results = detail.json()["data"]["runtime_results"]
+    assert [row["id"] for row in replay_results] == [str(value) for value in result_ids]
+    assert [row["tick_number"] for row in replay_results] == [1, 1]
+    assert [row["run_id"] for row in replay_results] == [
+        "slice6-api-run",
+        "slice6-api-run",
+    ]
+    assert len({row["agent_id"] for row in replay_results}) == 2
+    assert get_counts() == {"tick_calls": 0, "runtime_calls": 0, "llm_calls": 0}
+
+    missing_runtime = client.get(
+        f"/v1/simulations/{simulation_id}/replay/0", headers=headers
+    )
+    assert missing_runtime.status_code == 404
+    assert missing_runtime.json()["error"]["code"] == "REPLAY_RESOURCE_NOT_FOUND"
+
+    with session_factory() as session:
+        after = {
+            "runtime": session.scalar(select(func.count()).select_from(RuntimeResult)),
+            "snapshots": session.scalar(
+                select(func.count()).select_from(SimulationSnapshot)
+            ),
+            "events": session.scalar(select(func.count()).select_from(Event)),
+            "tick": session.get(Simulation, simulation_id).current_tick,
+        }
+    assert after == before
+
+
+def test_replay_detail_reports_missing_snapshot_and_mismatch(api_context) -> None:
+    client, session_factory, _ = api_context
+    headers = _register(client, "slice6-replay-errors")
+    simulation_id = _create_simulation(client, headers, "Replay errors")
+
+    with session_factory.begin() as session:
+        simulation = session.get(Simulation, simulation_id)
+        simulation.current_tick = 3
+        agent_id = session.scalar(
+            select(Agent.id).where(Agent.simulation_id == simulation_id)
+        )
+        session.add(
+            RuntimeResult(
+                id=uuid7(),
+                run_id="missing-snapshot",
+                tick_number=3,
+                agent_id=agent_id,
+                status="PROPOSED",
+                action_type="IDLE",
+                intent={},
+                retry_count=0,
+                model="test-model",
+                prompt_version="test-prompt-v1",
+                idempotency_key="missing-snapshot:3",
+                result_fingerprint="f" * 64,
+            )
+        )
+    missing = client.get(
+        f"/v1/simulations/{simulation_id}/replay/3", headers=headers
+    )
+    assert missing.status_code == 404
+
+    _, snapshot_id = _persist_runtime_and_snapshot(
+        session_factory,
+        simulation_id,
+        tick_number=4,
+        run_id="mismatch-run",
+    )
+    with session_factory.begin() as session:
+        snapshot = session.get(SimulationSnapshot, snapshot_id)
+        snapshot.payload = {**snapshot.payload, "runtime_results": []}
+    mismatch = client.get(
+        f"/v1/simulations/{simulation_id}/replay/4", headers=headers
+    )
+    assert mismatch.status_code == 409
+    assert mismatch.json()["error"]["code"] == "SNAPSHOT_MISMATCH"


### PR DESCRIPTION
## 작업 개요

Slice 6 frontend가 호출하는 설정·Snapshot·Replay backend HTTP API가 누락되어 있어,
기존 Slice 6 Snapshot service/repository 및 Replay 무재실행 계약을 재사용하여 실제 API 경로를 연결했습니다.

## 관련 Issue

- Parent: #116
- Persistence: #118
- UI: #120
- Replay no-rerun: #121
- Slice 6 integration blocker fix

## 변경 내용

- PUT/PATCH `/v1/simulations/{simulation_id}/parameters` 구현
- GET `/v1/simulations/{simulation_id}/snapshots/{tick_number}` 구현
- POST `/v1/simulations/{simulation_id}/restore` 구현
- GET `/v1/simulations/{simulation_id}/replay` 구현
- GET `/v1/simulations/{simulation_id}/replay/{tick_number}` 구현
- Replay 목록 pagination용 repository helper 추가
- 저장된 RuntimeResult·Snapshot만 사용하는 read-only Replay service 추가
- frontend 계약의 `{error:{code,message}}` 오류 envelope 적용
- ownership 및 400/401/403/404/409 API 검증 추가

## 결정 사항 및 이유

기존 Slice 6 Task 1의 `SimulationSnapshotService` 및 repository를 재사용하여
새 architecture나 migration 없이 HTTP API 계층만 최소 연결했습니다.

Replay 및 restore는 저장된 결과만 읽으며,
새 Runtime·LLM·Tick·Simulation·Snapshot을 생성하지 않습니다.

## 테스트 / 확인 내용

- [x] 신규 Slice 6 API 테스트: 4 passed
- [x] Slice 6 persistence/no-rerun/API regression: 20 passed
- [x] 전체 backend regression: 289 passed
- [x] Replay Runtime 호출 0회
- [x] Replay LLM 호출 0회
- [x] Replay Tick 호출 0회
- [x] Replay/restore DB write 0 확인
- [x] OpenAPI route 등록 확인
- [x] frontend API 계약 재대조
- [x] git diff --check 통과
- [x] frontend/migration 변경 없음

## AI 사용 여부

사용 여부: 사용함

사용한 작업:
- 누락된 Slice 6 backend HTTP API 연결
- API integration test 작성 및 회귀 검증

사람이 검토한 내용:
- 기존 Slice 6 계약 재사용 여부
- Replay 무재실행 및 read-only 동작
- frontend API 계약과의 정합성
- 테스트 및 변경 범위

## 리뷰어가 봐야 할 부분

- Replay list/detail이 저장된 RuntimeResult·Snapshot만 읽는지
- restore가 새 Simulation을 생성하지 않는지
- ownership 및 오류 코드가 frontend 계약과 일치하는지
- 기존 Snapshot service/repository를 중복 구현하지 않았는지
