### PR TITLE
[Feature] Slice 5 Task 5 — Tick 10 대표 캠페인 통합

### DIFF
--- a/backend/app/api/ticks.py
+++ b/backend/app/api/ticks.py
@@ -12,6 +12,11 @@ from app.domain.models import User
 from app.services.manual_tick import TickAlreadyRunningError, advance_manual_tick
 from app.services.runtime_dependency import get_agent_runtime
 from app.services.simulations import require_owned_simulation
+from app.services.simulation_events import (
+    TickResultPublisher,
+    build_tick_result_messages,
+    get_tick_result_publisher,
+)
 from app.simulation.agent_runtime import AgentRuntime
 
 
@@ -77,18 +82,21 @@ router = APIRouter(tags=["ticks"])
     "/simulations/{simulation_id}/ticks/advance",
     response_model=TickAdvanceResponse,
 )
-def advance_tick(
+async def advance_tick(
     simulation_id: UUID,
     db: Session = Depends(get_db),
     current_user: User = Depends(require_user_role),
     runtime: AgentRuntime = Depends(get_agent_runtime),
+    publisher: TickResultPublisher = Depends(get_tick_result_publisher),
 ):
     simulation = require_owned_simulation(db, simulation_id, current_user)
     try:
-        result = asyncio.run(advance_manual_tick(db, simulation, runtime=runtime))
-        db.commit()
+        result = await asyncio.to_thread(
+            lambda: asyncio.run(advance_manual_tick(db, simulation, runtime=runtime))
+        )
+        await asyncio.to_thread(db.commit)
     except TickAlreadyRunningError:
-        db.rollback()
+        await asyncio.to_thread(db.rollback)
         return JSONResponse(
             status_code=409,
             content={
@@ -99,8 +107,31 @@ def advance_tick(
             },
         )
     except Exception:
-        db.rollback()
+        await asyncio.to_thread(db.rollback)
         raise
+
+    relationship_deltas = [
+        {
+            "effect_id": effect.effect_id,
+            "rule_id": effect.rule_id,
+            "source_agent_id": str(effect.source_agent_id),
+            "target_agent_id": str(effect.target_agent_id),
+            "metric": effect.metric,
+            "before": effect.before,
+            "applied_delta": effect.after_preview - effect.before,
+            "after": effect.after_preview,
+            "reason": effect.reason,
+        }
+        for effect in result.policy_result.relationship_effects
+        if effect.target_agent_id is not None
+    ]
+    await publisher.publish(
+        build_tick_result_messages(
+            simulation.id,
+            result.event_batch_result,
+            relationship_deltas,
+        )
+    )
 
     return TickAdvanceResponse(
         simulation_id=simulation.id,

--- a/backend/app/repositories/relationships.py
+++ b/backend/app/repositories/relationships.py
@@ -14,6 +14,7 @@ from app.domain.relationship_metrics import (
 
 
 RelationshipRow: TypeAlias = Relationship
+FRIEND_ENTRY_THRESHOLD = 50
 
 
 class RelationshipNotFoundError(LookupError):
@@ -152,6 +153,14 @@ def apply_deltas(session: Session, deltas: list[RelationshipDelta]) -> None:
 
     for relationship, delta in pending:
         setattr(relationship, delta.metric, delta.after)
+
+    for relationship in {item[0] for item in pending}:
+        if (
+            relationship.trust >= FRIEND_ENTRY_THRESHOLD
+            and relationship.affection >= FRIEND_ENTRY_THRESHOLD
+            and relationship.closeness >= FRIEND_ENTRY_THRESHOLD
+        ):
+            relationship.relationship_type = "friend"
 
     # TODO(issue-41-task5): 상위 Tick Commit 경계에서 State, Memory,
     # Event, Outbox 변경과 함께 commit/rollback하도록 통합한다.

--- a/backend/app/services/event_magic_phase.py
+++ b/backend/app/services/event_magic_phase.py
@@ -38,6 +38,10 @@ class EventAndMagicResult:
     events: tuple[Event, ...]
     special_events: tuple[SpecialEvent, ...]
     resolved_effects: tuple[EffectCandidate, ...]
+    reflection_eligible_event_keys: tuple[str, ...]
+
+
+REFLECTION_IMPORTANCE_THRESHOLD = 70
 
 
 def run_event_and_magic_phase(
@@ -80,4 +84,15 @@ def run_event_and_magic_phase(
         events=magic_result.converted_events,
         special_events=magic_result.special_events,
         resolved_effects=tuple(resolved),
+        reflection_eligible_event_keys=tuple(
+            [
+                event.event_key
+                for event in magic_result.converted_events
+                if event.importance >= REFLECTION_IMPORTANCE_THRESHOLD
+            ]
+            + [
+                f"magic:{event.event_subtype}:{event.tick}"
+                for event in magic_result.special_events
+            ]
+        ),
     )

--- a/backend/app/services/event_persistence.py
+++ b/backend/app/services/event_persistence.py
@@ -132,6 +132,4 @@ def persist_event_batch(session: Session, batch: EventBatch) -> dict:
     session.add(EventBatchResult(simulation_id=batch.simulation_id, tick_number=batch.tick_number,
                                  input_payload=payload, result_payload=result))
     session.flush()
-    # TODO(#105): invoke inside the fenced Tick commit alongside Runtime/relationships;
-    # advance current_tick there, and publish get_event_result() only after commit.
     return deepcopy(result)

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -6,6 +6,7 @@ from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 from uuid6 import uuid7
 
+from app.domain.event_persistence import EventBatch, EventWrite, StateDelta
 from app.domain.models import (
     Agent,
     AgentState,
@@ -18,6 +19,7 @@ from app.domain.models import (
 )
 from app.services.database_runtime_results import DatabaseRuntimeResultSink
 from app.services.event_magic_phase import EventAndMagicResult, run_event_and_magic_phase
+from app.services.event_persistence import persist_event_batch
 from app.services.policy_commit import PolicyCommitResult, evaluate_and_apply_policy
 from app.services.runtime_input_adapter import RuntimeInputAdapter
 from app.services.runtime_orchestrator import RuntimeOrchestrator
@@ -68,6 +70,7 @@ class ManualTickResult:
     retrieval_traces: dict[str, list[str]]
     retrieved_memories: dict[str, tuple[MemoryItem, ...]]
     event_and_magic_result: EventAndMagicResult
+    event_batch_result: dict
 
 
 def tick_position(tick_number: int) -> tuple[int, Block]:
@@ -306,6 +309,95 @@ def _run_event_and_magic_phase(
     )
 
 
+def _build_event_batch(
+    db: Session,
+    *,
+    simulation_id: UUID,
+    run_id: UUID,
+    tick_number: int,
+    result: EventAndMagicResult,
+) -> EventBatch:
+    """Adapt final Task 1 output to the existing Task 3 commit contract."""
+    event_writes = [
+        EventWrite(
+            id=uuid7(),
+            event_type=event.event_type,
+            event_subtype=event.event_subtype,
+            title=event.title,
+            description=event.description,
+            participant_agent_ids=tuple(
+                UUID(agent_id) for agent_id in event.participant_agent_ids
+            ),
+            location_id=UUID(event.location_id),
+            source="event_master",
+            impact_level=event.impact_level.value,
+            importance=event.importance,
+            expected_effects=event.expected_effects,
+        )
+        for event in result.events
+    ]
+    event_writes.extend(
+        EventWrite(
+            id=uuid7(),
+            event_type=event.event_subtype,
+            title=event.title,
+            description=event.description,
+            participant_agent_ids=tuple(
+                UUID(agent_id) for agent_id in event.participant_agent_ids
+            ),
+            location_id=UUID(event.location_id),
+            source="magic_layer",
+            impact_level="high",
+            importance=80,
+        )
+        for event in result.special_events
+        if event.location_id is not None
+    )
+
+    agent_ids = {UUID(effect.source_agent_id) for effect in result.resolved_effects}
+    states = {
+        state.agent_id: state
+        for state in db.scalars(
+            select(AgentState).where(AgentState.agent_id.in_(agent_ids)).with_for_update()
+        )
+    }
+    state_deltas = []
+    for effect in result.resolved_effects:
+        agent_id = UUID(effect.source_agent_id)
+        state = states[agent_id]
+        before = getattr(state, effect.metric)
+        minimum = -100 if effect.metric == "mood" else 0
+        after = max(minimum, min(100, before + effect.delta))
+        state_deltas.append(
+            StateDelta(
+                source_agent_id=agent_id,
+                metric=effect.metric,
+                before=before,
+                requested_total=effect.delta,
+                applied_delta=after - before,
+                after=after,
+                effect_ids=(effect.effect_id,),
+            )
+        )
+
+    missing_agent_ids = tuple(
+        UUID(agent_id)
+        for event in result.special_events
+        for agent_id in event.missing_agent_ids
+    )
+    return EventBatch(
+        simulation_id=simulation_id,
+        run_id=str(run_id),
+        tick_number=tick_number,
+        policy_version="policy-mvp-0.1",
+        resolver_version="resolver-mvp-0.1",
+        resolution_id=f"{run_id}:{tick_number}",
+        events=tuple(event_writes),
+        resolved_effects=tuple(state_deltas),
+        missing_agent_ids=missing_agent_ids,
+    )
+
+
 async def advance_manual_tick(
     db: Session,
     simulation: Simulation,
@@ -373,7 +465,7 @@ async def advance_manual_tick(
     preselected_ids = [
         agent.id
         for agent in agents
-        if agent.fixture_key == "student-01"
+        if agent.agent_type in ("student", "user_persona")
         or (agent.agent_type == "professor" and agent.id in participant_ids)
     ]
     if not any(agent.fixture_key == "student-01" for agent in agents):
@@ -460,6 +552,14 @@ async def advance_manual_tick(
     )
     if tick_result.status != "completed" or batch is None or policy_result is None:
         raise RuntimeError("TickEngine completed without a Runtime batch")
+    event_batch = _build_event_batch(
+        db,
+        simulation_id=simulation.id,
+        run_id=run_id,
+        tick_number=current_tick,
+        result=event_and_magic_result,
+    )
+    event_batch_result = persist_event_batch(db, event_batch)
     simulation.current_tick = current_tick
     simulation.current_day = current_day
     db.flush()
@@ -476,4 +576,5 @@ async def advance_manual_tick(
             for agent_id, memories in snapshot.data.get("memories", {}).items()
         },
         event_and_magic_result=event_and_magic_result,
+        event_batch_result=event_batch_result,
     )

--- a/backend/app/services/runtime_orchestrator.py
+++ b/backend/app/services/runtime_orchestrator.py
@@ -18,6 +18,7 @@ from app.simulation.agent_runtime import (
     RelationshipSummary,
     ScheduleSummary,
 )
+from app.simulation.intent_conflict import resolve_talk_conflicts
 
 
 class AgentRuntimeExecutor(Protocol):
@@ -88,10 +89,11 @@ class RuntimeOrchestrator:
     def run_batch(
         self, runtime_inputs: Sequence[AgentRuntimeInput]
     ) -> RuntimeBatchExecutionResult:
-        results = tuple(
+        proposed_results = tuple(
             self._runtime.run(runtime_input)
             for runtime_input in runtime_inputs
         )
+        results = resolve_talk_conflicts(proposed_results).runtime_results
         save_result = self._result_sink.save_batch(results)
         return RuntimeBatchExecutionResult(
             results=results,

--- a/backend/app/services/simulation_events.py
+++ b/backend/app/services/simulation_events.py
@@ -1,0 +1,60 @@
+from typing import Protocol
+from uuid import UUID
+
+
+class TickResultPublisher(Protocol):
+    async def publish(self, messages: tuple[dict, ...]) -> None: ...
+
+
+class NullTickResultPublisher:
+    async def publish(self, messages: tuple[dict, ...]) -> None:
+        return None
+
+
+tick_result_publisher: TickResultPublisher = NullTickResultPublisher()
+
+
+def get_tick_result_publisher() -> TickResultPublisher:
+    return tick_result_publisher
+
+
+def build_tick_result_messages(
+    simulation_id: UUID,
+    result: dict,
+    relationship_effects: list[dict],
+) -> tuple[dict, ...]:
+    """Build Task 4 payloads without owning a WebSocket transport."""
+    return (
+        {
+            "type": "TICK_UPDATED",
+            "data": {
+                "simulation_id": str(simulation_id),
+                "tick_number": result["tick_number"],
+                "block": result["block"],
+                "resolved_effects": result["resolved_effects"],
+            },
+        },
+        *(
+            {
+                "type": "EVENT_CREATED",
+                "data": {
+                    "simulation_id": str(simulation_id),
+                    "tick_number": result["tick_number"],
+                    "event_id": event["id"],
+                    **event,
+                },
+            }
+            for event in result["events"]
+        ),
+        *(
+            {
+                "type": "RELATIONSHIP_UPDATED",
+                "data": {
+                    "simulation_id": str(simulation_id),
+                    "tick_number": result["tick_number"],
+                    **effect,
+                },
+            }
+            for effect in relationship_effects
+        ),
+    )

--- a/backend/app/simulation/intent_conflict.py
+++ b/backend/app/simulation/intent_conflict.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from app.simulation.agent_runtime import (
+    ActionAlternative,
+    ActionType,
+    AgentReaction,
+    AgentRuntimeResult,
+    DecisionExplanation,
+    IntentCandidate,
+    ReactionValence,
+    RelativePriority,
+    RuntimeStatus,
+)
+
+
+@dataclass(frozen=True)
+class TalkConflictResolution:
+    runtime_results: tuple[AgentRuntimeResult, ...]
+    mutual_pairs: tuple[tuple[UUID, UUID], ...]
+    wait_fallback_agent_ids: tuple[UUID, ...]
+
+
+def resolve_talk_conflicts(
+    runtime_results: tuple[AgentRuntimeResult, ...],
+) -> TalkConflictResolution:
+    """Accept mutual TALK pairs and convert every unmatched TALK to WAIT."""
+    talks = {
+        result.agent_id: result.intent.target_agent_id
+        for result in runtime_results
+        if result.intent.action_type == ActionType.TALK
+        and result.intent.target_agent_id is not None
+    }
+    mutual_agent_ids = {
+        source_id
+        for source_id, target_id in talks.items()
+        if talks.get(target_id) == source_id
+    }
+    mutual_pairs: list[tuple[UUID, UUID]] = []
+    seen: set[UUID] = set()
+    for result in runtime_results:
+        source_id = result.agent_id
+        target_id = talks.get(source_id)
+        if source_id in mutual_agent_ids and source_id not in seen and target_id is not None:
+            mutual_pairs.append((source_id, target_id))
+            seen.update((source_id, target_id))
+
+    fallback_ids: list[UUID] = []
+    resolved: list[AgentRuntimeResult] = []
+    for result in runtime_results:
+        if result.intent.action_type != ActionType.TALK or result.agent_id in mutual_agent_ids:
+            resolved.append(result)
+            continue
+        fallback_ids.append(result.agent_id)
+        wait_intent = IntentCandidate(
+            action_type=ActionType.WAIT,
+            target_agent_id=None,
+            target_location_id=None,
+            related_event_id=None,
+            utterance=None,
+            motivation_summary="TALK 충돌로 WAIT_FALLBACK 적용",
+            reaction=AgentReaction(
+                valence=ReactionValence.NEUTRAL,
+                relationship_signals=[],
+                state_signals=[],
+            ),
+            decision_explanation=DecisionExplanation(
+                alternatives=[
+                    ActionAlternative(
+                        action_type=ActionType.WAIT,
+                        description="상호 TALK가 성립하지 않아 대기한다.",
+                        relative_priority=RelativePriority.HIGH,
+                        selected=True,
+                    )
+                ],
+                influencing_factors=[],
+            ),
+            memory_candidates=[],
+        )
+        resolved.append(
+            result.model_copy(
+                update={
+                    "status": RuntimeStatus.FALLBACK,
+                    "intent": wait_intent,
+                    "failure_reason": "WAIT_FALLBACK",
+                }
+            )
+        )
+    return TalkConflictResolution(
+        runtime_results=tuple(resolved),
+        mutual_pairs=tuple(mutual_pairs),
+        wait_fallback_agent_ids=tuple(fallback_ids),
+    )

--- a/backend/app/simulation/policy/engine.py
+++ b/backend/app/simulation/policy/engine.py
@@ -11,6 +11,11 @@ from app.simulation.policy.registries.signal_policy import get_relationship_delt
 
 SUPPORTED_POLICY_VERSIONS = {"policy-mvp-0.1"}
 
+ACTION_STATE_EFFECTS: dict[str, tuple[tuple[str, int], ...]] = {
+    "TALK": (("fatigue", 1),),
+    "WAIT": (("hunger", 2), ("fatigue", 1)),
+}
+
 RELATIONSHIP_SIGNAL_TO_METRIC: dict[RelationshipSignalType, str] = {
     RelationshipSignalType.TRUST_UP: "trust",
     RelationshipSignalType.TRUST_DOWN: "trust",
@@ -87,6 +92,24 @@ def evaluate_policy(inp: PolicyEvaluationInput) -> PolicyEvaluationResult:
         reaction = runtime_result.intent.reaction
         action_type = runtime_result.intent.action_type
         seen_effect_source_keys: set[tuple[str, ...]] = set()
+
+        for metric, delta in ACTION_STATE_EFFECTS.get(str(action_type), ()):
+            current = state_index.get(source_agent_id, {}).get(metric, 0)
+            effect_candidates.append(EffectCandidate(
+                effect_id=(
+                    f"{inp.run_id}:{inp.tick_number}:{source_agent_id}:"
+                    f"action:{action_type}:{metric}"
+                ),
+                target_type=EffectTargetType.AGENT_STATE,
+                source_agent_id=source_agent_id,
+                target_agent_id=None,
+                metric=metric,
+                delta=delta,
+                before=current,
+                after_preview=_clamp_preview(current, delta, metric),
+                rule_id=f"ACTION_{action_type}",
+                reason=f"{action_type} 기본 효과",
+            ))
 
         relationship_directions: dict[tuple[str, str], set[int]] = {}
         for signal in reaction.relationship_signals:

--- a/backend/tests/slice5_campaign.py
+++ b/backend/tests/slice5_campaign.py
@@ -1,0 +1,276 @@
+import asyncio
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.models import (
+    Agent,
+    AgentState,
+    Relationship,
+    RuntimeResult,
+    Simulation,
+    StudentProfile,
+    User,
+)
+from app.services.fixtures import seed_slice_zero
+from app.services.manual_tick import advance_manual_tick
+from app.simulation.agent_runtime import AgentRuntime, AgentRuntimeInput
+
+
+@dataclass(frozen=True)
+class CampaignTick:
+    tick_number: int
+    events: tuple[tuple[str, str | None, tuple[str, ...]], ...]
+    statuses: tuple[tuple[str, str, int | None, int | None], ...]
+    runtime_actions: tuple[tuple[str, str, str, str | None], ...]
+    relationship: tuple[int, int, int, str | None]
+    reflection_eligible_event_keys: tuple[str, ...]
+
+
+class CanonicalCampaignLLM:
+    def generate(self, runtime_input: AgentRuntimeInput) -> dict:
+        fixture_key = runtime_input.agent.fixture_key
+        agents_by_name = {agent.name: agent.agent_id for agent in runtime_input.nearby_agents}
+        if runtime_input.tick_number == 10 and fixture_key in {
+            "student-01",
+            "student-02",
+            "student-03",
+        }:
+            target_name = {
+                "student-01": "레오",
+                "student-02": "아델",
+                "student-03": "아델",
+            }[fixture_key]
+            target_id = agents_by_name[target_name]
+            relationship_signals = []
+            if fixture_key in {"student-01", "student-03"}:
+                relationship_signals = [
+                    {
+                        "signal_type": "TRUST_UP",
+                        "intensity": "LOW",
+                        "target_agent_id": str(target_id),
+                    }
+                ]
+            return self._response(
+                action_type="TALK",
+                target_agent_id=target_id,
+                relationship_signals=relationship_signals,
+            )
+        if runtime_input.tick_number == 10 and fixture_key == "student-05":
+            return self._response(
+                action_type="WAIT",
+                state_signals=[
+                    {"signal_type": "STRESS_DOWN", "intensity": "HIGH"}
+                ],
+            )
+        if runtime_input.agent.agent_type == "professor":
+            class_event = runtime_input.events[0]
+            return self._response(
+                action_type="TEACH_CLASS",
+                target_location_id=class_event.location_id,
+                related_event_id=class_event.event_id,
+            )
+        return self._response(action_type="WAIT")
+
+    @staticmethod
+    def _response(
+        *,
+        action_type: str,
+        target_agent_id: UUID | None = None,
+        target_location_id: UUID | None = None,
+        related_event_id: UUID | None = None,
+        relationship_signals: list[dict] | None = None,
+        state_signals: list[dict] | None = None,
+    ) -> dict:
+        return {
+            "action_type": action_type,
+            "target_agent_id": str(target_agent_id) if target_agent_id else None,
+            "target_location_id": str(target_location_id) if target_location_id else None,
+            "related_event_id": str(related_event_id) if related_event_id else None,
+            "utterance": "대화하자." if action_type == "TALK" else None,
+            "motivation_summary": "Slice 5 canonical campaign",
+            "reaction": {
+                "valence": "POSITIVE" if action_type == "TALK" else "NEUTRAL",
+                "relationship_signals": relationship_signals or [],
+                "state_signals": state_signals or [],
+            },
+            "decision_explanation": {
+                "alternatives": [
+                    {
+                        "action_type": action_type,
+                        "description": "canonical action",
+                        "relative_priority": "HIGH",
+                        "selected": True,
+                    }
+                ],
+                "influencing_factors": [],
+            },
+            "memory_candidates": [],
+        }
+
+
+def prepare_canonical_campaign(db: Session) -> tuple[Simulation, dict[str, Agent]]:
+    user = User(
+        id=uuid4(),
+        username=str(uuid4()),
+        display_name="Slice 5 campaign",
+        password_hash="test",
+        roles=["USER"],
+    )
+    db.add(user)
+    db.flush()
+    simulation = Simulation(
+        id=uuid4(),
+        owner_id=user.id,
+        name="Canonical Tick 10 campaign",
+        current_tick=9,
+        current_day=3,
+    )
+    db.add(simulation)
+    db.flush()
+    seed_slice_zero(db, simulation.id)
+    agents = {
+        agent.fixture_key: agent
+        for agent in db.scalars(
+            select(Agent)
+            .where(Agent.simulation_id == simulation.id)
+            .order_by(Agent.fixture_key)
+        )
+    }
+    profiles = {
+        profile.agent_id: profile
+        for profile in db.scalars(
+            select(StudentProfile).where(
+                StudentProfile.agent_id.in_([agent.id for agent in agents.values()])
+            )
+        )
+    }
+    profiles[agents["student-01"].id].interest_field = "캠페인 전공"
+    profiles[agents["student-02"].id].interest_field = "캠페인 전공"
+
+    states = {
+        state.agent_id: state
+        for state in db.scalars(
+            select(AgentState).where(AgentState.simulation_id == simulation.id)
+        )
+    }
+    for key in ("student-01", "student-02", "student-03", "student-04"):
+        states[agents[key].id].fatigue = 85
+    states[agents["student-05"].id].stress = 95
+
+    db.add_all(
+        [
+            Relationship(
+                id=uuid4(),
+                simulation_id=simulation.id,
+                source_agent_id=agents["student-01"].id,
+                target_agent_id=agents["student-02"].id,
+                trust=49,
+                affection=50,
+                closeness=50,
+            ),
+            Relationship(
+                id=uuid4(),
+                simulation_id=simulation.id,
+                source_agent_id=agents["student-02"].id,
+                target_agent_id=agents["student-01"].id,
+                trust=0,
+                affection=0,
+                closeness=0,
+            ),
+        ]
+    )
+    target = agents["student-05"]
+    for tick in range(1, 10):
+        run_id = f"campaign-history-{tick}"
+        db.add(
+            RuntimeResult(
+                id=uuid4(),
+                run_id=run_id,
+                tick_number=tick,
+                agent_id=target.id,
+                status="PROPOSED",
+                action_type="WAIT",
+                intent={
+                    "action_type": "WAIT",
+                    "reaction": {"state_signals": [], "relationship_signals": []},
+                },
+                retry_count=0,
+                failure_reason=None,
+                model="campaign-history",
+                prompt_version="campaign-v1",
+                idempotency_key=f"{run_id}:{tick}:{target.id}",
+                result_fingerprint=f"campaign-{tick:02d}".ljust(64, "0"),
+            )
+        )
+    db.commit()
+    return simulation, agents
+
+
+def run_canonical_campaign(db: Session) -> tuple[CampaignTick, ...]:
+    simulation, agents = prepare_canonical_campaign(db)
+    runtime = AgentRuntime(CanonicalCampaignLLM(), model="slice5-campaign")
+    fixture_by_id = {str(agent.id): key for key, agent in agents.items()}
+    snapshots: list[CampaignTick] = []
+    for _ in range(10):
+        result = asyncio.run(advance_manual_tick(db, simulation, runtime=runtime))
+        db.commit()
+        relationship = db.scalar(
+            select(Relationship).where(
+                Relationship.source_agent_id == agents["student-01"].id,
+                Relationship.target_agent_id == agents["student-02"].id,
+            )
+        )
+        refreshed_agents = list(
+            db.scalars(
+                select(Agent)
+                .where(Agent.simulation_id == simulation.id)
+                .order_by(Agent.fixture_key)
+            )
+        )
+        snapshots.append(
+            CampaignTick(
+                tick_number=result.current_tick,
+                events=tuple(
+                    (
+                        event["event_type"],
+                        event.get("event_subtype"),
+                        tuple(
+                            fixture_by_id[agent_id]
+                            for agent_id in event["participant_agent_ids"]
+                        ),
+                    )
+                    for event in result.event_batch_result["events"]
+                ),
+                statuses=tuple(
+                    (
+                        agent.fixture_key,
+                        agent.active_status,
+                        agent.inactive_until_tick,
+                        agent.cursed_until_tick,
+                    )
+                    for agent in refreshed_agents
+                ),
+                runtime_actions=tuple(
+                    (
+                        fixture_by_id[str(runtime_result.agent_id)],
+                        runtime_result.intent.action_type,
+                        runtime_result.status,
+                        runtime_result.failure_reason,
+                    )
+                    for runtime_result in result.runtime_results
+                ),
+                relationship=(
+                    relationship.trust,
+                    relationship.affection,
+                    relationship.closeness,
+                    relationship.relationship_type,
+                ),
+                reflection_eligible_event_keys=(
+                    result.event_and_magic_result.reflection_eligible_event_keys
+                ),
+            )
+        )
+    return tuple(snapshots)

--- a/backend/tests/test_event_magic_policy_integration.py
+++ b/backend/tests/test_event_magic_policy_integration.py
@@ -559,3 +559,104 @@ def test_advance_manual_tick_wires_db_class_event_into_event_master(db):
 
     # Magic Layer로도 정상 전달된다 (converted_events에 동일 CLASS Event가 포함).
     assert any(e.event_type == "CLASS" for e in event_and_magic.events)
+
+    # Task 5 production commit 경계가 Task 3 저장 계약까지 실제로 연결된다.
+    saved = result.event_batch_result
+    assert saved["simulation_id"] == str(simulation_id)
+    assert saved["tick_number"] == 1
+    assert any(event["event_type"] == "CLASS" for event in saved["events"])
+    assert db.get(Simulation, simulation_id).current_tick == 1
+
+
+def test_advance_manual_tick_rolls_back_all_tick_writes_after_event_batch_failure(
+    db, monkeypatch
+):
+    """A fatal failure after Task 3 flush leaves the complete Tick unchanged."""
+    import asyncio
+
+    from sqlalchemy import func
+
+    from app.domain.models import (
+        Event as DomainEvent,
+        EventBatchResult,
+        Relationship,
+        RuntimeResult,
+    )
+    from app.services import manual_tick
+    from app.simulation.agent_runtime import AgentRuntime, MockLLMClient
+
+    simulation_id = _setup_simulation(db)
+    simulation = db.get(Simulation, simulation_id)
+    participants = list(
+        db.scalars(
+            select(Agent)
+            .where(
+                Agent.simulation_id == simulation_id,
+                Agent.fixture_key.in_(("student-01", "professor-01")),
+            )
+            .order_by(Agent.fixture_key)
+        )
+    )
+    relationship = Relationship(
+        id=uuid4(),
+        simulation_id=simulation_id,
+        source_agent_id=participants[0].id,
+        target_agent_id=participants[1].id,
+        trust=7,
+    )
+    db.add(relationship)
+    db.commit()
+
+    state_before = {
+        state.agent_id: (state.hunger, state.fatigue, state.stress, state.satisfaction, state.mood)
+        for state in db.scalars(
+            select(AgentState).where(AgentState.simulation_id == simulation_id)
+        )
+    }
+    event_count_before = db.scalar(
+        select(func.count()).select_from(DomainEvent).where(
+            DomainEvent.simulation_id == simulation_id
+        )
+    )
+    original_persist = manual_tick.persist_event_batch
+
+    def fail_after_event_batch_flush(session, batch):
+        original_persist(session, batch)
+        relationship.trust = 10
+        session.flush()
+        raise RuntimeError("injected downstream failure")
+
+    monkeypatch.setattr(manual_tick, "persist_event_batch", fail_after_event_batch_flush)
+    with pytest.raises(RuntimeError, match="injected downstream"):
+        asyncio.run(
+            manual_tick.advance_manual_tick(
+                db,
+                simulation,
+                runtime=AgentRuntime(MockLLMClient(), model="rollback-test"),
+            )
+        )
+    db.rollback()
+
+    assert db.get(Simulation, simulation_id).current_tick == 0
+    assert db.get(Relationship, relationship.id).trust == 7
+    assert db.scalar(
+        select(func.count()).select_from(DomainEvent).where(
+            DomainEvent.simulation_id == simulation_id
+        )
+    ) == event_count_before
+    assert db.scalar(
+        select(func.count()).select_from(EventBatchResult).where(
+            EventBatchResult.simulation_id == simulation_id
+        )
+    ) == 0
+    assert db.scalar(
+        select(func.count()).select_from(RuntimeResult).join(
+            Agent, Agent.id == RuntimeResult.agent_id
+        ).where(Agent.simulation_id == simulation_id)
+    ) == 0
+    assert {
+        state.agent_id: (state.hunger, state.fatigue, state.stress, state.satisfaction, state.mood)
+        for state in db.scalars(
+            select(AgentState).where(AgentState.simulation_id == simulation_id)
+        )
+    } == state_before

--- a/backend/tests/test_intent_conflict.py
+++ b/backend/tests/test_intent_conflict.py
@@ -1,0 +1,114 @@
+from uuid import UUID
+
+from app.simulation.agent_runtime import AgentRuntimeResult
+from app.simulation.intent_conflict import resolve_talk_conflicts
+from app.simulation.policy.engine import evaluate_policy
+from app.simulation.policy.models import AgentSnapshot, PolicyEvaluationInput
+
+
+A = UUID("00000000-0000-0000-0000-00000000000a")
+B = UUID("00000000-0000-0000-0000-00000000000b")
+C = UUID("00000000-0000-0000-0000-00000000000c")
+
+
+def talk(agent_id: UUID, target_id: UUID) -> AgentRuntimeResult:
+    return AgentRuntimeResult.model_validate(
+        {
+            "run_id": "talk-run",
+            "tick_number": 10,
+            "agent_id": agent_id,
+            "status": "PROPOSED",
+            "intent": {
+                "action_type": "TALK",
+                "target_agent_id": target_id,
+                "target_location_id": None,
+                "related_event_id": None,
+                "utterance": "대화하자.",
+                "motivation_summary": "대화 요청",
+                "reaction": {
+                    "valence": "POSITIVE",
+                    "relationship_signals": [
+                        {
+                            "signal_type": "TRUST_UP",
+                            "intensity": "LOW",
+                            "target_agent_id": target_id,
+                        }
+                    ],
+                    "state_signals": [],
+                },
+                "decision_explanation": {
+                    "alternatives": [
+                        {
+                            "action_type": "TALK",
+                            "description": "대화한다.",
+                            "relative_priority": "HIGH",
+                            "selected": True,
+                        }
+                    ],
+                    "influencing_factors": [],
+                },
+                "memory_candidates": [],
+            },
+            "retry_count": 0,
+            "failure_reason": None,
+            "model": "campaign",
+            "prompt_version": "test",
+            "idempotency_key": f"talk-run:10:{agent_id}",
+        }
+    )
+
+
+def test_mutual_talk_is_kept_and_third_party_becomes_wait_fallback() -> None:
+    resolution = resolve_talk_conflicts((talk(A, B), talk(B, A), talk(C, A)))
+
+    assert resolution.mutual_pairs == ((A, B),)
+    assert resolution.wait_fallback_agent_ids == (C,)
+    assert [result.intent.action_type for result in resolution.runtime_results] == [
+        "TALK",
+        "TALK",
+        "WAIT",
+    ]
+    fallback = resolution.runtime_results[2]
+    assert fallback.status == "FALLBACK"
+    assert fallback.failure_reason == "WAIT_FALLBACK"
+    assert fallback.intent.reaction.relationship_signals == []
+
+
+def test_wait_fallback_uses_wait_effect_without_talk_or_relationship_effect() -> None:
+    resolved = resolve_talk_conflicts((talk(A, B), talk(B, A), talk(C, A)))
+    evaluation = evaluate_policy(
+        PolicyEvaluationInput(
+            run_id="talk-run",
+            tick_number=10,
+            policy_version="policy-mvp-0.1",
+            agent_snapshots={
+                str(agent_id): AgentSnapshot(
+                    agent_id=str(agent_id),
+                    hunger=10,
+                    fatigue=10,
+                    stress=10,
+                    satisfaction=50,
+                )
+                for agent_id in (A, B, C)
+            },
+            relationship_snapshots=[],
+            runtime_results=list(resolved.runtime_results),
+            valid_agent_ids={str(A), str(B), str(C)},
+        )
+    )
+
+    c_effects = [
+        effect
+        for effect in evaluation.effect_candidates
+        if effect.source_agent_id == str(C)
+    ]
+    assert {(effect.metric, effect.delta, effect.rule_id) for effect in c_effects} == {
+        ("hunger", 2, "ACTION_WAIT"),
+        ("fatigue", 1, "ACTION_WAIT"),
+    }
+    assert not any(effect.target_agent_id is not None for effect in c_effects)
+
+
+def test_talk_resolution_is_deterministic() -> None:
+    inputs = (talk(A, B), talk(B, A), talk(C, A))
+    assert resolve_talk_conflicts(inputs) == resolve_talk_conflicts(inputs)

--- a/backend/tests/test_relationship_repository.py
+++ b/backend/tests/test_relationship_repository.py
@@ -131,6 +131,64 @@ def test_apply_deltas_flushes_without_committing(relationship_db) -> None:
         assert get_pair(session, source_agent_id, target_agent_id).trust == 20
 
 
+def test_friend_entry_is_directional_and_uses_final_numeric_values(
+    relationship_db,
+) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    with session_factory.begin() as session:
+        relationship = get_pair(session, source_agent_id, target_agent_id)
+        relationship.trust = 49
+        relationship.affection = 51
+        relationship.closeness = 50
+
+    delta = make_delta(
+        source_agent_id,
+        target_agent_id,
+        before=49,
+        requested_total=1,
+        applied_delta=1,
+        after=50,
+    )
+    with session_factory.begin() as session:
+        apply_deltas(session, [delta])
+
+    with session_factory() as session:
+        relationship = get_pair(session, source_agent_id, target_agent_id)
+        assert relationship.relationship_type == "friend"
+        assert get_pair(session, target_agent_id, source_agent_id) is None
+
+
+def test_friend_entry_rolls_back_with_relationship_delta(relationship_db) -> None:
+    session_factory, _, source_agent_id, target_agent_id = relationship_db
+    with session_factory.begin() as session:
+        relationship = get_pair(session, source_agent_id, target_agent_id)
+        relationship.trust = 49
+        relationship.affection = 50
+        relationship.closeness = 50
+
+    with session_factory() as session:
+        apply_deltas(
+            session,
+            [
+                make_delta(
+                    source_agent_id,
+                    target_agent_id,
+                    before=49,
+                    requested_total=1,
+                    applied_delta=1,
+                    after=50,
+                )
+            ],
+        )
+        assert get_pair(session, source_agent_id, target_agent_id).relationship_type == "friend"
+        session.rollback()
+
+    with session_factory() as session:
+        relationship = get_pair(session, source_agent_id, target_agent_id)
+        assert relationship.trust == 49
+        assert relationship.relationship_type is None
+
+
 def test_apply_deltas_accepts_negative_closeness(relationship_db) -> None:
     session_factory, _, source_agent_id, target_agent_id = relationship_db
     delta = make_delta(

--- a/backend/tests/test_simulation_events.py
+++ b/backend/tests/test_simulation_events.py
@@ -1,0 +1,56 @@
+from uuid import uuid4
+
+from app.services.simulation_events import build_tick_result_messages
+
+
+def test_persisted_tick_payload_uses_existing_task4_message_contract() -> None:
+    simulation_id = uuid4()
+    event_id = uuid4()
+    result = {
+        "tick_number": 10,
+        "block": "morning",
+        "events": [
+            {
+                "id": str(event_id),
+                "event_type": "MAGIC_EXPLOSION",
+                "participant_agent_ids": [str(uuid4())],
+            }
+        ],
+        "resolved_effects": [
+            {
+                "target_type": "AGENT_STATE",
+                "source_agent_id": str(uuid4()),
+                "metric": "stress",
+                "before": 10,
+                "applied_delta": 8,
+                "after": 18,
+            }
+        ],
+    }
+    relationship_effect = {
+        "source_agent_id": str(uuid4()),
+        "target_agent_id": str(uuid4()),
+        "metric": "trust",
+        "before": 1,
+        "applied_delta": 3,
+        "after": 4,
+    }
+
+    messages = build_tick_result_messages(
+        simulation_id,
+        result,
+        [relationship_effect],
+    )
+
+    assert [message["type"] for message in messages] == [
+        "TICK_UPDATED",
+        "EVENT_CREATED",
+        "RELATIONSHIP_UPDATED",
+    ]
+    assert all(
+        message["data"]["simulation_id"] == str(simulation_id)
+        and message["data"]["tick_number"] == 10
+        for message in messages
+    )
+    assert messages[0]["data"]["resolved_effects"] == result["resolved_effects"]
+    assert messages[1]["data"]["event_id"] == str(event_id)

--- a/backend/tests/test_slice1_e2e.py
+++ b/backend/tests/test_slice1_e2e.py
@@ -136,6 +136,10 @@ def test_slice_one_full_vertical_flow(client):
         stored = list(db.scalars(select(RuntimeResult).order_by(RuntimeResult.agent_id)))
         assert {fixtures_by_id[result.agent_id] for result in stored} == {
             "student-01",
+            "student-02",
+            "student-03",
+            "student-04",
+            "student-05",
             "professor-01",
         }
         run_ids = {result.run_id for result in stored}
@@ -157,7 +161,7 @@ def test_slice_one_full_vertical_flow(client):
             assert api_result["action_type"] == result.action_type
         simulation = db.get(Simulation, simulation_uuid)
         assert (simulation.current_tick, simulation.current_day) == (1, 1)
-        assert db.scalar(select(func.count()).select_from(RuntimeResult)) == 2
+        assert db.scalar(select(func.count()).select_from(RuntimeResult)) == 6
         states = list(
             db.scalars(select(AgentState).where(AgentState.agent_id.in_(participant_ids)))
         )
@@ -175,11 +179,12 @@ def test_slice_two_policy_applies_directional_relationship_delta(client, monkeyp
 
     def generate_relationship_signal(self, runtime_input):
         response = original_generate(self, runtime_input)
-        target_agent_id = next(
-            agent_id
-            for agent_id in runtime_input.events[0].participant_agent_ids
-            if agent_id != runtime_input.agent.agent_id
-        )
+        if (
+            runtime_input.agent.agent_id not in runtime_input.events[0].participant_agent_ids
+            or not runtime_input.nearby_agents
+        ):
+            return response
+        target_agent_id = runtime_input.nearby_agents[0].agent_id
         response["reaction"]["relationship_signals"] = [
             {
                 "signal_type": "TRUST_UP",
@@ -196,7 +201,7 @@ def test_slice_two_policy_applies_directional_relationship_delta(client, monkeyp
 
     assert response.status_code == 200, response.text
     deltas = response.json()["relationship_deltas"]
-    assert len(deltas) == 2
+    assert len(deltas) == 1
     assert {(delta["metric"], delta["delta"]) for delta in deltas} == {
         ("trust", 3)
     }
@@ -205,19 +210,17 @@ def test_slice_two_policy_applies_directional_relationship_delta(client, monkeyp
         agents = list(
             db.scalars(select(Agent).where(Agent.simulation_id == UUID(simulation_id)))
         )
-        participants = {
-            agent.id for agent in agents if agent.fixture_key in {"student-01", "professor-01"}
-        }
         relationships = list(db.scalars(select(Relationship)))
-        assert len(relationships) == 2
+        assert len(relationships) == 1
         assert {
             (relationship.source_agent_id, relationship.target_agent_id, relationship.trust)
             for relationship in relationships
         } == {
-            (source, target, 3)
-            for source in participants
-            for target in participants
-            if source != target
+            (
+                UUID(deltas[0]["source_agent_id"]),
+                UUID(deltas[0]["target_agent_id"]),
+                3,
+            )
         }
 
 
@@ -425,6 +428,10 @@ def test_tick_api_uses_engine_and_each_batch_boundary_once(client, monkeypatch):
     assert calls == {"engine": 1, "runtime_phase": 1, "save_batch": 1}
     assert {result["agent_name"] for result in response.json()["agent_results"]} == {
         "아델",
+        "레오",
+        "리아",
+        "카이",
+        "세라",
         "에단",
     }
 
@@ -455,7 +462,87 @@ def test_manual_tick_preserves_tick_engine_policy_extension(client):
         )
         db.commit()
 
-    assert len(received_policy_inputs) == len(result.runtime_results) == 2
+    assert len(received_policy_inputs) == len(result.runtime_results) == 6
     assert {item.agent_id for item in received_policy_inputs} == {
         str(runtime_result.agent_id) for runtime_result in result.runtime_results
     }
+
+
+class RecordingTickPublisher:
+    def __init__(self):
+        self.calls = []
+
+    async def publish(self, messages):
+        self.calls.append(messages)
+
+
+def test_tick_publishes_once_after_commit_and_matches_rest_result(client):
+    from app.main import app
+    from app.services.simulation_events import get_tick_result_publisher
+
+    test_client, _ = client
+    simulation_id, headers = register_login_create(test_client)
+    publisher = RecordingTickPublisher()
+    app.dependency_overrides[get_tick_result_publisher] = lambda: publisher
+
+    response = test_client.post(
+        f"/v1/simulations/{simulation_id}/ticks/advance", headers=headers
+    )
+    assert response.status_code == 200
+    assert len(publisher.calls) == 1
+
+    stored = test_client.get(
+        f"/v1/simulations/{simulation_id}/event-results/1",
+        headers=headers,
+    )
+    assert stored.status_code == 200
+    stored_payload = stored.json()
+    messages = publisher.calls[0]
+    tick_message = next(item for item in messages if item["type"] == "TICK_UPDATED")
+    event_messages = [item for item in messages if item["type"] == "EVENT_CREATED"]
+    assert tick_message["data"]["simulation_id"] == simulation_id
+    assert tick_message["data"]["tick_number"] == stored_payload["tick_number"]
+    assert tick_message["data"]["resolved_effects"] == stored_payload["resolved_effects"]
+    assert [
+        {
+            key: value
+            for key, value in item["data"].items()
+            if key not in {"simulation_id", "tick_number", "event_id"}
+        }
+        for item in event_messages
+    ] == stored_payload["events"]
+
+
+@pytest.mark.parametrize("failure_stage", ["persistence", "runtime_relationship"])
+def test_failed_tick_never_publishes(client, monkeypatch, failure_stage):
+    from app.main import app
+    from app.services import manual_tick
+    from app.services.simulation_events import get_tick_result_publisher
+
+    test_client, _ = client
+    simulation_id, headers = register_login_create(test_client)
+    publisher = RecordingTickPublisher()
+    app.dependency_overrides[get_tick_result_publisher] = lambda: publisher
+
+    if failure_stage == "persistence":
+        monkeypatch.setattr(
+            manual_tick,
+            "persist_event_batch",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("persistence failure")
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            manual_tick,
+            "evaluate_and_apply_policy",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("runtime relationship failure")
+            ),
+        )
+
+    response = test_client.post(
+        f"/v1/simulations/{simulation_id}/ticks/advance", headers=headers
+    )
+    assert response.status_code == 500
+    assert publisher.calls == []

--- a/backend/tests/test_slice2_policy_engine.py
+++ b/backend/tests/test_slice2_policy_engine.py
@@ -242,6 +242,7 @@ def test_invalid_relationship_signal_keeps_valid_effects():
     assert {(effect.metric, effect.target_agent_id) for effect in result.effect_candidates} == {
         ("trust", str(AGENT_B)),
         ("mood", None),
+        ("fatigue", None),
     }
     assert result.rejected_effects[0]["reason"] == "INVALID_RELATIONSHIP_TARGET"
 

--- a/backend/tests/test_slice5_tick10_campaign.py
+++ b/backend/tests/test_slice5_tick10_campaign.py
@@ -1,0 +1,62 @@
+import os
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from tests.slice5_campaign import run_canonical_campaign
+
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL,
+    reason="TEST_DATABASE_URL is required",
+)
+
+
+def run_once():
+    engine = create_engine(TEST_DATABASE_URL)
+    with engine.connect() as connection:
+        outer = connection.begin()
+        with Session(connection, join_transaction_mode="create_savepoint") as db:
+            result = run_canonical_campaign(db)
+        outer.rollback()
+    engine.dispose()
+    return result
+
+
+def test_canonical_tick10_campaign_covers_eight_production_scenarios() -> None:
+    campaign = run_once()
+    events = [event for tick in campaign for event in tick.events]
+
+    assert len(campaign) == 10
+    assert campaign[0].tick_number == 10
+    assert campaign[-1].tick_number == 19
+    assert any(event[0] == "CLASS" for event in events)
+    assert any(event[0] == "GROUP_PROJECT" for event in events)
+    assert any(event[0] == "MAGIC_EXPLOSION" for event in events)
+    assert any(event[0] == "STUDENT_MISSING" for event in events)
+    assert any(event[0] == "CURSE_SPREAD" for event in events)
+
+    tick10_actions = {item[0]: item[1:] for item in campaign[0].runtime_actions}
+    assert tick10_actions["student-01"][0] == "TALK"
+    assert tick10_actions["student-02"][0] == "TALK"
+    assert tick10_actions["student-03"] == (
+        "WAIT",
+        "FALLBACK",
+        "WAIT_FALLBACK",
+    )
+    assert campaign[0].relationship == (50, 50, 50, "friend")
+    assert any(tick.reflection_eligible_event_keys for tick in campaign)
+
+    statuses = {
+        tick.tick_number: {status[0]: status[1:] for status in tick.statuses}
+        for tick in campaign
+    }
+    assert statuses[10]["student-05"] == ("inactive_temporary", 13, None)
+    assert statuses[13]["student-05"] == ("active", None, 16)
+    assert statuses[16]["student-05"] == ("active", None, None)
+
+
+def test_canonical_tick10_campaign_is_semantically_deterministic_twice() -> None:
+    assert run_once() == run_once()


### PR DESCRIPTION
## 작업 개요
Slice 5의 Event Master·Magic·Policy·Resolver·Commit 흐름을 Tick 10 대표 캠페인으로 실제 production 경로에서 통합한다.

## 관련 Issue
Closes #105

## 변경 내용
- `manual_tick.py`: Task 1(Event Master·Magic) 산출물을 Task 3 `EventBatch` 계약으로 변환해 같은 Tick transaction에서 `persist_event_batch()`로 커밋. Runtime/Relationship/current_tick과 동일 transaction 경계 유지.
- `intent_conflict.py` (신규): A↔B 상호 TALK는 유지하고, 그 외 TALK는 canonical `WAIT` 효과만 적용하는 최소 Conflict Resolver 구현 (`docs/03-system-design/policy-signal-delta.md` §Action 기본 효과의 기존 WAIT_FALLBACK 원칙을 그대로 따름).
- `relationships.py`: relationship 숫자 delta 확정 이후 같은 transaction에서 `trust/affection/closeness >= 50` 조건으로 방향성 FRIEND 라벨 전이 (Issue #188 계약, rollback 시 원복 검증 포함).
- `event_magic_phase.py`: `importance >= 70` Reflection 적격 Event 식별 결과를 노출 (`docs/04-feature-specs/slice-5-integration.md` §6 기존 계약 재사용).
- `simulation_events.py` (신규): commit 성공 이후에만 발행되는 `TickResultPublisher` 계약. socket transport는 소유하지 않으며, 실제 WebSocket 연결은 develop의 PR #154(인증된 `/v1/ws/simulations/{id}`)에 후속 연결 예정.
- `ticks.py`: 위 publisher를 commit 이후 시점에 정확히 1회 호출하도록 연결.
- `slice5_campaign.py` (신규): Task 6에서 재사용 가능한 canonical Tick 10 대표 캠페인 fixture/helper. 테스트는 초기 Agent/relationship/schedule/seed만 구성하고, 결과는 실제 Tick → Event Master → Magic → Policy → Resolver → Commit 경로로 생성.

## 커버리지 (8개 시나리오, 모두 production 경로에서 재현)
1. 예정 Event(CLASS)
2. 동적 Event(GROUP_PROJECT)
3. 대표 Magic Event(MAGIC_EXPLOSION)
4. STUDENT_MISSING → 재활성화 → CURSED → 해제 전체 사이클
5. CURSE_SPREAD
6. mutual TALK + 제3자 → WAIT_FALLBACK
7. FRIEND 진입
8. Reflection 적격 Event(importance >= 70)

## 테스트 / 확인 내용
- 격리 PostgreSQL(pgvector) fresh migration으로 검증
- `pytest tests/test_slice5_tick10_campaign.py tests/test_intent_conflict.py tests/test_simulation_events.py`: 6 passed (8개 시나리오 커버리지 + determinism 2회 동일 결과 포함)
- `pytest tests/test_relationship_repository.py tests/test_slice2_policy_engine.py tests/test_event_magic_policy_integration.py tests/test_slice1_e2e.py`: 64 passed (post-commit publisher 성공 1회 발행 / 실패 0회 발행 / REST 재조회 payload 일치, rollback 시 relationship_type 포함 전체 원복 검증 포함)
- 전체 backend: `pytest tests/`: **358 passed**, 0 failed, 0 skipped(선재 실패 없음)
- Frontend: `npm test -- --run`: 45 passed / `npm run build`: 성공 (frontend 코드 변경 없음)

## AI 사용 여부
사용 여부: 사용함
사용한 작업: 이전 세션에서 중단된 구현 이어받아 완성, 테스트 실행 및 검증
사람이 검토한 내용: FRIEND/TALK/Reflection 계약이 기존 docs·Issue #188과 일치하는지, transaction 경계, rollback 검증