### PR TITLE
[Feature] Slice 7 Task 2 — 공유 설정 검색·필터·가져오기 UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,8 @@ import { apiRequest } from "./api/client.js";
 import SettingsPanel from "./components/SettingsPanel.jsx";
 import ReplayPanel from "./components/ReplayPanel.jsx";
 import SnapshotPanel from "./components/SnapshotPanel.jsx";
+import SharingPanel from "./components/SharingPanel.jsx";
+import SharedBrowser from "./components/SharedBrowser.jsx";
 import RelationshipFlow from "./components/RelationshipFlow.jsx";
 import EventLogPanel from "./components/EventLogPanel.jsx";
 import UserPersonaSetup from "./components/UserPersonaSetup.jsx";
@@ -104,7 +106,9 @@ export default function App() {
   const [tickError, setTickError] = useState(null); // { type, message }
   const [sessionNotice, setSessionNotice] = useState("");
   const [authNotice, setAuthNotice] = useState("");
-  const [managementView, setManagementView] = useState(null); // null | "settings" | "replay" | "snapshot"
+  const [managementView, setManagementView] = useState(null); // null | "settings" | "replay" | "snapshot" | "sharing"
+  const [isImported, setIsImported] = useState(false); // 이 Simulation이 공유 설정을 가져와 생성됐는지
+  const [sharedBrowserOpen, setSharedBrowserOpen] = useState(false);
 
   const { connected, lastTick, eventLog, wsRelationshipDeltas } = useSimulationWS(
     simulation?.id,
@@ -124,11 +128,26 @@ export default function App() {
     setTickError(null);
     setAuthNotice(notice);
     setManagementView(null);
+    setIsImported(false);
+    setSharedBrowserOpen(false);
   }
 
   function handleEnroll(newSimulation) {
     setSimulationId(newSimulation.id);
     setSimulation(newSimulation);
+    setIsImported(false);
+    loadAgents(newSimulation.id);
+  }
+
+  // 공유 설정 가져오기 성공 시 호출된다. import는 요청자 소유의 새 Simulation을
+  // 정확히 하나 생성할 뿐 Runtime/LLM/Tick을 실행하지 않으므로, 응답으로 받은
+  // Simulation으로 그대로 이동한다(원본과는 무관한 새 Simulation).
+  function handleImported(newSimulation) {
+    setSimulationId(newSimulation.id);
+    setSimulation(newSimulation);
+    setIsImported(true);
+    setSharedBrowserOpen(false);
+    setManagementView(null);
     loadAgents(newSimulation.id);
   }
 
@@ -257,13 +276,28 @@ export default function App() {
               title={connected ? "실시간 연결됨" : "연결 끊김"}
             >●</span>
           )}
+          <button type="button" onClick={() => setSharedBrowserOpen(true)}>
+            공유 설정 둘러보기
+          </button>
           <div className="profile"><span>{auth.user.display_name}</span><small>@{auth.user.username}</small></div>
         </div>
       </header>
       <main>
+        {sharedBrowserOpen ? (
+          <SharedBrowser
+            token={auth.access_token}
+            onImported={handleImported}
+            onClose={() => setSharedBrowserOpen(false)}
+          />
+        ) : (
+        <>
         <section className="workspace">
             <div className="panel agent-list">
-              <h1>{simulation.name}</h1><p>Agent {agents.length}명</p>
+              <h1>
+                {simulation.name}
+                {isImported && <span className="imported-badge">가져온 Simulation</span>}
+              </h1>
+              <p>Agent {agents.length}명</p>
               {loading && <p className="message">Agent를 불러오는 중...</p>}
               {error && <p className="message error" role="alert">{error}</p>}
               {error && <button type="button" onClick={() => loadAgents(simulation.id)}>Agent 다시 불러오기</button>}
@@ -416,6 +450,13 @@ export default function App() {
                 >
                   Snapshot
                 </button>
+                <button
+                  type="button"
+                  aria-pressed={managementView === "sharing"}
+                  onClick={() => setManagementView("sharing")}
+                >
+                  공유
+                </button>
               </div>
 
               {managementView === "settings" && (
@@ -431,6 +472,13 @@ export default function App() {
               {managementView === "snapshot" && (
                 <SnapshotPanel token={auth.access_token} simulationId={simulation.id} />
               )}
+              {managementView === "sharing" && (
+                <SharingPanel
+                  token={auth.access_token}
+                  simulationId={simulation.id}
+                  simulationStatus={simulation.status}
+                />
+              )}
             </div>
 
             <div className="panel relationship-panel">
@@ -443,6 +491,8 @@ export default function App() {
             agentNames={agentNameById}
             onAgentSelect={handleEventAgentSelect}
           />
+        </>
+        )}
       </main>
     </div>
   );

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -81,6 +81,7 @@ function createFetchMock({ login, createSimulation, agents: agentsHandlers } = {
     if (url.endsWith('/agents')) return agentsHandler()
     if (url.includes('/user-persona/config')) return response({ data: personaConfigData })
     if (url.includes('/user-persona')) return response({}, 404) // 아직 미설정 (정상 상태)
+    if (url.includes('/v1/shares') && (!options.method || options.method === 'GET')) return response([])
     return response({}, 404)
   })
 }
@@ -423,5 +424,28 @@ describe('Slice 6 설정·Replay·Snapshot 진입점', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
 
     expect(await screen.findByText('이번 Tick에서 표시할 Agent 행동 결과가 없습니다.')).toBeInTheDocument()
+  })
+})
+
+describe('Slice 7 공유·가져오기 진입점', () => {
+  it('관리 탭에 공유 탭이 있고 SharingPanel로 전환된다', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+
+    await userEvent.click(screen.getByRole('button', { name: '공유' }))
+    expect(screen.getByRole('heading', { name: '설정 공유' })).toBeInTheDocument()
+  })
+
+  it('헤더의 공유 설정 둘러보기 버튼을 누르면 SharedBrowser가 열리고 닫을 수 있다', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+    await setupSimulationWithAgents(fetchMock)
+
+    await userEvent.click(screen.getByRole('button', { name: '공유 설정 둘러보기' }))
+    expect(await screen.findByRole('heading', { name: '공유 설정 둘러보기' })).toBeInTheDocument()
+    expect(await screen.findByText('공개된 공유 설정이 없습니다.')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: '닫기' }))
+    expect(screen.queryByRole('heading', { name: '공유 설정 둘러보기' })).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: simulation.name })).toBeInTheDocument()
   })
 })

