### PR TITLE
[Fix] Slice 5 acceptance blocker — Tick 커밋 후 publisher 실패가 REST 응답을 오염시킴

### DIFF
--- a/backend/app/api/ticks.py
+++ b/backend/app/api/ticks.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
@@ -18,6 +19,9 @@ from app.services.simulation_events import (
     get_tick_result_publisher,
 )
 from app.simulation.agent_runtime import AgentRuntime
+
+
+logger = logging.getLogger(__name__)
 
 
 class DecisionExplanationResponse(BaseModel):
@@ -125,13 +129,22 @@ async def advance_tick(
         for effect in result.policy_result.relationship_effects
         if effect.target_agent_id is not None
     ]
-    await publisher.publish(
-        build_tick_result_messages(
-            simulation.id,
-            result.event_batch_result,
-            relationship_deltas,
+    try:
+        await publisher.publish(
+            build_tick_result_messages(
+                simulation.id,
+                result.event_batch_result,
+                relationship_deltas,
+            )
         )
-    )
+    except Exception:
+        # WebSocket은 알림 채널일 뿐이다. Tick은 이미 commit되었으므로
+        # push 실패가 REST 응답을 오염시키지 않는다 (REST가 단일 진실 소스).
+        logger.exception(
+            "tick result publish failed after commit (simulation_id=%s, tick_number=%s)",
+            simulation.id,
+            result.current_tick,
+        )
 
     return TickAdvanceResponse(
         simulation_id=simulation.id,

--- a/backend/tests/test_slice1_e2e.py
+++ b/backend/tests/test_slice1_e2e.py
@@ -513,6 +513,35 @@ def test_tick_publishes_once_after_commit_and_matches_rest_result(client):
     ] == stored_payload["events"]
 
 
+class LossyTickPublisher:
+    async def publish(self, messages):
+        raise RuntimeError("WebSocket connection lost")
+
+
+def test_publish_failure_does_not_fail_rest_response_and_rest_stays_authoritative(client):
+    """WS는 알림 채널일 뿐이다. push 유실이 REST 응답/재조회 결과를 오염시키면 안 된다."""
+    from app.main import app
+    from app.services.simulation_events import get_tick_result_publisher
+
+    test_client, _ = client
+    simulation_id, headers = register_login_create(test_client)
+    app.dependency_overrides[get_tick_result_publisher] = lambda: LossyTickPublisher()
+
+    response = test_client.post(
+        f"/v1/simulations/{simulation_id}/ticks/advance", headers=headers
+    )
+    assert response.status_code == 200
+    advance_payload = response.json()
+    assert advance_payload["current_tick"] == 1
+
+    stored = test_client.get(
+        f"/v1/simulations/{simulation_id}/event-results/1",
+        headers=headers,
+    )
+    assert stored.status_code == 200
+    assert stored.json()["tick_number"] == 1
+
+
 @pytest.mark.parametrize("failure_stage", ["persistence", "runtime_relationship"])
 def test_failed_tick_never_publishes(client, monkeypatch, failure_stage):
     from app.main import app


### PR DESCRIPTION
## 작업 개요
Issue #106 E2E 검증(WS 유실 → REST 재조회) 과정에서 발견한 blocker를 최소 범위로 수정한다.

## 관련 Issue
Closes #197

## 문제
`POST /v1/simulations/{simulation_id}/ticks/advance`에서 `db.commit()` 성공 이후 `publisher.publish(...)`를 try/except 없이 호출했다. publish가 예외를 던지면 이미 성공적으로 commit된 Tick임에도 요청이 500으로 실패해 PR #91의 "REST·WS 단일 진실 소스 원칙"(push 유실 시 REST 결과를 항상 우선)에 위배됐다.

## 변경 내용
- `ticks.py`: publish 호출을 try/except로 감싸 실패를 로깅만 하고 흡수, `TickAdvanceResponse`는 정상 반환
- publisher 계약(`TickResultPublisher`, `build_tick_result_messages`) 자체는 변경 없음

## 테스트
- 신규: WS 유실 시에도 REST 응답 200 및 event-results 재조회가 정상 동작하는 회귀 테스트
- 전체 backend: `pytest tests/`: **359 passed**

## AI 사용 여부
사용 여부: 사용함
사용한 작업: #106 E2E 검증 중 발견한 버그 수정 및 테스트 작성
사람이 검토한 내용: PR #91의 REST·WS 단일 진실 소스 원칙과의 정합성