### PR TITLE
[Feature] Slice 7 Task 1A 설정 가져오기 transaction

### DIFF
--- a/backend/alembic/versions/20260827_0011_add_share_imports.py
+++ b/backend/alembic/versions/20260827_0011_add_share_imports.py
@@ -1,0 +1,37 @@
+"""add share import idempotency ledger
+
+Revision ID: 20260827_0011
+Revises: 20260826_0010
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20260827_0011"
+down_revision = "20260826_0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "share_imports",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("request_user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("idempotency_key", sa.String(200), nullable=False),
+        sa.Column("share_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("fingerprint", sa.String(64), nullable=False),
+        sa.Column("simulation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["request_user_id"], ["users.id"], ondelete="RESTRICT", onupdate="RESTRICT"),
+        sa.ForeignKeyConstraint(["share_id"], ["simulation_shares.id"], ondelete="RESTRICT", onupdate="RESTRICT"),
+        sa.ForeignKeyConstraint(["simulation_id"], ["simulations.id"], ondelete="RESTRICT", onupdate="RESTRICT"),
+        sa.UniqueConstraint("request_user_id", "idempotency_key", name="uq_share_imports_user_key"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("share_imports")

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -4,6 +4,7 @@ from app.api.agents import router as agents_router
 from app.api.auth import router as auth_router
 from app.api.events import router as events_router
 from app.api.simulation_history import router as simulation_history_router
+from app.api.simulation_imports import router as simulation_imports_router
 from app.api.simulation_shares import router as simulation_shares_router
 from app.api.simulations import router as simulations_router
 from app.api.ticks import router as ticks_router
@@ -17,6 +18,7 @@ api_router.include_router(agents_router)
 api_router.include_router(simulations_router)
 api_router.include_router(simulation_history_router)
 api_router.include_router(simulation_shares_router)
+api_router.include_router(simulation_imports_router)
 api_router.include_router(ticks_router)
 api_router.include_router(user_persona_router)
 api_router.include_router(websockets_router)

--- a/backend/app/api/simulation_imports.py
+++ b/backend/app/api/simulation_imports.py
@@ -1,0 +1,24 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header
+from sqlalchemy.orm import Session
+
+from app.api.schemas import SimulationResponse
+from app.api.slice7_errors import Slice7ErrorRoute
+from app.core.database import get_db
+from app.core.security import require_user_role
+from app.domain.models import User
+from app.services.simulation_imports import import_share
+
+router = APIRouter(tags=["simulation-imports"], route_class=Slice7ErrorRoute)
+
+
+@router.post("/shares/{share_id}/imports", response_model=SimulationResponse, status_code=201)
+def create_import(
+    share_id: UUID,
+    idempotency_key: str = Header(..., alias="Idempotency-Key", min_length=1, max_length=200),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> SimulationResponse:
+    simulation = import_share(db, current_user, share_id, idempotency_key)
+    return SimulationResponse.model_validate(simulation)

--- a/backend/app/api/simulation_shares.py
+++ b/backend/app/api/simulation_shares.py
@@ -1,10 +1,6 @@
-from collections.abc import Callable
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
-from fastapi.routing import APIRoute
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
@@ -13,60 +9,16 @@ from app.api.schemas import (
     SimulationShareDetailResponse,
     SimulationShareSummaryResponse,
 )
+from app.api.slice7_errors import Slice7ErrorRoute
 from app.core.database import get_db
 from app.core.security import get_current_user, require_user_role
 from app.domain.models import User
 from app.services.simulation_shares import (
-    ShareAccessDeniedError,
-    ShareNotFoundError,
-    SimulationNotReadyForShareError,
     cancel_simulation_share,
     create_simulation_share,
     get_public_simulation_shares,
     get_simulation_share_detail,
 )
-
-
-class Slice7APIError(Exception):
-    def __init__(self, status_code: int, code: str, message: str) -> None:
-        self.status_code = status_code
-        self.code = code
-        self.message = message
-
-
-def _error_response(status_code: int, code: str, message: str) -> JSONResponse:
-    return JSONResponse(status_code=status_code, content={"error": {"code": code, "message": message}})
-
-
-class Slice7ErrorRoute(APIRoute):
-    def get_route_handler(self) -> Callable:
-        original_handler = super().get_route_handler()
-
-        async def handler(request: Request):
-            try:
-                return await original_handler(request)
-            except Slice7APIError as exc:
-                return _error_response(exc.status_code, exc.code, exc.message)
-            except ShareNotFoundError as exc:
-                return _error_response(404, "SHARE_NOT_FOUND", str(exc))
-            except ShareAccessDeniedError as exc:
-                return _error_response(403, "SHARE_ACCESS_DENIED", str(exc))
-            except SimulationNotReadyForShareError as exc:
-                return _error_response(409, "SIMULATION_SHARE_NOT_READY", str(exc))
-            except RequestValidationError:
-                return _error_response(422, "INVALID_SHARE_REQUEST", "Invalid request")
-            except HTTPException as exc:
-                codes = {
-                    401: "AUTHENTICATION_REQUIRED",
-                    403: "SHARE_ACCESS_DENIED",
-                    404: "SHARE_NOT_FOUND",
-                }
-                return _error_response(
-                    exc.status_code, codes.get(exc.status_code, "INVALID_SHARE_REQUEST"), str(exc.detail)
-                )
-
-        return handler
-
 
 router = APIRouter(tags=["simulation-shares"], route_class=Slice7ErrorRoute)
 optional_bearer_scheme = HTTPBearer(auto_error=False)

--- a/backend/app/api/slice7_errors.py
+++ b/backend/app/api/slice7_errors.py
@@ -1,0 +1,81 @@
+from collections.abc import Callable
+
+from fastapi import HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
+
+from app.services.simulation_imports import (
+    ImportIdempotencyConflictError,
+    InvalidSharePayloadError,
+    ShareImportFailedError,
+    ShareNotFoundForImportError,
+    SharePersonaTargetInvalidError,
+    UnsupportedShareSchemaVersionError,
+)
+from app.services.simulation_shares import (
+    ShareAccessDeniedError,
+    ShareNotFoundError,
+    SimulationNotReadyForShareError,
+)
+
+
+class Slice7APIError(Exception):
+    def __init__(self, status_code: int, code: str, message: str) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+
+
+def _error_response(status_code: int, code: str, message: str) -> JSONResponse:
+    return JSONResponse(status_code=status_code, content={"error": {"code": code, "message": message}})
+
+
+class Slice7ErrorRoute(APIRoute):
+    """Shared canonical error mapping for every Slice 7 sharing/import route.
+
+    Maps the Slice 7 contract's error table
+    (docs/04-feature-specs/slice-7-config-sharing-import-deployment.md §5) to
+    responses, mirroring the Slice6ErrorRoute pattern already used by
+    app/api/simulation_history.py.
+    """
+
+    def get_route_handler(self) -> Callable:
+        original_handler = super().get_route_handler()
+
+        async def handler(request: Request):
+            try:
+                return await original_handler(request)
+            except Slice7APIError as exc:
+                return _error_response(exc.status_code, exc.code, exc.message)
+            except ShareNotFoundError as exc:
+                return _error_response(404, "SHARE_NOT_FOUND", str(exc))
+            except ShareNotFoundForImportError as exc:
+                return _error_response(404, "SHARE_NOT_FOUND", str(exc))
+            except ShareAccessDeniedError as exc:
+                return _error_response(403, "SHARE_ACCESS_DENIED", str(exc))
+            except SimulationNotReadyForShareError as exc:
+                return _error_response(409, "SIMULATION_SHARE_NOT_READY", str(exc))
+            except ImportIdempotencyConflictError as exc:
+                return _error_response(409, "IMPORT_IDEMPOTENCY_CONFLICT", str(exc))
+            except UnsupportedShareSchemaVersionError as exc:
+                return _error_response(422, "UNSUPPORTED_SHARE_SCHEMA_VERSION", str(exc))
+            except SharePersonaTargetInvalidError as exc:
+                return _error_response(422, "SHARE_PERSONA_TARGET_INVALID", str(exc))
+            except InvalidSharePayloadError as exc:
+                return _error_response(422, "INVALID_SHARE_PAYLOAD", str(exc))
+            except ShareImportFailedError as exc:
+                return _error_response(500, "SHARE_IMPORT_FAILED", str(exc))
+            except RequestValidationError:
+                return _error_response(422, "INVALID_SHARE_REQUEST", "Invalid request")
+            except HTTPException as exc:
+                codes = {
+                    401: "AUTHENTICATION_REQUIRED",
+                    403: "SHARE_ACCESS_DENIED",
+                    404: "SHARE_NOT_FOUND",
+                }
+                return _error_response(
+                    exc.status_code, codes.get(exc.status_code, "INVALID_SHARE_REQUEST"), str(exc.detail)
+                )
+
+        return handler

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -162,6 +162,32 @@ class SimulationShare(TimestampMixin, Base):
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
+class ShareImport(TimestampMixin, Base):
+    """Idempotency ledger and provenance record for Slice 7 imports.
+
+    Identity is `(request_user_id, idempotency_key)`; `fingerprint` is the
+    canonical `share_id` fingerprint the request must match on retry.
+    """
+
+    __tablename__ = "share_imports"
+    __table_args__ = (
+        UniqueConstraint("request_user_id", "idempotency_key", name="uq_share_imports_user_key"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    request_user_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False
+    )
+    idempotency_key: Mapped[str] = mapped_column(String(200), nullable=False)
+    share_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("simulation_shares.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False
+    )
+    fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    simulation_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"), nullable=False
+    )
+
+
 class Location(TimestampMixin, Base):
     __tablename__ = "locations"
     __table_args__ = (

--- a/backend/app/repositories/share_imports.py
+++ b/backend/app/repositories/share_imports.py
@@ -1,0 +1,15 @@
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.models import ShareImport
+
+
+def get_by_identity(db: Session, request_user_id: UUID, idempotency_key: str) -> ShareImport | None:
+    return db.scalar(
+        select(ShareImport).where(
+            ShareImport.request_user_id == request_user_id,
+            ShareImport.idempotency_key == idempotency_key,
+        )
+    )

--- a/backend/app/services/simulation_imports.py
+++ b/backend/app/services/simulation_imports.py
@@ -1,0 +1,420 @@
+import hashlib
+import json
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from uuid6 import uuid7
+
+from app.domain.models import (
+    Agent,
+    AgentState,
+    Location,
+    Organization,
+    OrganizationMembership,
+    ProfessorProfile,
+    Relationship,
+    ShareImport,
+    Simulation,
+    SimulationShare,
+    StudentProfile,
+    User,
+    UserPersonaConfig,
+)
+from app.repositories.share_imports import get_by_identity
+from app.repositories.simulation_shares import get_share_by_id
+from app.repositories.simulation_snapshots import SimulationConfigRepository, SimulationSnapshotRepository
+from app.services.simulation_shares import SCHEMA_VERSION
+from app.services.user_persona import RULE_VERSION
+
+REQUIRED_TOP_LEVEL_KEYS = (
+    "schema_version",
+    "simulation",
+    "locations",
+    "organizations",
+    "agents",
+    "relationships",
+    "organization_memberships",
+)
+REQUIRED_AGENT_KEYS = (
+    "fixture_key",
+    "fixture_version",
+    "agent_type",
+    "name",
+    "mbti_type",
+    "traits",
+    "role_profile",
+)
+REQUIRED_TRAIT_KEYS = (
+    "openness",
+    "conscientiousness",
+    "extraversion",
+    "agreeableness",
+    "emotional_stability",
+)
+REQUIRED_RELATIONSHIP_METRIC_KEYS = (
+    "affection",
+    "closeness",
+    "trust",
+    "tension",
+    "rivalry",
+    "dependency",
+)
+
+
+class ShareImportError(Exception):
+    pass
+
+
+class ShareNotFoundForImportError(ShareImportError):
+    pass
+
+
+class UnsupportedShareSchemaVersionError(ShareImportError):
+    pass
+
+
+class InvalidSharePayloadError(ShareImportError):
+    pass
+
+
+class SharePersonaTargetInvalidError(ShareImportError):
+    pass
+
+
+class ImportIdempotencyConflictError(ShareImportError):
+    pass
+
+
+class ShareImportFailedError(ShareImportError):
+    pass
+
+
+def compute_fingerprint(share_id: UUID) -> str:
+    canonical = json.dumps({"share_id": str(share_id)}, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _get_importable_share(db: Session, share_id: UUID, viewer: User) -> SimulationShare:
+    share = get_share_by_id(db, share_id)
+    if share is None or share.revoked_at is not None:
+        raise ShareNotFoundForImportError("Shared simulation not found")
+    is_owner = viewer.id == share.owner_id
+    if share.visibility == "private" and not is_owner:
+        raise ShareNotFoundForImportError("Shared simulation not found")
+    return share
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise InvalidSharePayloadError(message)
+
+
+def _validate_payload(payload: dict) -> None:
+    for key in REQUIRED_TOP_LEVEL_KEYS:
+        _require(key in payload, f"missing top-level field: {key}")
+
+    simulation = payload["simulation"]
+    _require(isinstance(simulation, dict), "simulation must be an object")
+    _require(bool(simulation.get("name")), "simulation.name is required")
+
+    locations = payload["locations"]
+    _require(isinstance(locations, list), "locations must be a list")
+    location_codes: set[str] = set()
+    for location in locations:
+        _require(bool(location.get("code")), "location.code is required")
+        _require(location["code"] not in location_codes, "duplicate location code")
+        location_codes.add(location["code"])
+
+    organizations = payload["organizations"]
+    _require(isinstance(organizations, list), "organizations must be a list")
+    organization_keys: set[str] = set()
+    for organization in organizations:
+        key = organization.get("fixture_key")
+        _require(bool(key), "organization.fixture_key is required")
+        _require(key not in organization_keys, "duplicate organization fixture_key")
+        organization_keys.add(key)
+
+    agents = payload["agents"]
+    _require(isinstance(agents, list) and len(agents) > 0, "agents must be a non-empty list")
+    agent_keys: set[str] = set()
+    for agent in agents:
+        for key in REQUIRED_AGENT_KEYS:
+            _require(key in agent, f"agent missing field: {key}")
+        _require(agent["fixture_key"] not in agent_keys, "duplicate agent fixture_key")
+        agent_keys.add(agent["fixture_key"])
+        _require(agent["agent_type"] in ("student", "professor"), "invalid agent_type")
+        traits = agent["traits"]
+        for trait_key in REQUIRED_TRAIT_KEYS:
+            _require(trait_key in traits, f"agent traits missing field: {trait_key}")
+        role = agent["role_profile"]
+        profile_type = role.get("profile_type")
+        if profile_type == "student":
+            _require("grade" in role and "interest_field" in role, "student role_profile incomplete")
+        elif profile_type == "professor":
+            _require("academic_rank" in role and "specialty" in role, "professor role_profile incomplete")
+        else:
+            raise InvalidSharePayloadError("unsupported role_profile.profile_type")
+        state = agent.get("state")
+        if state is not None:
+            location_code = state.get("location_code")
+            _require(
+                location_code is None or location_code in location_codes,
+                "agent state references unknown location_code",
+            )
+
+    for relationship in payload["relationships"]:
+        _require(
+            relationship.get("source_agent_fixture_key") in agent_keys,
+            "relationship references unknown source agent",
+        )
+        _require(
+            relationship.get("target_agent_fixture_key") in agent_keys,
+            "relationship references unknown target agent",
+        )
+        metrics = relationship.get("metrics", {})
+        for metric_key in REQUIRED_RELATIONSHIP_METRIC_KEYS:
+            _require(metric_key in metrics, f"relationship metrics missing field: {metric_key}")
+
+    for membership in payload["organization_memberships"]:
+        _require(
+            membership.get("organization_fixture_key") in organization_keys,
+            "membership references unknown organization",
+        )
+        _require(
+            membership.get("agent_fixture_key") in agent_keys,
+            "membership references unknown agent",
+        )
+
+    persona_key = simulation.get("user_persona_fixture_key")
+    if persona_key is not None and persona_key not in agent_keys:
+        raise SharePersonaTargetInvalidError("user_persona_fixture_key does not match any agent in roster")
+
+
+def _build_simulation(db: Session, owner: User, payload: dict) -> Simulation:
+    sim_data = payload["simulation"]
+    simulation = Simulation(
+        id=uuid7(),
+        owner_id=owner.id,
+        name=sim_data["name"],
+        magic_enabled=bool(sim_data.get("magic_enabled", True)),
+    )
+    db.add(simulation)
+    db.flush()
+
+    location_id_by_code: dict[str, UUID] = {}
+    for location_data in payload["locations"]:
+        location = Location(
+            id=uuid7(),
+            simulation_id=simulation.id,
+            code=location_data["code"],
+            name=location_data.get("name", location_data["code"]),
+            is_active=bool(location_data.get("is_active", True)),
+        )
+        db.add(location)
+        db.flush()
+        location_id_by_code[location_data["code"]] = location.id
+
+    organization_id_by_fixture: dict[str, UUID] = {}
+    for organization_data in payload["organizations"]:
+        organization = Organization(
+            id=uuid7(),
+            simulation_id=simulation.id,
+            organization_type=organization_data["organization_type"],
+            name=organization_data["name"],
+            description=organization_data.get("description"),
+            is_active=bool(organization_data.get("is_active", True)),
+        )
+        db.add(organization)
+        db.flush()
+        organization_id_by_fixture[organization_data["fixture_key"]] = organization.id
+
+    agent_id_by_fixture: dict[str, UUID] = {}
+    persona_agent_id: UUID | None = None
+    persona_fixture_key = sim_data.get("user_persona_fixture_key")
+    for agent_data in payload["agents"]:
+        traits = agent_data["traits"]
+        agent = Agent(
+            id=uuid7(),
+            simulation_id=simulation.id,
+            fixture_key=agent_data["fixture_key"],
+            fixture_version=agent_data["fixture_version"],
+            agent_type=agent_data["agent_type"],
+            name=agent_data["name"],
+            gender=agent_data.get("gender"),
+            personality_type=agent_data.get("personality_type"),
+            mbti_type=agent_data["mbti_type"],
+            openness=traits["openness"],
+            conscientiousness=traits["conscientiousness"],
+            extraversion=traits["extraversion"],
+            agreeableness=traits["agreeableness"],
+            emotional_stability=traits["emotional_stability"],
+        )
+        db.add(agent)
+        db.flush()
+        agent_id_by_fixture[agent_data["fixture_key"]] = agent.id
+
+        role = agent_data["role_profile"]
+        if role["profile_type"] == "student":
+            db.add(
+                StudentProfile(
+                    agent_id=agent.id, grade=role["grade"], interest_field=role["interest_field"]
+                )
+            )
+        else:
+            db.add(
+                ProfessorProfile(
+                    agent_id=agent.id, academic_rank=role["academic_rank"], specialty=role["specialty"]
+                )
+            )
+
+        state = agent_data.get("state")
+        if state is not None:
+            location_id = location_id_by_code.get(state.get("location_code"))
+            db.add(
+                AgentState(
+                    id=uuid7(),
+                    simulation_id=simulation.id,
+                    agent_id=agent.id,
+                    location_id=location_id,
+                    hunger=state["hunger"],
+                    fatigue=state["fatigue"],
+                    stress=state["stress"],
+                    satisfaction=state["satisfaction"],
+                    mood=state["mood"],
+                    current_action=state.get("current_action"),
+                )
+            )
+
+        if persona_fixture_key is not None and agent_data["fixture_key"] == persona_fixture_key:
+            persona_agent_id = agent.id
+
+    for membership_data in payload["organization_memberships"]:
+        db.add(
+            OrganizationMembership(
+                id=uuid7(),
+                simulation_id=simulation.id,
+                organization_id=organization_id_by_fixture[membership_data["organization_fixture_key"]],
+                agent_id=agent_id_by_fixture[membership_data["agent_fixture_key"]],
+                membership_role=membership_data.get("membership_role"),
+            )
+        )
+
+    for relationship_data in payload["relationships"]:
+        metrics = relationship_data["metrics"]
+        db.add(
+            Relationship(
+                id=uuid7(),
+                simulation_id=simulation.id,
+                source_agent_id=agent_id_by_fixture[relationship_data["source_agent_fixture_key"]],
+                target_agent_id=agent_id_by_fixture[relationship_data["target_agent_fixture_key"]],
+                affection=metrics["affection"],
+                closeness=metrics["closeness"],
+                trust=metrics["trust"],
+                tension=metrics["tension"],
+                rivalry=metrics["rivalry"],
+                dependency=metrics["dependency"],
+            )
+        )
+
+    db.flush()
+
+    config_repository = SimulationConfigRepository()
+    config = config_repository.create_version(
+        db,
+        simulation,
+        event_frequency="medium",
+        event_impact="medium",
+        magic_enabled=simulation.magic_enabled,
+        user_persona_settings={},
+        policy_version=sim_data.get("policy_version"),
+        resolver_version=sim_data.get("resolver_version"),
+    )
+
+    if persona_agent_id is not None:
+        persona_agent = db.get(Agent, persona_agent_id)
+        db.add(
+            UserPersonaConfig(
+                simulation_id=simulation.id,
+                agent_id=persona_agent_id,
+                mbti_type=persona_agent.mbti_type,
+                personality_rule_version=RULE_VERSION,
+                openness=persona_agent.openness,
+                conscientiousness=persona_agent.conscientiousness,
+                extraversion=persona_agent.extraversion,
+                agreeableness=persona_agent.agreeableness,
+                emotional_stability=persona_agent.emotional_stability,
+            )
+        )
+        db.flush()
+
+    SimulationSnapshotRepository().create(db, simulation, config)
+    db.flush()
+    return simulation
+
+
+def import_share(
+    db: Session,
+    request_user: User,
+    share_id: UUID,
+    idempotency_key: str,
+) -> Simulation:
+    """Create a new owned Simulation from a share's immutable Snapshot.
+
+    Never calls TickEngine, AgentRuntime, RuntimeOrchestrator or any LLM
+    client — import is a pure data-copy transaction.
+    """
+    fingerprint = compute_fingerprint(share_id)
+
+    existing = get_by_identity(db, request_user.id, idempotency_key)
+    if existing is not None:
+        if existing.fingerprint != fingerprint:
+            raise ImportIdempotencyConflictError(
+                "idempotency key already used for a different share"
+            )
+        simulation = db.get(Simulation, existing.simulation_id)
+        if simulation is None:
+            raise ShareImportFailedError("recorded import result is missing")
+        return simulation
+
+    share = _get_importable_share(db, share_id, request_user)
+    if share.export_schema_version != SCHEMA_VERSION:
+        raise UnsupportedShareSchemaVersionError(
+            f"unsupported schema_version: {share.export_schema_version}"
+        )
+    payload = share.export_payload
+    _validate_payload(payload)
+
+    try:
+        simulation = _build_simulation(db, request_user, payload)
+        db.add(
+            ShareImport(
+                id=uuid7(),
+                request_user_id=request_user.id,
+                idempotency_key=idempotency_key,
+                share_id=share_id,
+                fingerprint=fingerprint,
+                simulation_id=simulation.id,
+            )
+        )
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        winner = get_by_identity(db, request_user.id, idempotency_key)
+        if winner is None or winner.fingerprint != fingerprint:
+            raise ImportIdempotencyConflictError(
+                "concurrent import used this idempotency key for a different share"
+            ) from None
+        simulation = db.get(Simulation, winner.simulation_id)
+        if simulation is None:
+            raise ShareImportFailedError("recorded import result is missing") from None
+        return simulation
+    except ShareImportError:
+        db.rollback()
+        raise
+    except Exception as exc:
+        db.rollback()
+        raise ShareImportFailedError(str(exc)) from exc
+
+    db.refresh(simulation)
+    return simulation

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -16,6 +16,7 @@ class SchemaModelTests(unittest.TestCase):
                 "users",
                 "simulations",
                 "simulation_shares",
+                "share_imports",
                 "locations",
                 "agents",
                 "student_profiles",

--- a/backend/tests/test_simulation_imports.py
+++ b/backend/tests/test_simulation_imports.py
@@ -1,0 +1,474 @@
+import os
+import threading
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from uuid6 import uuid7
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+TABLES = (
+    "share_imports",
+    "simulation_shares",
+    "simulation_snapshots",
+    "simulation_configs",
+    "user_persona_configs",
+    "relationships",
+    "organization_memberships",
+    "organizations",
+    "agent_states",
+    "student_profiles",
+    "professor_profiles",
+    "agents",
+    "locations",
+    "simulations",
+    "users",
+)
+
+
+@pytest.fixture()
+def client():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(text(f"TRUNCATE {', '.join(TABLES)} RESTART IDENTITY CASCADE"))
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client, session_factory, engine
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client: TestClient, username: str) -> dict[str, str]:
+    password = "Slice0-password!"
+    register = client.post(
+        "/v1/auth/register",
+        json={"username": username, "display_name": username, "password": password},
+    )
+    assert register.status_code == 201
+    login = client.post("/v1/auth/login", json={"username": username, "password": password})
+    assert login.status_code == 200
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def create_simulation(client: TestClient, headers: dict[str, str], name: str = "Shared sim") -> str:
+    response = client.post("/v1/simulations", headers=headers, json={"name": name})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def create_share(
+    client: TestClient, headers: dict[str, str], simulation_id: str, visibility: str = "public"
+) -> dict:
+    response = client.post(
+        f"/v1/simulations/{simulation_id}/shares",
+        headers=headers,
+        json={"visibility": visibility, "title": "share", "description": None},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def import_share(
+    client: TestClient, headers: dict[str, str], share_id: str, idempotency_key: str
+):
+    return client.post(
+        f"/v1/shares/{share_id}/imports",
+        headers={**headers, "Idempotency-Key": idempotency_key},
+    )
+
+
+def _seed_org_and_relationship(session_factory, simulation_id: str) -> None:
+    with session_factory() as db:
+        agent_rows = db.execute(
+            text("SELECT id, fixture_key FROM agents WHERE simulation_id = :sid ORDER BY fixture_key"),
+            {"sid": simulation_id},
+        ).fetchall()
+        student_a_id, _ = agent_rows[0]
+        student_b_id, _ = agent_rows[1]
+        org_id = uuid7()
+        db.execute(
+            text(
+                "INSERT INTO organizations (id, simulation_id, organization_type, name, "
+                "description, is_active, created_at, updated_at) VALUES "
+                "(:id, :sid, 'club', 'Magic Club', 'desc', true, now(), now())"
+            ),
+            {"id": org_id, "sid": simulation_id},
+        )
+        db.execute(
+            text(
+                "INSERT INTO organization_memberships (id, simulation_id, organization_id, "
+                "agent_id, membership_role, joined_at, created_at, updated_at) VALUES "
+                "(:id, :sid, :org_id, :agent_id, 'member', now(), now(), now())"
+            ),
+            {"id": uuid7(), "sid": simulation_id, "org_id": org_id, "agent_id": student_a_id},
+        )
+        db.execute(
+            text(
+                "INSERT INTO relationships (id, simulation_id, source_agent_id, target_agent_id, "
+                "affection, closeness, trust, tension, rivalry, dependency, created_at, updated_at) "
+                "VALUES (:id, :sid, :src, :dst, 10, 5, 0, 0, 0, 0, now(), now())"
+            ),
+            {"id": uuid7(), "sid": simulation_id, "src": student_a_id, "dst": student_b_id},
+        )
+        db.commit()
+
+
+def test_import_creates_owned_simulation_with_full_roster(client) -> None:
+    from app.simulation.instrumentation import get_counts, reset_counters
+
+    test_client, session_factory, _ = client
+    owner_headers = register_and_login(test_client, "owner-imp")
+    importer_headers = register_and_login(test_client, "importer-imp")
+    simulation_id = create_simulation(test_client, owner_headers)
+    _seed_org_and_relationship(session_factory, simulation_id)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+
+    reset_counters()
+    response = import_share(test_client, importer_headers, share["id"], "key-1")
+    counts = get_counts()
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["current_tick"] == 0
+    new_simulation_id = body["id"]
+    assert new_simulation_id != simulation_id
+    assert counts == {"llm_calls": 0, "runtime_calls": 0, "tick_calls": 0}
+
+    with session_factory() as db:
+        owner_row = db.execute(
+            text("SELECT owner_id FROM simulations WHERE id = :id"), {"id": new_simulation_id}
+        ).fetchone()
+        importer_id = db.execute(
+            text("SELECT id FROM users WHERE username = 'importer-imp'")
+        ).scalar_one()
+        assert str(owner_row[0]) == str(importer_id)
+
+        agent_count = db.execute(
+            text("SELECT count(*) FROM agents WHERE simulation_id = :id"), {"id": new_simulation_id}
+        ).scalar_one()
+        assert agent_count == 6
+        student_count = db.execute(
+            text(
+                "SELECT count(*) FROM agents a JOIN student_profiles sp ON sp.agent_id = a.id "
+                "WHERE a.simulation_id = :id"
+            ),
+            {"id": new_simulation_id},
+        ).scalar_one()
+        assert student_count == 5
+        professor_count = db.execute(
+            text(
+                "SELECT count(*) FROM agents a JOIN professor_profiles pp ON pp.agent_id = a.id "
+                "WHERE a.simulation_id = :id"
+            ),
+            {"id": new_simulation_id},
+        ).scalar_one()
+        assert professor_count == 1
+        org_count = db.execute(
+            text("SELECT count(*) FROM organizations WHERE simulation_id = :id"),
+            {"id": new_simulation_id},
+        ).scalar_one()
+        assert org_count == 1
+        membership_count = db.execute(
+            text("SELECT count(*) FROM organization_memberships WHERE simulation_id = :id"),
+            {"id": new_simulation_id},
+        ).scalar_one()
+        assert membership_count == 1
+        relationship_count = db.execute(
+            text("SELECT count(*) FROM relationships WHERE simulation_id = :id"),
+            {"id": new_simulation_id},
+        ).scalar_one()
+        assert relationship_count == 1
+        snapshot_count = db.execute(
+            text("SELECT count(*) FROM simulation_snapshots WHERE simulation_id = :id"),
+            {"id": new_simulation_id},
+        ).scalar_one()
+        assert snapshot_count == 1
+
+
+def test_import_maps_user_persona_to_new_agent(client) -> None:
+    test_client, session_factory, _ = client
+    owner_headers = register_and_login(test_client, "owner-persona")
+    importer_headers = register_and_login(test_client, "importer-persona")
+    simulation_id = create_simulation(test_client, owner_headers)
+
+    with session_factory() as db:
+        student = db.execute(
+            text(
+                "SELECT id FROM agents WHERE simulation_id = :sid AND agent_type = 'student' "
+                "ORDER BY fixture_key LIMIT 1"
+            ),
+            {"sid": simulation_id},
+        ).scalar_one()
+        db.commit()
+    set_persona = test_client.post(
+        f"/v1/simulations/{simulation_id}/user-persona",
+        headers=owner_headers,
+        json={
+            "agent_id": str(student),
+            "mbti_type": "ISTJ",
+            "personality_rule_version": "mbti-big-five-v0.1",
+            "openness": -25,
+            "conscientiousness": 25,
+            "extraversion": -25,
+            "agreeableness": -20,
+            "emotional_stability": 0,
+        },
+    )
+    assert set_persona.status_code == 200, set_persona.text
+
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+    assert share["export_payload"]["simulation"]["user_persona_fixture_key"] is not None
+
+    response = import_share(test_client, importer_headers, share["id"], "key-persona")
+    assert response.status_code == 201
+    new_simulation_id = response.json()["id"]
+
+    with session_factory() as db:
+        persona_row = db.execute(
+            text("SELECT agent_id FROM user_persona_configs WHERE simulation_id = :id"),
+            {"id": new_simulation_id},
+        ).fetchone()
+        assert persona_row is not None
+        agent_type = db.execute(
+            text("SELECT agent_type FROM agents WHERE id = :id"), {"id": persona_row[0]}
+        ).scalar_one()
+        assert agent_type == "student"
+
+
+def test_import_rejects_private_share_for_non_owner(client) -> None:
+    test_client, _, _ = client
+    owner_headers = register_and_login(test_client, "owner-priv-imp")
+    importer_headers = register_and_login(test_client, "importer-priv-imp")
+    simulation_id = create_simulation(test_client, owner_headers)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="private")
+
+    response = import_share(test_client, importer_headers, share["id"], "key-priv")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "SHARE_NOT_FOUND"
+
+
+def test_import_owner_can_import_own_private_share(client) -> None:
+    test_client, _, _ = client
+    owner_headers = register_and_login(test_client, "owner-self-imp")
+    simulation_id = create_simulation(test_client, owner_headers)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="private")
+
+    response = import_share(test_client, owner_headers, share["id"], "key-self")
+    assert response.status_code == 201
+
+
+def test_import_rejects_revoked_share(client) -> None:
+    test_client, _, _ = client
+    owner_headers = register_and_login(test_client, "owner-revoked-imp")
+    importer_headers = register_and_login(test_client, "importer-revoked-imp")
+    simulation_id = create_simulation(test_client, owner_headers)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+    test_client.delete(f"/v1/shares/{share['id']}", headers=owner_headers)
+
+    response = import_share(test_client, importer_headers, share["id"], "key-revoked")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "SHARE_NOT_FOUND"
+
+
+def test_import_requires_idempotency_key_header(client) -> None:
+    test_client, _, _ = client
+    owner_headers = register_and_login(test_client, "owner-noheader")
+    simulation_id = create_simulation(test_client, owner_headers)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+
+    response = test_client.post(f"/v1/shares/{share['id']}/imports", headers=owner_headers)
+    assert response.status_code == 422
+
+
+def test_import_same_key_same_share_is_idempotent(client) -> None:
+    test_client, session_factory, _ = client
+    owner_headers = register_and_login(test_client, "owner-idem")
+    importer_headers = register_and_login(test_client, "importer-idem")
+    simulation_id = create_simulation(test_client, owner_headers)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+
+    first = import_share(test_client, importer_headers, share["id"], "same-key")
+    second = import_share(test_client, importer_headers, share["id"], "same-key")
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert first.json()["id"] == second.json()["id"]
+
+    with session_factory() as db:
+        importer_id = db.execute(
+            text("SELECT id FROM users WHERE username = 'importer-idem'")
+        ).scalar_one()
+        count = db.execute(
+            text("SELECT count(*) FROM simulations WHERE owner_id = :id"), {"id": importer_id}
+        ).scalar_one()
+        assert count == 1
+
+
+def test_import_same_key_different_share_is_conflict(client) -> None:
+    test_client, _, _ = client
+    owner_headers = register_and_login(test_client, "owner-conflict")
+    importer_headers = register_and_login(test_client, "importer-conflict")
+    sim_a = create_simulation(test_client, owner_headers, "A")
+    sim_b = create_simulation(test_client, owner_headers, "B")
+    share_a = create_share(test_client, owner_headers, sim_a, visibility="public")
+    share_b = create_share(test_client, owner_headers, sim_b, visibility="public")
+
+    first = import_share(test_client, importer_headers, share_a["id"], "shared-key")
+    assert first.status_code == 201
+
+    second = import_share(test_client, importer_headers, share_b["id"], "shared-key")
+    assert second.status_code == 409
+    assert second.json()["error"]["code"] == "IMPORT_IDEMPOTENCY_CONFLICT"
+
+
+def test_import_rollback_on_injected_failure_leaves_no_partial_state(client, monkeypatch) -> None:
+    test_client, session_factory, _ = client
+    owner_headers = register_and_login(test_client, "owner-rollback")
+    importer_headers = register_and_login(test_client, "importer-rollback")
+    simulation_id = create_simulation(test_client, owner_headers)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+
+    import app.services.simulation_imports as imports_module
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("injected failure")
+
+    monkeypatch.setattr(
+        imports_module.SimulationSnapshotRepository, "create", _boom
+    )
+
+    response = import_share(test_client, importer_headers, share["id"], "key-rollback")
+    assert response.status_code == 500
+    assert response.json()["error"]["code"] == "SHARE_IMPORT_FAILED"
+
+    with session_factory() as db:
+        importer_id = db.execute(
+            text("SELECT id FROM users WHERE username = 'importer-rollback'")
+        ).scalar_one()
+        sim_count = db.execute(
+            text("SELECT count(*) FROM simulations WHERE owner_id = :id"), {"id": importer_id}
+        ).scalar_one()
+        assert sim_count == 0
+        agent_count = db.execute(text("SELECT count(*) FROM agents")).scalar_one()
+        # only the original owner's 6 agents exist; nothing extra was created
+        assert agent_count == 6
+        idempotency_count = db.execute(text("SELECT count(*) FROM share_imports")).scalar_one()
+        assert idempotency_count == 0
+
+    # original untouched
+    with session_factory() as db:
+        original_status = db.execute(
+            text("SELECT status, current_tick FROM simulations WHERE id = :id"),
+            {"id": simulation_id},
+        ).fetchone()
+        assert original_status == ("ready", 0)
+
+
+def test_original_simulation_and_share_payload_are_immutable_after_import(client) -> None:
+    test_client, session_factory, _ = client
+    owner_headers = register_and_login(test_client, "owner-immutable-imp")
+    importer_headers = register_and_login(test_client, "importer-immutable-imp")
+    simulation_id = create_simulation(test_client, owner_headers, "Original name")
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+
+    before_payload = share["export_payload"]
+
+    import_share(test_client, importer_headers, share["id"], "key-immutable")
+
+    with session_factory() as db:
+        original = db.execute(
+            text("SELECT name, status, current_tick FROM simulations WHERE id = :id"),
+            {"id": simulation_id},
+        ).fetchone()
+        assert original == ("Original name", "ready", 0)
+
+    after_detail = test_client.get(f"/v1/shares/{share['id']}", headers=owner_headers).json()
+    assert after_detail["export_payload"] == before_payload
+
+
+def test_concurrent_imports_with_same_key_create_exactly_one_simulation(client) -> None:
+    test_client, session_factory, engine = client
+    owner_headers = register_and_login(test_client, "owner-race")
+    importer_headers = register_and_login(test_client, "importer-race")
+    simulation_id = create_simulation(test_client, owner_headers)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+
+    from app.core.security import authenticate_access_token
+    from app.domain.models import User
+    from app.services.simulation_imports import import_share as import_share_service
+    from uuid import UUID as PyUUID
+
+    importer_token = importer_headers["Authorization"].split(" ")[1]
+
+    results: list[object] = []
+    barrier = threading.Barrier(2)
+
+    def worker():
+        session_factory_local = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+        with session_factory_local() as db:
+            user = authenticate_access_token(db, importer_token)
+            barrier.wait()
+            try:
+                simulation = import_share_service(db, user, PyUUID(share["id"]), "race-key")
+                results.append(("ok", simulation.id))
+            except Exception as exc:  # noqa: BLE001
+                results.append(("error", exc))
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 2
+    ok_results = [r for r in results if r[0] == "ok"]
+    assert len(ok_results) == 2
+    assert ok_results[0][1] == ok_results[1][1]
+
+    with session_factory() as db:
+        importer_id = db.execute(
+            text("SELECT id FROM users WHERE username = 'importer-race'")
+        ).scalar_one()
+        count = db.execute(
+            text("SELECT count(*) FROM simulations WHERE owner_id = :id"), {"id": importer_id}
+        ).scalar_one()
+        assert count == 1
+
+
+def test_import_unsupported_schema_version_is_422(client) -> None:
+    test_client, session_factory, _ = client
+    owner_headers = register_and_login(test_client, "owner-schema")
+    importer_headers = register_and_login(test_client, "importer-schema")
+    simulation_id = create_simulation(test_client, owner_headers)
+    share = create_share(test_client, owner_headers, simulation_id, visibility="public")
+
+    with session_factory() as db:
+        db.execute(
+            text("UPDATE simulation_shares SET export_schema_version = 'legacy-v0' WHERE id = :id"),
+            {"id": share["id"]},
+        )
+        db.commit()
+
+    response = import_share(test_client, importer_headers, share["id"], "key-schema")
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "UNSUPPORTED_SHARE_SCHEMA_VERSION"
+
+
+def test_import_unknown_share_is_404(client) -> None:
+    test_client, _, _ = client
+    importer_headers = register_and_login(test_client, "importer-unknown")
+    response = import_share(test_client, importer_headers, str(uuid4()), "key-unknown")
+    assert response.status_code == 404


### PR DESCRIPTION
## 작업 개요

공유된 export payload를 검증하고 원본을 변경하지 않으면서 요청자 소유의 새 Simulation을 생성하는 import transaction을 구현합니다.

## 관련 Issue

Closes #144
Parent: #142
Decision: #143
공유 저장·CRUD·조회 API: #164 (PR #167)

## 변경 내용

- `POST /v1/shares/{share_id}/imports` (Idempotency-Key 필수, body 없음)
- 서버 저장 slice7-share-v1 payload만 사용, client 제출 payload 없음
- schema_version/필수 필드·참조 무결성/persona 매핑 검증 (422)
- private→소유자만, unlisted/public→누구나, 취소됨→404
- 새 Simulation 1개 생성: Location/Organization/Agent(Student 5·Professor 1)/Profile/AgentState/Relationship/OrganizationMembership/User Persona/SimulationConfig/Tick 0 Snapshot을 fixture_key 기준 재구성
- (request_user_id, idempotency_key) + share_id fingerprint 기준 idempotency, DB unique constraint로 동시 요청 exactly-once
- 전체 단일 transaction, 실패 시 전체 rollback (500 SHARE_IMPORT_FAILED)
- import 경로에서 Runtime/LLM/Tick 호출 0회 (instrumentation으로 검증)

## 테스트 / 확인 내용

- [x] Slice7 가져오기: 13 passed (동시성 테스트 포함)
- [x] backend 전체: 587 passed, skip 0
- [x] 격리 PostgreSQL fresh DB `alembic upgrade head` 단일 head
- [x] `git diff --check`

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: 계약 대조, transaction/idempotency/rollback 구현, 테스트 작성
- 사람이 검토한 내용: (self-review 예정)

## 리뷰어가 봐야 할 부분

- import 중 Runtime/LLM/Tick 호출이 정말 0회인지
- rollback이 새 Simulation과 모든 하위 데이터, idempotency 레코드까지 포함하는지
- 동시 요청에서도 정확히 1개만 생성되는지