### PR TITLE
[Chore] Slice 7 Task 3 — Railway 배포 구성 준비 (실제 배포 제외)

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,7 @@
 [alembic]
 script_location = alembic
 prepend_sys_path = .
+path_separator = os
 sqlalchemy.url = postgresql+psycopg://postgres@localhost:5432/magic_academy
 
 [loggers]

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -3,16 +3,29 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.core.database import engine
+from app.core.migration_status import get_current_db_revisions, get_head_revisions
 
 router = APIRouter(tags=["health"])
 
 
 @router.get("/health")
 def health() -> dict[str, str]:
+    """Application, DB connectivity and migration-head readiness (contract §6.1).
+
+    Returns 503 until the DB is reachable *and* its applied Alembic
+    revision(s) match this deployment's migration heads, so a rolling
+    deploy is never marked ready before `alembic upgrade head` has
+    actually completed against it.
+    """
     try:
         with engine.connect() as connection:
             connection.execute(text("SELECT 1"))
+            current_revisions = get_current_db_revisions(connection)
     except SQLAlchemyError as exc:
         raise HTTPException(status_code=503, detail="Database unavailable") from exc
 
-    return {"status": "ok", "database": "ok"}
+    expected_revisions = get_head_revisions()
+    if current_revisions != expected_revisions:
+        raise HTTPException(status_code=503, detail="Database migrations are not up to date")
+
+    return {"status": "ok", "database": "ok", "migration": "ok"}

--- a/backend/app/core/logging_middleware.py
+++ b/backend/app/core/logging_middleware.py
@@ -1,0 +1,70 @@
+"""Structured one-line-JSON request logging (Slice 7 contract §6.2).
+
+Only the allow-listed fields below are ever logged. In particular this
+middleware never reads or logs: headers (Authorization/cookies included),
+query strings, request/response bodies, or path params other than the
+three explicitly allowed identifiers — so no JWT, password, API key,
+secret, prompt text or free-form user input can reach the log line.
+"""
+
+import json
+import logging
+import time
+import uuid
+from datetime import UTC, datetime
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from app.core.config import get_settings
+
+logger = logging.getLogger("magic_academy.request")
+
+# The only path-parameter names ever copied into a log line.
+ALLOWED_PATH_PARAM_KEYS = ("simulation_id", "share_id", "run_id", "tick_number")
+
+
+def _operation(request: Request) -> str:
+    route = request.scope.get("route")
+    path_template = getattr(route, "path", None) or request.url.path
+    return f"{request.method} {path_template}"
+
+
+class StructuredLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        settings = get_settings()
+        start = time.monotonic()
+        request_id = str(uuid.uuid4())
+        trace_id = request.headers.get("x-trace-id") or str(uuid.uuid4())
+        request.state.request_id = request_id
+        request.state.trace_id = trace_id
+
+        status_code = 500
+        error_code = None
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        except Exception:
+            error_code = "UNHANDLED_EXCEPTION"
+            raise
+        finally:
+            duration_ms = round((time.monotonic() - start) * 1000, 2)
+            record: dict[str, object] = {
+                "timestamp": datetime.now(UTC).isoformat(),
+                "level": "ERROR" if status_code >= 500 else "INFO",
+                "service": "magic-academy-backend",
+                "environment": settings.environment,
+                "trace_id": trace_id,
+                "request_id": request_id,
+                "operation": _operation(request),
+                "result": status_code,
+                "duration_ms": duration_ms,
+            }
+            if error_code:
+                record["error_code"] = error_code
+            path_params = dict(request.path_params)
+            for key in ALLOWED_PATH_PARAM_KEYS:
+                if key in path_params:
+                    record[key] = str(path_params[key])
+            logger.info(json.dumps(record, sort_keys=True))