--- a/frontend/src/api/sharing.js
+++ b/frontend/src/api/sharing.js
@@ -1,0 +1,66 @@
+// frontend/src/api/sharing.js
+//
+// Slice 7 설정 공유·가져오기 API 클라이언트.
+// 기준: docs/04-feature-specs/slice-7-config-sharing-import-deployment.md
+// 기존 client.js(apiRequest) 컨벤션을 그대로 따른다:
+//   - apiRequest(path, { token, method, body, headers })
+//   - 성공 응답 본문을 그대로 반환 (이 API는 {data} 래핑 없이 리소스를 직접 반환한다)
+//   - 실패 시 이미 status/code/message가 채워진 Error를 throw
+
+import { apiRequest } from "./client.js";
+
+/**
+ * 현재 Simulation을 공유한다. status=ready인 시작 전 Simulation만 가능하며
+ * 서버가 공유 시점의 불변 export payload(slice7-share-v1)를 직접 조립한다 —
+ * 클라이언트는 payload를 제출하지 않는다.
+ * POST /simulations/{simulation_id}/shares
+ */
+export async function createShare(token, simulationId, { visibility, title = "", description = null }) {
+  return apiRequest(`/v1/simulations/${simulationId}/shares`, {
+    token,
+    method: "POST",
+    body: JSON.stringify({ visibility, title, description }),
+  });
+}
+
+/**
+ * 공유를 취소한다(soft delete). 이후 외부 상세 조회·가져오기는 404가 된다.
+ * DELETE /shares/{share_id}
+ */
+export async function cancelShare(token, shareId) {
+  await apiRequest(`/v1/shares/${shareId}`, { token, method: "DELETE" });
+}
+
+/**
+ * 공개(public) 공유 목록/검색. 인증 없이도 조회 가능하다.
+ * GET /shares
+ */
+export async function listShares(token, { q, limit = 20, offset = 0 } = {}) {
+  const params = new URLSearchParams();
+  if (q) params.set("q", q);
+  params.set("limit", String(limit));
+  params.set("offset", String(offset));
+  return apiRequest(`/v1/shares?${params.toString()}`, { token });
+}
+
+/**
+ * 공유 상세 조회. public/unlisted는 누구나(정확한 id 필요), private는 소유자만.
+ * GET /shares/{share_id}
+ */
+export async function getShareDetail(token, shareId) {
+  return apiRequest(`/v1/shares/${shareId}`, { token });
+}
+
+/**
+ * 공유를 가져와 요청자 소유의 새 Simulation을 생성한다. body는 없으며
+ * Idempotency-Key header가 필수다. 같은 key로 같은 공유를 다시 요청하면
+ * 새 Simulation을 만들지 않고 기존 결과를 반환한다.
+ * POST /shares/{share_id}/imports
+ */
+export async function importShare(token, shareId, idempotencyKey) {
+  return apiRequest(`/v1/shares/${shareId}/imports`, {
+    token,
+    method: "POST",
+    headers: { "Idempotency-Key": idempotencyKey },
+  });
+}

