### PR TITLE
[Fix] Memory 상한 E2E 계약 정합화

### DIFF
--- a/backend/tests/test_memory_adapter.py
+++ b/backend/tests/test_memory_adapter.py
@@ -135,7 +135,7 @@ async def test_memory_store_uses_session_on_caller_thread():
 
 @pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
 async def test_memory_store_enforces_cap_end_to_end_via_real_db() -> None:
-    """build_memory_store로 11번째 저장 시 실제 DB에서 enforce_cap(10)까지 적용된다"""
+    """11번째 저장 시 최신 2개를 보존하고 나머지 최저 중요도를 제거한다."""
     engine = create_engine(TEST_DATABASE_URL)
     session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
     with engine.begin() as connection:
@@ -202,8 +202,10 @@ async def test_memory_store_enforces_cap_end_to_end_via_real_db() -> None:
             rows = session.scalars(
                 select(AgentMemory).where(AgentMemory.agent_id == agent_id)
             ).all()
+            contents = {row.content for row in rows}
             assert len(rows) == 10
-            assert not any(row.content == "memory-lowest-importance" for row in rows)
+            assert "memory-lowest-importance" in contents
+            assert "memory-1" not in contents
     finally:
         engine.dispose()
 class FakeRepository:


### PR DESCRIPTION
## 작업 개요

backend 전체 회귀를 막던 Memory cap E2E 기대값을 canonical 보존 계약과 일치시킵니다.

## 관련 Issue

Closes #190

## 변경 내용

- 최신 2개 Memory가 importance와 무관하게 보존되는지 검증
- 최신 2개를 제외한 항목 중 importance가 가장 낮은 기존 Memory가 제거되는지 검증

## 결정 사항 및 이유

`docs/03-system-design/agent-runtime.md §4.3`은 최신 2개를 항상 보존하도록 확정합니다. production repository와 단위 테스트는 이미 이 계약을 따르므로 잘못된 E2E 기대값만 수정합니다.

## 테스트 / 확인 내용

- [x] Memory repository/adapter: 15 passed
- [x] Backend 전체: 560 passed, skip 0
- [x] `git diff --check`

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: 실패 재현, canonical 계약 대조, 테스트 기대값 수정
- 사람이 검토한 내용: 최신 2개 보존 및 importance 기반 제거 계약

## 리뷰어가 봐야 할 부분

- production 코드 변경 없이 E2E 기대값만 canonical 계약에 맞췄는지