--- a/backend/app/core/migration_status.py
+++ b/backend/app/core/migration_status.py
@@ -1,0 +1,30 @@
+"""Compare the DB's applied Alembic revision(s) against the repo's migration heads.
+
+Used by /health so a deployment is never reported ready before its own
+migrations have actually been applied (Slice 7 contract §6.1).
+"""
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def get_head_revisions() -> set[str]:
+    config = Config(str(BACKEND_ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(BACKEND_ROOT / "alembic"))
+    script = ScriptDirectory.from_config(config)
+    return set(script.get_heads())
+
+
+def get_current_db_revisions(connection: Connection) -> set[str]:
+    try:
+        rows = connection.execute(text("SELECT version_num FROM alembic_version")).fetchall()
+    except Exception:
+        # alembic_version does not exist yet — migrations have never run.
+        return set()
+    return {row[0] for row in rows}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api.health import router as health_router
 from app.api.router import api_router
 from app.core.config import get_settings
+from app.core.logging_middleware import StructuredLoggingMiddleware
 
 settings = get_settings()
 
@@ -12,6 +13,8 @@ app = FastAPI(
     version=settings.app_version,
     debug=settings.debug,
 )
+
+app.add_middleware(StructuredLoggingMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,0 +1,24 @@
+# Railway service config for the backend (FastAPI + PostgreSQL/pgvector).
+#
+# Root Directory for this Railway service must be set to `backend/` so this
+# file and ./Dockerfile are used. Required Railway service Variables (set via
+# the Railway dashboard, never committed here):
+#   DATABASE_URL (or DB_HOST/POSTGRES_*), JWT_SECRET, CORS_ORIGINS
+#   (the deployed frontend's public URL), ANTHROPIC_API_KEY/OPENAI_API_KEY
+#   as applicable, ENVIRONMENT=production.
+#
+# Migrations run once, before the app starts serving traffic — if
+# `alembic upgrade head` fails, the deploy fails and the previous version
+# keeps serving (fail-closed; see docs/04-feature-specs/
+# slice-7-config-sharing-import-deployment.md §6.1).
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"
+healthcheckPath = "/health"
+healthcheckTimeout = 100
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/backend/tests/test_health_and_logging.py
+++ b/backend/tests/test_health_and_logging.py
@@ -1,0 +1,95 @@
+"""Slice 7 Task 3 — /health migration readiness and structured request logging.
+
+기준: docs/04-feature-specs/slice-7-config-sharing-import-deployment.md §6
+"""
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def client():
+    from app.main import app
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_health_reports_ok_when_migrations_are_up_to_date(client) -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {"status": "ok", "database": "ok", "migration": "ok"}
+
+
+def test_health_returns_503_when_db_revision_is_stale(client) -> None:
+    engine = create_engine(TEST_DATABASE_URL)
+    with engine.begin() as connection:
+        original = connection.execute(text("SELECT version_num FROM alembic_version")).fetchall()
+        connection.execute(text("DELETE FROM alembic_version"))
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES ('stale-revision')")
+        )
+    try:
+        response = client.get("/health")
+        assert response.status_code == 503
+    finally:
+        with engine.begin() as connection:
+            connection.execute(text("DELETE FROM alembic_version"))
+            for row in original:
+                connection.execute(
+                    text("INSERT INTO alembic_version (version_num) VALUES (:v)"),
+                    {"v": row[0]},
+                )
+
+
+def test_structured_request_log_has_required_fields_and_no_secrets(client, caplog) -> None:
+    import logging
+
+    caplog.set_level(logging.INFO, logger="magic_academy.request")
+    response = client.get("/health", headers={"Authorization": "Bearer super-secret-token"})
+    assert response.status_code == 200
+
+    records = [r for r in caplog.records if r.name == "magic_academy.request"]
+    assert len(records) == 1
+    payload = json.loads(records[0].message)
+
+    for field in (
+        "timestamp",
+        "level",
+        "service",
+        "environment",
+        "trace_id",
+        "request_id",
+        "operation",
+        "result",
+        "duration_ms",
+    ):
+        assert field in payload
+
+    assert payload["operation"] == "GET /health"
+    assert payload["result"] == 200
+
+    serialized = json.dumps(payload)
+    assert "super-secret-token" not in serialized
+    assert "authorization" not in serialized.lower()
+    assert "bearer" not in serialized.lower()
+
+
+def test_structured_request_log_includes_allowed_path_params(client, caplog) -> None:
+    import logging
+
+    caplog.set_level(logging.INFO, logger="magic_academy.request")
+    client.get("/v1/shares/00000000-0000-0000-0000-000000000000")
+
+    records = [r for r in caplog.records if r.name == "magic_academy.request"]
+    payload = json.loads(records[-1].message)
+    assert payload["operation"] == "GET /shares/{share_id}"
+    assert payload["share_id"] == "00000000-0000-0000-0000-000000000000"

--- a/docs/04-feature-specs/slice-7-railway-deployment.md
+++ b/docs/04-feature-specs/slice-7-railway-deployment.md
@@ -1,0 +1,126 @@
+---
+title: Slice 7 — Railway 배포 런북
+status: draft
+updated: 2026-08-27
+source:
+  - "GitHub Issue #146"
+  - "docs/04-feature-specs/slice-7-config-sharing-import-deployment.md §6"
+  - "docs/03-system-design/infra.md §3"
+---
+
+# Slice 7 — Railway 배포 런북
+
+> 이 문서는 Task 3(#146)의 배포 구성·절차를 기록한다. 실제 `railway login`/배포
+> 실행은 이 세션에서 완료할 수 없었다(아래 "현재 상태" 참고). 배포 없이 준비
+> 가능한 코드/설정은 모두 완료했다.
+
+## 1. 현재 상태 — BLOCKED
+
+이 세션에는 Railway CLI 인증 수단이 전혀 없다.
+
+- `npx @railway/cli whoami` → `Unauthorized. Please login with 'railway login'`
+- `RAILWAY_TOKEN` 등 관련 환경변수 없음
+- Repository에 Railway GitHub App 연동 없음(webhook은 Discord만 존재)
+- Repository Actions secrets 없음
+
+`railway login`은 브라우저 기반 OAuth 상호작용이 필요해 자율 Agent가 완료할 수
+없다. 기존 Railway project가 있다면 사람이 다음 중 하나를 제공해야 재개할 수
+있다.
+
+1. 이 머신에서 `railway login` 실행(대화형), 또는
+2. `RAILWAY_TOKEN`(프로젝트 토큰) 환경변수 제공
+
+기존 Railway project가 전혀 없다면 새 프로젝트 생성이 필요한데, 이는 과금
+발생 가능성이 있는 새 리소스 생성이라 임의로 진행하지 않는다.
+
+## 2. 서비스 구성
+
+Root Directory 기준으로 Railway 서비스 3개를 구성한다(모두 GitHub 연동 자동
+배포 권장, `docs/03-system-design/infra.md` §3 결론과 동일):
+
+| 서비스 | Root Directory | 비고 |
+| --- | --- | --- |
+| PostgreSQL | (Railway 제공 Managed DB) | pgvector 지원 필요 — Railway의 PostgreSQL 템플릿이 아니라 `pgvector/pgvector` 호환 이미지 확인 필요. 미지원 시 Railway의 Docker Image 서비스로 `pgvector/pgvector:0.8.5-pg16`을 직접 배포 |
+| backend | `backend/` | `backend/railway.toml` + `backend/Dockerfile` 사용 |
+| frontend | `frontend/` | `frontend/railway.toml` + `frontend/Dockerfile` 사용 |
+
+### 2.1 backend 필수 Variables
+
+| 이름 | 값 |
+| --- | --- |
+| `DATABASE_URL` | Railway PostgreSQL의 연결 문자열(`postgresql+psycopg://` 접두어로 변환됨, `app/core/config.py` 참고) |
+| `JWT_SECRET` | 32자 이상 랜덤 값(새로 생성 금지 지시에 따라 기존 값이 있으면 재사용, 없으면 사람이 생성) |
+| `CORS_ORIGINS` | 배포된 frontend 공개 URL 정확히 지정(와일드카드 금지, §6.1) |
+| `ENVIRONMENT` | `production` |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` | 실제 사용 중인 provider만, 존재 여부만 확인하고 값은 노출하지 않는다 |
+
+### 2.2 frontend 필수 Variables (빌드 타임에 필요)
+
+| 이름 | 값 |
+| --- | --- |
+| `VITE_API_URL` | 배포된 backend 공개 URL |
+| `VITE_WS_URL` | 배포된 backend의 WebSocket URL(`wss://` 스킴) |
+
+Vite는 `import.meta.env.VITE_*`를 빌드 시점에 정적으로 inline하므로, 이 값들은
+런타임이 아니라 **빌드 이전**에 Railway Variables로 설정돼 있어야 한다.
+
+## 3. 시작 커맨드 (로컬 검증 완료)
+
+- backend: `alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}`
+  (`backend/railway.toml`) — 격리 PostgreSQL로 로컬에서 기동·`/health` 200 확인함.
+- frontend: `npm run build && npm run preview -- --host 0.0.0.0 --port ${PORT:-4173}`
+  (`frontend/railway.toml`) — 로컬에서 기동 확인, 임의 Host 헤더로도 200 확인함
+  (`vite.config.js`의 `preview.allowedHosts = true`).
+
+migration 실패 시 `alembic upgrade head`가 0이 아닌 코드로 종료되어 `&&` 뒤의
+uvicorn이 시작되지 않으므로, 실패한 버전은 트래픽을 받지 못한다(fail-closed).
+
+## 4. `/health` 계약
+
+`GET /health`는 다음을 모두 만족해야 200을 반환한다(`backend/app/api/health.py`).
+
+1. 애플리케이션이 요청을 처리할 수 있다.
+2. DB에 연결할 수 있다(`SELECT 1`).
+3. DB에 적용된 Alembic revision이 이 배포의 migration head와 정확히 일치한다
+   (`backend/app/core/migration_status.py`).
+
+셋 중 하나라도 실패하면 503을 반환한다. Railway healthcheckPath로 지정되어
+있어(§3의 `backend/railway.toml`), migration이 끝나기 전이나 실패한 배포는
+Railway가 트래픽을 넘기지 않는다.
+
+## 5. 구조화 로그
+
+모든 요청이 한 줄 JSON으로 로그에 남는다
+(`backend/app/core/logging_middleware.py`). 필드: `timestamp`, `level`,
+`service`, `environment`, `trace_id`, `request_id`, `operation`, `result`,
+`duration_ms`, 그리고 경로에 존재할 때만 `simulation_id`/`share_id`/`run_id`/
+`tick_number`.
+
+절대 로그에 남기지 않는 값(코드로 보장, 헤더/바디를 아예 읽지 않음):
+Authorization/JWT/cookie/API key/Secret, 요청·응답 본문 전체, Prompt/Chain of
+Thought.
+
+## 6. 배포 Golden Path (Railway 접근 가능해진 뒤 수행)
+
+1. `railway login` 또는 `RAILWAY_TOKEN` 설정 확인 (`railway whoami`)
+2. 기존 project 확인(`railway status` 또는 dashboard) — 없으면 STOP하고 사용자에게
+   보고(새 프로젝트 생성은 과금 가능성이 있어 임의 진행 금지)
+3. 위 Variables가 3개 서비스에 설정돼 있는지 확인
+4. backend 배포 → `/health` 200 확인 → 로그에서 구조화 JSON 한 줄 확인
+5. frontend 배포 → 루트 페이지 200 확인
+6. 인증된 상태로 Simulation 생성 → 공유 생성(public) → 목록/검색에서 발견 →
+   상세 조회 → 가져오기(Idempotency-Key 포함) → 새 Simulation 확인
+7. 가져오기 중 Runtime/LLM/Tick 호출 0회 확인(§4의 instrumentation 카운터는
+   프로덕션에 없으므로, 로그의 `operation`이 import 경로 이외의 Tick/Runtime
+   엔드포인트를 호출하지 않았는지로 대체 확인)
+8. WebSocket AUTH handshake 확인(`wss://<backend>/ws/simulations/{id}`)
+
+## 7. 장애 확인 절차
+
+- `/health` 503 → backend 로그에서 `"operation": "GET /health"` 라인의
+  `result`/직전 예외 확인. DB 연결 문제인지 migration 불일치인지 구분.
+- migration 실패 → Railway backend 서비스의 최신 배포 로그에서
+  `alembic upgrade head`의 표준 출력 확인(fail-closed이므로 이전 정상 버전이
+  계속 서비스 중이어야 한다).
+- CORS 오류 → `CORS_ORIGINS`가 frontend의 실제 공개 URL과 정확히 일치하는지
+  확인(트레일링 슬래시 등 사소한 불일치도 실패 원인이 될 수 있음).

--- a/frontend/railway.toml
+++ b/frontend/railway.toml
@@ -1,0 +1,21 @@
+# Railway service config for the frontend (React + Vite).
+#
+# Root Directory for this Railway service must be set to `frontend/` so this
+# file and ./Dockerfile are used. VITE_API_URL and VITE_WS_URL are baked in
+# at BUILD time (Vite inlines `import.meta.env.VITE_*`), so they must be set
+# as Railway service Variables pointing at the deployed backend's public
+# URL(s) before the build step runs — Railway exposes service Variables to
+# both build and runtime by default.
+#
+# The Dockerfile's default CMD runs the Vite dev server, which is not meant
+# for production; this overrides it to build once and serve the static
+# output.
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "npm run build && npm run preview -- --host 0.0.0.0 --port ${PORT:-4173}"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,13 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  preview: {
+    // Railway (and most PaaS) serve the app behind a dynamic/custom domain,
+    // not localhost — Vite's preview server otherwise rejects unknown Host
+    // headers.
+    host: true,
+    allowedHosts: true,
+  },
   test: {
     environment: 'jsdom',
     setupFiles: './src/test/setup.js',


### PR DESCRIPTION
## 작업 개요

Railway 배포에 필요한 코드/설정/문서를 준비합니다. **실제 `railway login`/배포 실행은 이 PR 범위에 포함되지 않습니다** — 아래 '현재 상태' 참고.

## 관련 Issue

Part of #146 (실제 배포 전까지 close하지 않음)
Parent: #142

## 변경 내용

- `/health`가 DB 연결뿐 아니라 적용된 Alembic revision이 migration head와 일치하는지까지 확인 (불일치 시 503)
- 요청당 구조화 JSON 로그 미들웨어 (필수 필드 포함, 헤더·바디 미접근으로 민감정보 원천 차단)
- `backend/railway.toml`, `frontend/railway.toml`: migration 선행 기동, production 시작 커맨드
- `vite.config.js`: `preview.allowedHosts`로 PaaS 동적 도메인 대응
- `docs/04-feature-specs/slice-7-railway-deployment.md`: 배포 런북, Golden Path, 장애 확인 절차, BLOCKED 상태 기록

## 현재 상태 — Railway 실제 배포 BLOCKED

- `npx @railway/cli whoami` → Unauthorized (login 필요, 브라우저 상호작용 필수)
- `RAILWAY_TOKEN` 등 관련 환경변수 없음
- repository에 Railway GitHub App 연동 없음, Actions secrets 없음
- 기존 Railway project를 사용할 방법이 이 세션에는 없음 — 새 유료 project 임의 생성은 금지 지시에 따라 시도하지 않음

## 테스트 / 확인 내용

- [x] /health·구조화 로그: 4 passed
- [x] backend 전체: 597 passed, skip 0
- [x] frontend 전체: 86 passed
- [x] production build PASS
- [x] 두 startCommand(backend: migration+uvicorn, frontend: build+preview) 로컬 기동 확인
- [x] `git diff --check`

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: 배포 구성 설계, migration/logging 구현, 로컬 검증
- 사람이 검토한 내용: (self-review 예정) — 실제 Railway 배포 재개는 사람의 login/token 제공 필요

## 리뷰어가 봐야 할 부분

- 로그에 민감정보가 정말 남지 않는지
- migration 불일치 시 /health가 확실히 503을 반환하는지