### PR TITLE
[Fix] Slice 6 Alembic migration head 통합

### DIFF
--- a/backend/alembic/versions/20260827_0009_merge_slice6_snapshot_head.py
+++ b/backend/alembic/versions/20260827_0009_merge_slice6_snapshot_head.py
@@ -1,0 +1,18 @@
+"""merge Slice 6 snapshot and develop migration heads
+
+Revision ID: 20260827_0009
+Revises: 20260821_0006, 20260827_0008
+"""
+
+revision = "20260827_0009"
+down_revision = ("20260821_0006", "20260827_0008")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## 작업 개요

최신 develop 반영 후 분기된 Slice 6 Snapshot migration head와 develop migration head를 하나로 합칩니다.

## 관련 Issue

Closes #189

## 변경 내용

- `20260821_0006`과 `20260827_0008`을 잇는 데이터 변경 없는 merge migration 추가

## 테스트 / 확인 내용

- [x] `alembic heads`: `20260827_0009` 단일 head
- [x] 기존 Slice 6 migration 적용 격리 DB `alembic upgrade head`
- [x] 신규 격리 PostgreSQL `alembic upgrade head`
- [x] Slice 6 집중: 22 passed
- [ ] Backend 전체: 559 passed, develop 기원 memory cap 회귀 1 failed (#190에서 처리)
- [x] `git diff --check`

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: migration graph 진단, merge migration 작성, 격리 DB 검증
- 사람이 검토한 내용: down_revision graph와 신규/기존 DB upgrade 결과

## 리뷰어가 봐야 할 부분

- schema 변경 없이 두 head만 통합하는 migration인지