--- a/frontend/src/components/SharedBrowser.jsx
+++ b/frontend/src/components/SharedBrowser.jsx
@@ -1,0 +1,189 @@
+// frontend/src/components/SharedBrowser.jsx
+//
+// 공유 설정 목록·검색·상세·가져오기.
+// - 목록/검색은 public 공유만 노출한다(private/unlisted는 서버가 애초에 반환하지 않는다).
+// - 상세는 정확한 share_id로 unlisted도 조회 가능하다(서버 접근 제어를 그대로 따른다).
+// - 가져오기는 POST /shares/{share_id}/imports (Idempotency-Key 필수, body 없음)만 호출하며,
+//   원본 payload를 클라이언트가 다시 제출하지 않는다.
+
+import { useEffect, useState } from "react";
+import { getShareDetail, importShare, listShares } from "../api/sharing.js";
+import ErrorMessage from "./ErrorMessage";
+
+function newIdempotencyKey() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
+  return `import-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function rosterSummary(payload) {
+  const agents = payload?.agents ?? [];
+  const studentCount = agents.filter((a) => a.role_profile?.profile_type === "student").length;
+  const professorCount = agents.filter((a) => a.role_profile?.profile_type === "professor").length;
+  return { studentCount, professorCount, organizationCount: payload?.organizations?.length ?? 0 };
+}
+
+export default function SharedBrowser({ token, onImported, onClose }) {
+  const [query, setQuery] = useState("");
+  const [shares, setShares] = useState([]);
+  const [listLoading, setListLoading] = useState(true);
+  const [listError, setListError] = useState(null);
+
+  const [selectedId, setSelectedId] = useState(null);
+  const [detail, setDetail] = useState(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState(null);
+
+  const [confirming, setConfirming] = useState(false);
+  const [importKey, setImportKey] = useState(null);
+  const [importLoading, setImportLoading] = useState(false);
+  const [importError, setImportError] = useState(null);
+
+  async function loadShares(q) {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const results = await listShares(token, { q });
+      setShares(results ?? []);
+    } catch (requestError) {
+      setListError(requestError);
+    } finally {
+      setListLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadShares();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleSearchSubmit(event) {
+    event.preventDefault();
+    loadShares(query);
+  }
+
+  async function handleSelect(shareId) {
+    setSelectedId(shareId);
+    setDetail(null);
+    setDetailError(null);
+    setConfirming(false);
+    setImportError(null);
+    setDetailLoading(true);
+    try {
+      const data = await getShareDetail(token, shareId);
+      setDetail(data);
+    } catch (requestError) {
+      setDetailError(requestError);
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  function startImport() {
+    setImportKey(newIdempotencyKey());
+    setImportError(null);
+    setConfirming(true);
+  }
+
+  async function confirmImport() {
+    setImportLoading(true);
+    setImportError(null);
+    try {
+      const simulation = await importShare(token, selectedId, importKey);
+      onImported?.(simulation);
+    } catch (requestError) {
+      setImportError(requestError);
+    } finally {
+      setImportLoading(false);
+    }
+  }
+
+  const summary = detail ? rosterSummary(detail.export_payload) : null;
+
+  return (
+    <section className="panel shared-browser" aria-labelledby="shared-browser-title">
+      <header className="shared-browser-header">
+        <h2 id="shared-browser-title">공유 설정 둘러보기</h2>
+        {onClose && (
+          <button type="button" onClick={onClose}>
+            닫기
+          </button>
+        )}
+      </header>
+
+      <form onSubmit={handleSearchSubmit}>
+        <label>
+          검색
+          <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="제목·설명 검색" />
+        </label>
+        <button disabled={listLoading}>{listLoading ? "검색 중..." : "검색"}</button>
+      </form>
+
+      {listLoading && <p className="message">공유 목록을 불러오는 중...</p>}
+      <ErrorMessage error={listError} />
+      {!listLoading && !listError && shares.length === 0 && (
+        <p className="message">공개된 공유 설정이 없습니다.</p>
+      )}
+
+      {!listLoading && !listError && shares.length > 0 && (
+        <ul className="shared-list">
+          {shares.map((item) => (
+            <li key={item.id}>
+              <button
+                type="button"
+                className={selectedId === item.id ? "shared-item active" : "shared-item"}
+                onClick={() => handleSelect(item.id)}
+              >
+                <b>{item.title || "(제목 없음)"}</b>
+                <span className="visibility-badge">{item.visibility}</span>
+                {item.description && <p>{item.description}</p>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {selectedId && (
+        <div className="shared-detail" aria-live="polite">
+          {detailLoading && <p className="message">공유 상세를 불러오는 중...</p>}
+          <ErrorMessage error={detailError} />
+
+          {detail && !detailLoading && !detailError && (
+            <div>
+              <h3>{detail.title || "(제목 없음)"}</h3>
+              {detail.description && <p>{detail.description}</p>}
+              {summary && (
+                <p>
+                  Student {summary.studentCount}명 · Professor {summary.professorCount}명 ·
+                  Organization {summary.organizationCount}개
+                </p>
+              )}
+
+              {!confirming && (
+                <button type="button" onClick={startImport}>
+                  이 설정 가져오기
+                </button>
+              )}
+
+              {confirming && (
+                <div role="alertdialog" aria-labelledby="import-confirm-title" className="import-confirm">
+                  <p id="import-confirm-title">
+                    이 공유 설정으로 새 Simulation을 만듭니다. 원본 Simulation은 변경되지 않습니다.
+                    계속할까요?
+                  </p>
+                  <button type="button" onClick={confirmImport} disabled={importLoading}>
+                    {importLoading ? "가져오는 중..." : "가져오기 확인"}
+                  </button>
+                  <button type="button" onClick={() => setConfirming(false)} disabled={importLoading}>
+                    취소
+                  </button>
+                </div>
+              )}
+
+              <ErrorMessage error={importError} />
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/SharedBrowser.test.jsx
+++ b/frontend/src/components/SharedBrowser.test.jsx
@@ -1,0 +1,115 @@
+// frontend/src/components/SharedBrowser.test.jsx
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SharedBrowser from "./SharedBrowser";
+import * as api from "../api/sharing.js";
+
+vi.mock("../api/sharing.js", () => ({
+  listShares: vi.fn(),
+  getShareDetail: vi.fn(),
+  importShare: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+const sampleShare = {
+  id: "share_01",
+  title: "마법 대학 표준 설정",
+  description: "6인 기본 구성",
+  visibility: "public",
+  export_schema_version: "slice7-share-v1",
+};
+
+const sampleDetail = {
+  ...sampleShare,
+  export_payload: {
+    agents: [
+      { role_profile: { profile_type: "student" } },
+      { role_profile: { profile_type: "student" } },
+      { role_profile: { profile_type: "professor" } },
+    ],
+    organizations: [{}],
+  },
+};
+
+describe("SharedBrowser", () => {
+  it("목록을 불러와 표시하고, 결과가 없으면 안내 메시지를 보여준다", async () => {
+    api.listShares.mockResolvedValue([]);
+
+    render(<SharedBrowser token="tok" />);
+
+    expect(await screen.findByText("공개된 공유 설정이 없습니다.")).toBeInTheDocument();
+  });
+
+  it("목록 항목을 선택하면 상세와 roster 요약을 보여준다", async () => {
+    api.listShares.mockResolvedValue([sampleShare]);
+    api.getShareDetail.mockResolvedValue(sampleDetail);
+
+    render(<SharedBrowser token="tok" />);
+    await screen.findByText("마법 대학 표준 설정");
+    fireEvent.click(screen.getByRole("button", { name: /마법 대학 표준 설정/ }));
+
+    expect(await screen.findByText(/Student 2명 · Professor 1명 · Organization 1개/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "이 설정 가져오기" })).toBeInTheDocument();
+  });
+
+  it("검색어를 제출하면 listShares에 q가 전달된다", async () => {
+    api.listShares.mockResolvedValue([]);
+    render(<SharedBrowser token="tok" />);
+    await screen.findByText("공개된 공유 설정이 없습니다.");
+
+    await userEvent.type(screen.getByLabelText("검색"), "마법");
+    fireEvent.click(screen.getByRole("button", { name: "검색" }));
+
+    expect(api.listShares).toHaveBeenLastCalledWith("tok", { q: "마법" });
+  });
+
+  it("가져오기를 확인하면 새 Simulation을 전달하며 onImported를 호출한다", async () => {
+    api.listShares.mockResolvedValue([sampleShare]);
+    api.getShareDetail.mockResolvedValue(sampleDetail);
+    api.importShare.mockResolvedValue({ id: "sim_new", name: "가져온 Simulation", status: "ready" });
+    const onImported = vi.fn();
+
+    render(<SharedBrowser token="tok" onImported={onImported} />);
+    await screen.findByText("마법 대학 표준 설정");
+    fireEvent.click(screen.getByRole("button", { name: /마법 대학 표준 설정/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "이 설정 가져오기" }));
+    fireEvent.click(screen.getByRole("button", { name: "가져오기 확인" }));
+
+    await vi.waitFor(() => expect(onImported).toHaveBeenCalledWith({
+      id: "sim_new",
+      name: "가져온 Simulation",
+      status: "ready",
+    }));
+    const [, , idempotencyKey] = api.importShare.mock.calls[0];
+    expect(typeof idempotencyKey).toBe("string");
+    expect(idempotencyKey.length).toBeGreaterThan(0);
+  });
+
+  it("가져오기 실패 시 오류를 표시하고 onImported를 호출하지 않는다", async () => {
+    api.listShares.mockResolvedValue([sampleShare]);
+    api.getShareDetail.mockResolvedValue(sampleDetail);
+    const error = new Error("공유를 찾을 수 없습니다.");
+    error.status = 404;
+    api.importShare.mockRejectedValue(error);
+    const onImported = vi.fn();
+
+    render(<SharedBrowser token="tok" onImported={onImported} />);
+    await screen.findByText("마법 대학 표준 설정");
+    fireEvent.click(screen.getByRole("button", { name: /마법 대학 표준 설정/ }));
+    fireEvent.click(await screen.findByRole("button", { name: "이 설정 가져오기" }));
+    fireEvent.click(screen.getByRole("button", { name: "가져오기 확인" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("공유를 찾을 수 없습니다.");
+    expect(onImported).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/SharingPanel.jsx
+++ b/frontend/src/components/SharingPanel.jsx
@@ -1,0 +1,110 @@
+// frontend/src/components/SharingPanel.jsx
+//
+// 현재 Simulation 설정 공유 생성·취소.
+// status=ready(시작 전)인 Simulation만 공유할 수 있다(Slice 7 계약).
+// 서버가 공유 시점의 불변 export payload를 직접 조립하므로 이 화면은
+// visibility/title/description만 입력받는다.
+
+import { useState } from "react";
+import { cancelShare, createShare } from "../api/sharing.js";
+import ErrorMessage from "./ErrorMessage";
+
+export default function SharingPanel({ token, simulationId, simulationStatus }) {
+  const isReady = (simulationStatus || "").toLowerCase() === "ready";
+
+  const [visibility, setVisibility] = useState("private");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [share, setShare] = useState(null);
+
+  const [cancelLoading, setCancelLoading] = useState(false);
+  const [cancelError, setCancelError] = useState(null);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await createShare(token, simulationId, { visibility, title, description });
+      setShare(result);
+      setCancelError(null);
+    } catch (requestError) {
+      setError(requestError);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCancel() {
+    setCancelLoading(true);
+    setCancelError(null);
+    try {
+      await cancelShare(token, share.id);
+      setShare(null);
+    } catch (requestError) {
+      setCancelError(requestError);
+    } finally {
+      setCancelLoading(false);
+    }
+  }
+
+  return (
+    <section className="panel sharing-panel" aria-labelledby="sharing-panel-title">
+      <h2 id="sharing-panel-title">설정 공유</h2>
+
+      {!isReady && (
+        <p className="message" role="status">
+          이 Simulation은 현재 상태({simulationStatus})에서 공유할 수 없습니다. 시작 전(ready)
+          상태의 Simulation만 공유할 수 있습니다.
+        </p>
+      )}
+
+      {isReady && !share && (
+        <form onSubmit={handleSubmit}>
+          <label>
+            공개 범위
+            <select value={visibility} onChange={(e) => setVisibility(e.target.value)}>
+              <option value="private">private (나만 보기)</option>
+              <option value="unlisted">unlisted (링크로만 접근)</option>
+              <option value="public">public (검색·목록 노출)</option>
+            </select>
+          </label>
+          <label>
+            제목
+            <input value={title} onChange={(e) => setTitle(e.target.value)} maxLength={200} />
+          </label>
+          <label>
+            설명
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={2000}
+            />
+          </label>
+          <button disabled={loading}>{loading ? "공유하는 중..." : "공유하기"}</button>
+        </form>
+      )}
+
+      <ErrorMessage error={error} />
+
+      {share && (
+        <div className="share-result" role="status">
+          <p className="message">
+            설정이 공유되었습니다. ({share.visibility})
+          </p>
+          <dl>
+            <dt>공유 ID</dt>
+            <dd>{share.id}</dd>
+          </dl>
+          <button type="button" onClick={handleCancel} disabled={cancelLoading}>
+            {cancelLoading ? "취소하는 중..." : "공유 취소"}
+          </button>
+          <ErrorMessage error={cancelError} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/SharingPanel.test.jsx
+++ b/frontend/src/components/SharingPanel.test.jsx
@@ -1,0 +1,75 @@
+// frontend/src/components/SharingPanel.test.jsx
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import SharingPanel from "./SharingPanel";
+import * as api from "../api/sharing.js";
+
+vi.mock("../api/sharing.js", () => ({
+  createShare: vi.fn(),
+  cancelShare: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+describe("SharingPanel", () => {
+  it("ready 상태가 아니면 공유 폼 대신 안내 메시지를 보여준다", () => {
+    render(<SharingPanel token="tok" simulationId="sim_01" simulationStatus="running" />);
+
+    expect(screen.getByText(/현재 상태\(running\)에서 공유할 수 없습니다/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "공유하기" })).not.toBeInTheDocument();
+  });
+
+  it("ready 상태에서 공유 생성에 성공하면 공유 ID와 취소 버튼을 보여준다", async () => {
+    api.createShare.mockResolvedValue({
+      id: "share_01",
+      visibility: "public",
+      export_schema_version: "slice7-share-v1",
+    });
+
+    render(<SharingPanel token="tok" simulationId="sim_01" simulationStatus="ready" />);
+    fireEvent.click(screen.getByRole("button", { name: "공유하기" }));
+
+    expect(await screen.findByText(/설정이 공유되었습니다/)).toBeInTheDocument();
+    expect(screen.getByText("share_01")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "공유 취소" })).toBeInTheDocument();
+    expect(api.createShare).toHaveBeenCalledWith("tok", "sim_01", {
+      visibility: "private",
+      title: "",
+      description: "",
+    });
+  });
+
+  it("실행 중 Simulation 공유 시 409 오류를 표시한다", async () => {
+    const error = new Error("이미 적용되었거나 Simulation이 시작되어 변경할 수 없습니다.");
+    error.status = 409;
+    error.code = "SIMULATION_SHARE_NOT_READY";
+    api.createShare.mockRejectedValue(error);
+
+    render(<SharingPanel token="tok" simulationId="sim_01" simulationStatus="ready" />);
+    fireEvent.click(screen.getByRole("button", { name: "공유하기" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/처리할 수 없습니다/);
+  });
+
+  it("공유 취소가 성공하면 다시 공유 폼을 보여준다", async () => {
+    api.createShare.mockResolvedValue({ id: "share_02", visibility: "private" });
+    api.cancelShare.mockResolvedValue(undefined);
+
+    render(<SharingPanel token="tok" simulationId="sim_01" simulationStatus="ready" />);
+    fireEvent.click(screen.getByRole("button", { name: "공유하기" }));
+    await screen.findByText(/설정이 공유되었습니다/);
+
+    fireEvent.click(screen.getByRole("button", { name: "공유 취소" }));
+
+    expect(await screen.findByRole("button", { name: "공유하기" })).toBeInTheDocument();
+    expect(api.cancelShare).toHaveBeenCalledWith("tok", "share_02");
+  });
+});


### PR DESCRIPTION
## 작업 개요

사용자가 공유 설정을 검색·필터하고 상세 내용을 확인한 뒤 새 Simulation으로 가져올 수 있는 UI를 구현합니다.

## 관련 Issue

Closes #145
Parent: #142
관련 Backend: #164(PR #167), #144(PR #200)

## 변경 내용

- `api/sharing.js`: createShare/cancelShare/listShares/getShareDetail/importShare — 실제 backend 경로/method/body/header와 일치
- `SharingPanel`: 현재 Simulation 공유 생성·취소 (관리 탭에 '공유' 탭 추가), ready 상태가 아니면 폼을 숨기고 안내만 표시
- `SharedBrowser`: 공개 공유 목록·검색·상세(roster 요약)·가져오기 확인 다이얼로그, 성공 시 새 Simulation으로 이동 (헤더 '공유 설정 둘러보기' 진입점)
- 가져오기 확인 시점에 Idempotency-Key를 1회 생성해 재시도까지 재사용
- 가져온 Simulation은 원본과 구분되도록 배지 표시
- loading/empty/401/403/404/409/422/500 상태를 기존 ErrorMessage로 공통 처리

## 테스트 / 확인 내용

- [x] SharingPanel: 4 passed
- [x] SharedBrowser: 5 passed
- [x] App 공유 진입점: 2 passed
- [x] frontend 전체: 86 passed
- [x] `npm run lint`: 기존 경고만(이번 변경분 0건)
- [x] `npm run build`: PASS
- [x] `git diff --check`

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: 계약/API 대조, 컴포넌트·테스트 작성
- 사람이 검토한 내용: (self-review 예정)

## 리뷰어가 봐야 할 부분

- 실제 backend API 계약(경로/헤더/에러 포맷)과 정확히 일치하는지
- private/unlisted 비노출이 서버 응답을 신뢰하는 구조로 충분한지
- 가져오기 확인 UX와 Idempotency-Key 재사용 타이밍