### PR TITLE
[Feature] MVP Tick 시간 및 Event 발생 정책 구현

### DIFF
--- a/backend/alembic/versions/20260827_0013_add_simulation_night_waiting.py
+++ b/backend/alembic/versions/20260827_0013_add_simulation_night_waiting.py
@@ -1,0 +1,30 @@
+"""add simulations.night_waiting
+
+Revision ID: 20260827_0013
+Revises: 20260827_0012
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260827_0013"
+down_revision = "20260827_0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "simulations",
+        sa.Column(
+            "night_waiting",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("simulations", "night_waiting")

--- a/backend/app/api/ticks.py
+++ b/backend/app/api/ticks.py
@@ -17,7 +17,16 @@ from app.services.manual_tick import (
     create_memory_callbacks,
 )
 from app.services.memory_dependency import get_memory_hooks
-from app.services.realtime_events import build_tick_events, connection_manager
+from app.services.night_transition import (
+    NightSkipConflictError,
+    NightSkipNotAllowedError,
+    skip_night,
+)
+from app.services.realtime_events import (
+    build_simulation_status_event,
+    build_tick_events,
+    connection_manager,
+)
 from app.services.runtime_dependency import get_agent_runtime, get_memory_repository
 from app.services.simulations import require_owned_simulation
 from app.services.simulation_events import (
@@ -257,3 +266,54 @@ async def advance_tick(
             for agent_id, memory_ids in result.retrieval_traces.items()
         ],
     )
+
+
+@router.post("/simulations/{simulation_id}/night/skip")
+def skip_night_endpoint(
+    simulation_id: UUID,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+):
+    simulation = require_owned_simulation(db, simulation_id, current_user)
+    try:
+        outcome = skip_night(db, simulation)
+        db.commit()
+    except NightSkipConflictError as exc:
+        db.rollback()
+        return JSONResponse(
+            status_code=409,
+            content={"error": {"code": "CONFLICT", "message": str(exc)}},
+        )
+    except NightSkipNotAllowedError as exc:
+        db.rollback()
+        return JSONResponse(
+            status_code=422,
+            content={"error": {"code": "BUSINESS_RULE_VIOLATION", "message": str(exc)}},
+        )
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(simulation)
+    if outcome.transitioned:
+        background_tasks.add_task(
+            connection_manager.broadcast,
+            simulation.id,
+            [
+                build_simulation_status_event(
+                    simulation.id,
+                    simulation.status,
+                    current_day=simulation.current_day,
+                    current_tick=simulation.current_tick,
+                )
+            ],
+        )
+    return {
+        "data": {
+            "id": str(simulation.id),
+            "status": simulation.status,
+            "current_day": simulation.current_day,
+            "current_tick": simulation.current_tick,
+        }
+    }

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -66,6 +66,7 @@ class Simulation(TimestampMixin, Base):
     current_day: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
     current_tick: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
     magic_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    night_waiting: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/services/event_frequency_history.py
+++ b/backend/app/services/event_frequency_history.py
@@ -1,0 +1,98 @@
+"""Tick 시작 시 고정할 Event 파라미터 스냅샷을 구성한다.
+
+``event_frequency`` / ``event_impact`` 정책 (mvp-tick-event-policy.md §4.3–§4.5)에
+필요한 값들을 그 Tick에 고정된 ``SimulationConfig``와 기존 ``events`` /
+``event_participants`` 기록에서 구한다. 별도 저장소를 추가하지 않는다.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.domain.models import Event, EventParticipant, SimulationConfig
+from app.services.event_magic_phase import EventParameters
+
+# events.event_type은 소문자로 저장된다 (persist_event_batch).
+_DYNAMIC_EVENT_TYPES: tuple[str, ...] = ("group_project", "meeting")
+_COOLDOWN_TICKS_BY_IMPACT: dict[str, int] = {"low": 0, "medium": 1, "high": 3}
+
+
+def build_event_parameters(
+    db: Session,
+    *,
+    simulation_id: UUID,
+    current_tick: int,
+    current_day: int,
+    config: SimulationConfig | None,
+) -> EventParameters:
+    """이번 Tick에 적용할 ``EventParameters``를 만든다.
+
+    ``config``가 ``None``이면(아직 설정이 없는 시뮬레이션) 빈도 정책을 적용하지
+    않는 기본값을 돌려준다 — Event Master는 기존과 동일하게 동작한다.
+    """
+    if config is None:
+        return EventParameters()
+
+    frequency_seed = f"{simulation_id}:{current_tick}:{config.version}"
+
+    daily_dynamic_count = int(
+        db.scalar(
+            select(func.count())
+            .select_from(Event)
+            .where(
+                Event.simulation_id == simulation_id,
+                Event.event_type.in_(_DYNAMIC_EVENT_TYPES),
+                Event.simulation_day == current_day,
+            )
+        )
+        or 0
+    )
+
+    rows = db.execute(
+        select(
+            Event.event_type,
+            Event.event_metadata["tick"].astext,
+            Event.event_metadata["impact_level"].astext,
+            Event.simulation_day,
+            EventParticipant.agent_id,
+        )
+        .join(EventParticipant, EventParticipant.event_id == Event.id)
+        .where(
+            Event.simulation_id == simulation_id,
+            Event.event_type.in_(_DYNAMIC_EVENT_TYPES),
+        )
+    ).all()
+
+    cooldown_excluded: dict[str, set[str]] = {"GROUP_PROJECT": set(), "MEETING": set()}
+    high_impact_today: set[str] = set()
+    for event_type, tick_text, impact_level, simulation_day, agent_id in rows:
+        impact = (impact_level or "medium").lower()
+        agent_str = str(agent_id)
+        type_key = event_type.upper()
+
+        try:
+            event_tick = int(tick_text) if tick_text is not None else None
+        except (TypeError, ValueError):
+            event_tick = None
+
+        if event_tick is not None:
+            cooldown = _COOLDOWN_TICKS_BY_IMPACT.get(impact, 0)
+            if cooldown > 0 and 0 <= current_tick - event_tick < cooldown:
+                cooldown_excluded.setdefault(type_key, set()).add(agent_str)
+
+        if impact == "high" and simulation_day == current_day:
+            high_impact_today.add(agent_str)
+
+    return EventParameters(
+        event_frequency=config.event_frequency,
+        event_impact=config.event_impact,
+        frequency_seed=frequency_seed,
+        daily_dynamic_count=daily_dynamic_count,
+        cooldown_excluded_agent_ids={
+            key: frozenset(values) for key, values in cooldown_excluded.items()
+        },
+        high_impact_agent_ids_today=frozenset(high_impact_today),
+    )

--- a/backend/app/services/event_magic_phase.py
+++ b/backend/app/services/event_magic_phase.py
@@ -11,7 +11,7 @@ transaction is Task 5's job (slice-5-integration.md §5,
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from app.simulation.event_master import (
     AgentSummary as EventMasterAgentSummary,
@@ -43,6 +43,28 @@ class EventAndMagicResult:
 
 REFLECTION_IMPORTANCE_THRESHOLD = 70
 
+# event_impact 효과 강도 배율 (mvp-tick-event-policy.md §4.4).
+IMPACT_MULTIPLIER_BY_NAME: dict[str, float] = {
+    "low": 0.5,
+    "medium": 1.0,
+    "high": 1.5,
+}
+
+
+@dataclass(frozen=True)
+class EventParameters:
+    """이번 Tick에 고정된 Event 파라미터 스냅샷 (mvp-tick-event-policy.md §4.3–§4.5).
+
+    ``frequency_seed``가 ``None``이면 Event Master는 빈도 정책 없이 기존처럼 동작한다.
+    """
+
+    event_frequency: str = "medium"
+    event_impact: str = "medium"
+    frequency_seed: str | None = None
+    daily_dynamic_count: int = 0
+    cooldown_excluded_agent_ids: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    high_impact_agent_ids_today: frozenset[str] = frozenset()
+
 
 def run_event_and_magic_phase(
     *,
@@ -55,12 +77,20 @@ def run_event_and_magic_phase(
     event_master_relationship_summaries: Sequence[EventMasterRelationshipSummary] = (),
     magic_relationship_snapshots: Sequence[RelationshipSnapshot] = (),
     lab_location_ids: frozenset[str] = frozenset(),
+    event_parameters: EventParameters | None = None,
 ) -> EventAndMagicResult:
+    params = event_parameters or EventParameters()
     events = EventMaster().generate(
         tick=tick,
         agent_summaries=agent_summaries,
         scheduled_events=scheduled_events,
         relationship_summaries=event_master_relationship_summaries,
+        event_frequency=params.event_frequency,
+        event_impact=params.event_impact,
+        frequency_seed=params.frequency_seed,
+        daily_dynamic_count=params.daily_dynamic_count,
+        cooldown_excluded_agent_ids=dict(params.cooldown_excluded_agent_ids),
+        high_impact_agent_ids_today=params.high_impact_agent_ids_today,
     )
     magic_result = MagicLayer().evaluate(
         tick=tick,
@@ -69,11 +99,15 @@ def run_event_and_magic_phase(
         relationship_snapshots=magic_relationship_snapshots,
         lab_location_ids=lab_location_ids,
     )
+    impact_multiplier = IMPACT_MULTIPLIER_BY_NAME.get(params.event_impact, 1.0)
     event_candidates = [
         candidate
         for event in magic_result.converted_events
         for candidate in build_event_effect_candidates(
-            event, run_id=run_id, agent_snapshots=agent_state_snapshots
+            event,
+            run_id=run_id,
+            agent_snapshots=agent_state_snapshots,
+            impact_multiplier=impact_multiplier,
         )
     ]
     magic_candidates = build_magic_effect_candidates(

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -30,8 +30,14 @@ from app.repositories.memory_repository import (
     MemoryCreateInput,
     MemoryRepository,
 )
+from app.repositories.simulation_snapshots import SimulationConfigRepository
 from app.services.database_runtime_results import DatabaseRuntimeResultSink
-from app.services.event_magic_phase import EventAndMagicResult, run_event_and_magic_phase
+from app.services.event_frequency_history import build_event_parameters
+from app.services.event_magic_phase import (
+    EventAndMagicResult,
+    EventParameters,
+    run_event_and_magic_phase,
+)
 from app.services.event_persistence import persist_event_batch
 from app.services.execution_metadata import (
     ExecutionMetadataInput,
@@ -43,6 +49,7 @@ from app.services.policy_commit import PolicyCommitResult, evaluate_and_apply_po
 from app.services.runtime_input_adapter import RuntimeInputAdapter
 from app.services.runtime_orchestrator import RuntimeOrchestrator
 from app.services.runtime_target_selection import select_tick_participant_ids
+from app.services.night_transition import apply_night_transition
 from app.services.simulation_tick import SimulationTickService
 from app.services.simulation_snapshots import SimulationSnapshotService
 from app.simulation.agent_runtime import (
@@ -256,6 +263,7 @@ def _run_event_and_magic_phase(
     tick: int,
     agents: list[Agent],
     scheduled_events: Sequence[ScheduledEventInput] = (),
+    event_parameters: EventParameters | None = None,
 ) -> EventAndMagicResult:
     """Event Master -> Magic Layer -> Policy/Resolver 최소 wiring (Issue #101).
 
@@ -372,6 +380,7 @@ def _run_event_and_magic_phase(
         scheduled_events=scheduled_events,
         event_master_relationship_summaries=event_master_relationship_summaries,
         magic_relationship_snapshots=magic_relationship_snapshots,
+        event_parameters=event_parameters,
     )
 
 
@@ -489,9 +498,22 @@ async def advance_manual_tick(
         raise TickAlreadyRunningError
 
     db.refresh(simulation, with_for_update=True)
+    # EVENING 이후 야간 대기 상태였다면 다음 날 MORNING으로 먼저 전환한다
+    # (수동 night/skip과 동일한 서비스 — mvp-tick-event-policy.md §4.2).
+    if simulation.night_waiting:
+        apply_night_transition(db, simulation)
     previous_tick = simulation.current_tick
     current_tick = previous_tick + 1
     current_day, block = tick_position(current_tick)
+    # 이 Tick에 적용할 Event 파라미터를 시작 시점에 고정한다 (§4.5).
+    pinned_config = SimulationConfigRepository().latest(db, simulation.id)
+    event_parameters = build_event_parameters(
+        db,
+        simulation_id=simulation.id,
+        current_tick=current_tick,
+        current_day=current_day,
+        config=pinned_config,
+    )
     run_id = uuid7()
     execution_seed = seed if seed is not None else secrets.randbits(63)
     if memory_adapter is None and memory_retriever is None and memory_store is None:
@@ -539,6 +561,7 @@ async def advance_manual_tick(
         scheduled_events=(
             (scheduled_event_input,) if scheduled_event_input is not None else ()
         ),
+        event_parameters=event_parameters,
     )
     participant_ids = {participant.agent_id for participant in participants}
     selected_ids = select_tick_participant_ids(
@@ -684,8 +707,10 @@ async def advance_manual_tick(
     )
     simulation.current_tick = current_tick
     simulation.current_day = current_day
+    # EVENING Tick commit 후 야간 대기 상태로 들어간다 (§4.2 불변식).
+    simulation.night_waiting = block == Block.EVENING
     db.flush()
-    SimulationSnapshotService().create_snapshot(db, simulation)
+    SimulationSnapshotService().create_snapshot(db, simulation, pinned_config)
     return ManualTickResult(
         previous_tick=previous_tick,
         current_tick=current_tick,

--- a/backend/app/services/night_transition.py
+++ b/backend/app/services/night_transition.py
@@ -1,0 +1,89 @@
+"""야간 전환 서비스.
+
+수동 밤 스킵(``POST /simulations/{id}/night/skip``)과 ``advance_manual_tick``의
+야간 통과가 공용으로 사용한다.
+계약: ``docs/04-feature-specs/mvp-tick-event-policy.md`` §4.2.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
+
+from app.domain.models import Simulation
+
+logger = logging.getLogger(__name__)
+
+_SKIPPABLE_STATUSES = frozenset({"running", "paused"})
+
+
+class NightSkipNotAllowedError(Exception):
+    """status가 밤 스킵을 허용하지 않는 상태(``ready`` / ``completed`` / ``failed``)."""
+
+
+class NightSkipConflictError(Exception):
+    """Tick 실행 중이거나, 야간 대기 상태가 아니며 이미 전환 완료된 상태도 아님."""
+
+
+@dataclass(frozen=True)
+class NightSkipOutcome:
+    simulation: Simulation
+    transitioned: bool  # True = 실제 전환 수행(WS 발행 대상), False = 멱등(무변경)
+
+
+def apply_night_transition(db: Session, simulation: Simulation) -> None:
+    """EVENING 이후 야간을 건너뛰고 다음 날 MORNING으로 전환한다.
+
+    - ``current_tick``은 변경하지 않는다.
+    - ``current_day += 1``.
+    - ``night_waiting = False``.
+    - 야간 회복(Agent 상태 변경)은 MVP 범위 밖이라 여기서 수행하지 않는다(회복량 0).
+      후속 이슈에서 이 함수 안에 회복 단계를 추가한다.
+    """
+    simulation.current_day += 1
+    simulation.night_waiting = False
+    db.flush()
+
+
+def skip_night(db: Session, simulation: Simulation) -> NightSkipOutcome:
+    """수동 밤 스킵. 인증·소유권 검사는 호출부(엔드포인트)가 이미 수행한 상태다.
+
+    ``docs/04-feature-specs/mvp-tick-event-policy.md`` §3.1 매트릭스를 구현한다.
+    """
+    locked = db.scalar(
+        select(
+            text("pg_try_advisory_xact_lock(hashtextextended(:simulation_id, 0))")
+        ).params(simulation_id=str(simulation.id))
+    )
+    if not locked:
+        raise NightSkipConflictError("a tick is currently running for this simulation")
+
+    db.refresh(simulation, with_for_update=True)
+
+    if simulation.status not in _SKIPPABLE_STATUSES:
+        raise NightSkipNotAllowedError(
+            f"night skip is not allowed while simulation status is {simulation.status}"
+        )
+
+    if simulation.night_waiting:
+        apply_night_transition(db, simulation)
+        return NightSkipOutcome(simulation=simulation, transitioned=True)
+
+    current_tick = simulation.current_tick
+    if current_tick > 0 and current_tick % 3 == 0:
+        derived_day = ((current_tick - 1) // 3) + 1
+        if simulation.current_day == derived_day + 1:
+            # 직전 night/skip으로 이미 전환이 완료된 상태 — 멱등 재호출.
+            return NightSkipOutcome(simulation=simulation, transitioned=False)
+        logger.warning(
+            "night/skip on inconsistent state "
+            "(simulation_id=%s, current_tick=%s, current_day=%s, night_waiting=False)",
+            simulation.id,
+            current_tick,
+            simulation.current_day,
+        )
+
+    raise NightSkipConflictError("simulation is not in a night-waiting state")

--- a/backend/app/services/realtime_events.py
+++ b/backend/app/services/realtime_events.py
@@ -71,10 +71,18 @@ def build_event_created_event(event: Event) -> RealtimeEvent:
 def build_simulation_status_event(
     simulation_id: UUID,
     status: str,
+    *,
+    current_day: int | None = None,
+    current_tick: int | None = None,
 ) -> RealtimeEvent:
+    data: dict[str, Any] = {"simulation_id": simulation_id, "status": status}
+    if current_day is not None:
+        data["current_day"] = current_day
+    if current_tick is not None:
+        data["current_tick"] = current_tick
     return RealtimeEvent(
         type="SIMULATION_STATUS_UPDATED",
-        data={"simulation_id": simulation_id, "status": status},
+        data=data,
     )
 
 

--- a/backend/app/services/simulation_snapshots.py
+++ b/backend/app/services/simulation_snapshots.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.domain.models import Simulation, SimulationSnapshot
+from app.domain.models import Simulation, SimulationConfig, SimulationSnapshot
 from app.repositories.simulation_snapshots import (
     SimulationConfigRepository,
     SimulationSnapshotRepository,
@@ -91,9 +91,17 @@ class SimulationSnapshotService:
         )
 
     def create_snapshot(
-        self, session: Session, simulation: Simulation
+        self,
+        session: Session,
+        simulation: Simulation,
+        config: SimulationConfig | None = None,
     ) -> SimulationSnapshot:
-        config = self.configs.latest(session, simulation.id)
+        """``config``이 주어지면 그 버전을 스냅샷에 고정한다 (Tick 시작 시 고정한
+        파라미터가 진행 중 변경분에 오염되지 않도록 — mvp-tick-event-policy.md §4.5).
+        주어지지 않으면 최신 config를 사용하고, 없으면 기본값으로 생성한다.
+        """
+        if config is None:
+            config = self.configs.latest(session, simulation.id)
         if config is None:
             config = self.save_config(
                 session,

--- a/backend/app/services/simulation_snapshots.py
+++ b/backend/app/services/simulation_snapshots.py
@@ -103,15 +103,21 @@ class SimulationSnapshotService:
         if config is None:
             config = self.configs.latest(session, simulation.id)
         if config is None:
-            config = self.save_config(
+            # 아직 config가 없는 시뮬레이션(예: Tick 시작 시점 §4.5)에는 기본값
+            # v1을 부트스트랩한다. 이는 시스템이 확정된 기본 설정을 물질화하는
+            # 것이지 사용자가 초기 설정을 바꾸는 것이 아니므로, save_config의 초기
+            # 설정 잠금(InitialSettingsLockedError, status != "ready" 이면서
+            # latest is None)에 걸려서는 안 된다. 잠금 정책은 사용자 경로
+            # (app/api/simulation_history.py → save_config)에서 그대로 유지된다.
+            config = self.configs.create_version(
                 session,
                 simulation,
-                SimulationConfigInput(
-                    event_frequency="medium",
-                    event_impact="medium",
-                    magic_enabled=simulation.magic_enabled,
-                    user_persona_settings={},
-                ),
+                event_frequency="medium",
+                event_impact="medium",
+                magic_enabled=simulation.magic_enabled,
+                user_persona_settings={},
+                policy_version=None,
+                resolver_version=None,
             )
         return self.snapshots.create(session, simulation, config)
 

--- a/backend/app/simulation/event_master.py
+++ b/backend/app/simulation/event_master.py
@@ -14,7 +14,9 @@ per-observer visibility subset.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import hashlib
+import random
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 
@@ -23,6 +25,8 @@ from enum import StrEnum
 SCHEDULED_EVENT_TYPES: frozenset[str] = frozenset(
     {"CLASS", "EXAM", "MT", "FESTIVAL", "STUDENT_COUNCIL"}
 )
+
+DYNAMIC_EVENT_TYPES: frozenset[str] = frozenset({"GROUP_PROJECT", "MEETING"})
 
 
 class ImpactLevel(StrEnum):
@@ -37,6 +41,22 @@ IMPACT_LEVEL_TO_IMPORTANCE: dict[ImpactLevel, int] = {
     ImpactLevel.MEDIUM: 50,
     ImpactLevel.HIGH: 80,
 }
+
+# event_impact / event_frequency 정책 (mvp-tick-event-policy.md §4.3, §4.4).
+IMPACT_LEVEL_BY_NAME: dict[str, ImpactLevel] = {
+    "low": ImpactLevel.LOW,
+    "medium": ImpactLevel.MEDIUM,
+    "high": ImpactLevel.HIGH,
+}
+DYNAMIC_FREQUENCY_PROBABILITY: dict[str, float] = {
+    "low": 0.25,
+    "medium": 0.50,
+    "high": 0.75,
+}
+DYNAMIC_DAILY_MAX: dict[str, int] = {"low": 1, "medium": 2, "high": 2}
+DYNAMIC_PARTICIPANT_CAP_BY_IMPACT: dict[str, int] = {"low": 2, "medium": 4, "high": 5}
+_LEGACY_GROUP_PROJECT_CAP = 4
+_LEGACY_MEETING_CAP = 5
 
 
 @dataclass(frozen=True)
@@ -107,6 +127,28 @@ def _importance_for(impact_level: ImpactLevel) -> int:
     return IMPACT_LEVEL_TO_IMPORTANCE[impact_level]
 
 
+def _dynamic_frequency_allows(
+    *,
+    scheduled_count: int,
+    event_frequency: str,
+    frequency_seed: str,
+    daily_dynamic_count: int,
+) -> bool:
+    """동적 Event 후보를 이번 Tick에 생성할지 결정론적으로 판정한다 (§4.3).
+
+    시드는 ``f"{simulation_id}:{tick_number}:{config_version}"``이며, 같은 시드는
+    항상 같은 결과를 낸다 (프로세스 간 불안정한 내장 ``hash()``는 쓰지 않는다).
+    """
+    if scheduled_count >= 3:
+        return False
+    if daily_dynamic_count >= DYNAMIC_DAILY_MAX.get(event_frequency, 2):
+        return False
+    probability = DYNAMIC_FREQUENCY_PROBABILITY.get(event_frequency, 0.50)
+    digest = hashlib.sha256(frequency_seed.encode("utf-8")).digest()
+    rng = random.Random(int.from_bytes(digest[:8], "big"))
+    return rng.random() < probability
+
+
 class EventMaster:
     """Tick당 예정/동적 일반 Event를 결정론적으로 생성한다."""
 
@@ -117,15 +159,67 @@ class EventMaster:
         agent_summaries: Sequence[AgentSummary],
         scheduled_events: Sequence[ScheduledEventInput] = (),
         relationship_summaries: Sequence[RelationshipSummary] = (),
+        event_frequency: str = "medium",
+        event_impact: str = "medium",
+        frequency_seed: str | None = None,
+        daily_dynamic_count: int = 0,
+        cooldown_excluded_agent_ids: Mapping[str, frozenset[str]] | None = None,
+        high_impact_agent_ids_today: frozenset[str] = frozenset(),
     ) -> list[Event]:
+        """예정 Event를 변환하고 동적 Event 후보를 생성한다.
+
+        ``frequency_seed``가 ``None``이면 빈도 정책 없이 모든 동적 후보를 생성한다
+        (Slice 5 기존 동작). ``frequency_seed``가 주어지면
+        ``docs/04-feature-specs/mvp-tick-event-policy.md`` §4.3 · §4.4 정책을 적용한다:
+        확률 판정 · Tick당 동적 Event 1개 상한 · 참여 Agent 상한 · 쿨다운 ·
+        당일 high 참여 제외.
+        """
         active_by_id = {
             summary.agent_id: summary for summary in agent_summaries if summary.active_status
         }
 
-        events: list[Event] = []
-        events.extend(self._convert_scheduled(tick, active_by_id, scheduled_events))
-        events.extend(self._generate_group_project(tick, active_by_id))
-        events.extend(self._generate_meeting(tick, active_by_id, relationship_summaries))
+        events: list[Event] = list(
+            self._convert_scheduled(tick, active_by_id, scheduled_events)
+        )
+
+        if frequency_seed is None:
+            events.extend(self._generate_group_project(tick, active_by_id))
+            events.extend(
+                self._generate_meeting(tick, active_by_id, relationship_summaries)
+            )
+            return events
+
+        if not _dynamic_frequency_allows(
+            scheduled_count=len(events),
+            event_frequency=event_frequency,
+            frequency_seed=frequency_seed,
+            daily_dynamic_count=daily_dynamic_count,
+        ):
+            return events
+
+        impact_level = IMPACT_LEVEL_BY_NAME.get(event_impact, ImpactLevel.MEDIUM)
+        participant_cap = DYNAMIC_PARTICIPANT_CAP_BY_IMPACT.get(event_impact, 4)
+        excluded = cooldown_excluded_agent_ids or {}
+        dynamic = self._generate_group_project(
+            tick,
+            active_by_id,
+            impact_level=impact_level,
+            participant_cap=participant_cap,
+            excluded_agent_ids=excluded.get("GROUP_PROJECT", frozenset()),
+            high_impact_agent_ids_today=high_impact_agent_ids_today,
+        )
+        if not dynamic:
+            dynamic = self._generate_meeting(
+                tick,
+                active_by_id,
+                relationship_summaries,
+                impact_level=impact_level,
+                participant_cap=participant_cap,
+                excluded_agent_ids=excluded.get("MEETING", frozenset()),
+                high_impact_agent_ids_today=high_impact_agent_ids_today,
+            )
+        # Tick당 동적 Event는 최대 1개 (§4.3).
+        events.extend(dynamic[:1])
         return events
 
     def build_random_incident(
@@ -200,14 +294,27 @@ class EventMaster:
         return events
 
     # ------------------------------------------------------------------
-    # 동적 Event: GROUP_PROJECT (같은 major_id 수강 Agent 우선, 2~4명)
+    # 동적 Event: GROUP_PROJECT (같은 major_id 수강 Agent 우선)
     # ------------------------------------------------------------------
     def _generate_group_project(
-        self, tick: int, active_by_id: dict[str, AgentSummary]
+        self,
+        tick: int,
+        active_by_id: dict[str, AgentSummary],
+        *,
+        impact_level: ImpactLevel = ImpactLevel.MEDIUM,
+        participant_cap: int | None = None,
+        excluded_agent_ids: frozenset[str] = frozenset(),
+        high_impact_agent_ids_today: frozenset[str] = frozenset(),
     ) -> list[Event]:
+        cap = participant_cap if participant_cap is not None else _LEGACY_GROUP_PROJECT_CAP
+        exclude_high = impact_level == ImpactLevel.HIGH
         groups: dict[tuple[str, str], list[AgentSummary]] = {}
         for summary in active_by_id.values():
             if summary.role != "student" or not summary.major_id or not summary.current_location_id:
+                continue
+            if summary.agent_id in excluded_agent_ids:
+                continue
+            if exclude_high and summary.agent_id in high_impact_agent_ids_today:
                 continue
             key = (summary.major_id, summary.current_location_id)
             groups.setdefault(key, []).append(summary)
@@ -217,7 +324,7 @@ class EventMaster:
             if len(members) < 2:
                 continue
             participant_ids = tuple(
-                sorted(member.agent_id for member in members)[:4]
+                sorted(member.agent_id for member in members)[:cap]
             )
             events.append(
                 Event(
@@ -226,8 +333,8 @@ class EventMaster:
                     participant_agent_ids=participant_ids,
                     location_id=location_id,
                     tick=tick,
-                    impact_level=ImpactLevel.MEDIUM,
-                    importance=_importance_for(ImpactLevel.MEDIUM),
+                    impact_level=impact_level,
+                    importance=_importance_for(impact_level),
                     title="조별 과제",
                     description=f"{major_id} 전공 Student들이 조별 과제를 진행한다.",
                 )
@@ -235,14 +342,27 @@ class EventMaster:
         return events
 
     # ------------------------------------------------------------------
-    # 동적 Event: MEETING (같은 위치 + 기존 우호 관계, 2~5명)
+    # 동적 Event: MEETING (같은 위치 + 기존 우호 관계)
     # ------------------------------------------------------------------
     def _generate_meeting(
         self,
         tick: int,
         active_by_id: dict[str, AgentSummary],
         relationship_summaries: Sequence[RelationshipSummary],
+        *,
+        impact_level: ImpactLevel = ImpactLevel.MEDIUM,
+        participant_cap: int | None = None,
+        excluded_agent_ids: frozenset[str] = frozenset(),
+        high_impact_agent_ids_today: frozenset[str] = frozenset(),
     ) -> list[Event]:
+        cap = participant_cap if participant_cap is not None else _LEGACY_MEETING_CAP
+        exclude_high = impact_level == ImpactLevel.HIGH
+
+        def _blocked(agent_id: str) -> bool:
+            if agent_id in excluded_agent_ids:
+                return True
+            return exclude_high and agent_id in high_impact_agent_ids_today
+
         # 우호적인 관계(affection+closeness 평균 > 0)만 MEETING 후보로 인정한다.
         friendly_pairs = {
             (rel.source_agent_id, rel.target_agent_id)
@@ -250,6 +370,8 @@ class EventMaster:
             if (rel.affection + rel.closeness) / 2 > 0
             and rel.source_agent_id in active_by_id
             and rel.target_agent_id in active_by_id
+            and not _blocked(rel.source_agent_id)
+            and not _blocked(rel.target_agent_id)
         }
         if not friendly_pairs:
             return []
@@ -271,7 +393,7 @@ class EventMaster:
         for location_id, members in sorted(groups.items()):
             if len(members) < 2:
                 continue
-            participant_ids = tuple(sorted(members)[:5])
+            participant_ids = tuple(sorted(members)[:cap])
             events.append(
                 Event(
                     event_key=f"meeting:{location_id}:{tick}",
@@ -279,8 +401,8 @@ class EventMaster:
                     participant_agent_ids=participant_ids,
                     location_id=location_id,
                     tick=tick,
-                    impact_level=ImpactLevel.MEDIUM,
-                    importance=_importance_for(ImpactLevel.MEDIUM),
+                    impact_level=impact_level,
+                    importance=_importance_for(impact_level),
                     title="친목 모임",
                     description="친한 Agent들이 함께 모인다.",
                 )

--- a/backend/app/simulation/policy/registries/event_policy.py
+++ b/backend/app/simulation/policy/registries/event_policy.py
@@ -73,8 +73,14 @@ def build_event_effect_candidates(
     *,
     run_id: str,
     agent_snapshots: Mapping[str, AgentSnapshot],
+    impact_multiplier: float = 1.0,
 ) -> list[EffectCandidate]:
-    """일반 Event(및 RANDOM_INCIDENT)의 참여 Agent 기본 효과를 EffectCandidate로 변환한다."""
+    """일반 Event(및 RANDOM_INCIDENT)의 참여 Agent 기본 효과를 EffectCandidate로 변환한다.
+
+    ``impact_multiplier``는 ``event_impact``의 효과 강도 배율(low 0.5 / medium 1.0 /
+    high 1.5, mvp-tick-event-policy.md §4.4)이다. 기본 delta에 배율을 곱한 뒤
+    ``round``로 정수화하며, 최종 범위 clamp는 기존 Conflict Resolver 단계가 담당한다.
+    """
     if event.event_type == "RANDOM_INCIDENT":
         rules = RANDOM_INCIDENT_EFFECTS.get(event.event_subtype or "", ())
     else:
@@ -89,6 +95,7 @@ def build_event_effect_candidates(
             continue
         for metric, delta in rules:
             current = _state_value(snapshot, metric)
+            scaled_delta = round(delta * impact_multiplier)
             candidates.append(
                 EffectCandidate(
                     effect_id=(
@@ -99,7 +106,7 @@ def build_event_effect_candidates(
                     source_agent_id=agent_id,
                     target_agent_id=None,
                     metric=metric,
-                    delta=delta,
+                    delta=scaled_delta,
                     before=current,
                     after_preview=current,
                     rule_id=f"EVENT_{event.event_type}",

--- a/backend/tests/slice5_campaign.py
+++ b/backend/tests/slice5_campaign.py
@@ -18,6 +18,13 @@ from app.services.fixtures import seed_slice_zero
 from app.services.manual_tick import advance_manual_tick
 from app.simulation.agent_runtime import AgentRuntime, AgentRuntimeInput
 
+# Canonical 캠페인은 재현 가능해야 한다 (test_..._is_semantically_deterministic_twice).
+# Tick 시작 시 고정되는 Event 빈도 시드는 f"{simulation_id}:{tick}:{config_version}"
+# 이므로 (event_frequency_history.build_event_parameters), simulation.id가 매 실행
+# 랜덤(uuid4)이면 동적 Event(GROUP_PROJECT/MEETING) 발생 여부가 실행마다 흔들린다.
+# 캠페인 fixture는 항상 같은 시뮬레이션을 재구성하므로 id도 고정한다.
+CANONICAL_CAMPAIGN_SIMULATION_ID = UUID("50000000-0000-0000-0000-000000000001")
+
 
 @dataclass(frozen=True)
 class CampaignTick:
@@ -122,7 +129,7 @@ def prepare_canonical_campaign(db: Session) -> tuple[Simulation, dict[str, Agent
     db.add(user)
     db.flush()
     simulation = Simulation(
-        id=uuid4(),
+        id=CANONICAL_CAMPAIGN_SIMULATION_ID,
         owner_id=user.id,
         name="Canonical Tick 10 campaign",
         current_tick=9,

--- a/backend/tests/test_mvp_tick_event_policy.py
+++ b/backend/tests/test_mvp_tick_event_policy.py
@@ -1,0 +1,367 @@
+"""MVP Tick 시간 및 Event 발생 정책 — 단위 테스트 (DB 불필요).
+
+계약: docs/04-feature-specs/mvp-tick-event-policy.md
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.services.event_magic_phase import (
+    IMPACT_MULTIPLIER_BY_NAME,
+    EventParameters,
+    run_event_and_magic_phase,
+)
+from app.services.manual_tick import tick_position
+from app.services.night_transition import (
+    NightSkipConflictError,
+    NightSkipNotAllowedError,
+    apply_night_transition,
+    skip_night,
+)
+from app.simulation.agent_runtime import Block
+from app.simulation.event_master import (
+    DYNAMIC_DAILY_MAX,
+    AgentSummary,
+    EventMaster,
+    ImpactLevel,
+    RelationshipSummary,
+    ScheduledEventInput,
+    _dynamic_frequency_allows,
+)
+from app.simulation.magic_layer import AgentSnapshot as MagicAgentSnapshot
+from app.simulation.policy.models import AgentSnapshot as PolicyAgentSnapshot
+from app.simulation.policy.registries.event_policy import build_event_effect_candidates
+
+
+# ---------------------------------------------------------------------------
+# §4.1 Tick 시간 구조 계약
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("tick", "day", "block"),
+    [
+        (1, 1, "MORNING"),
+        (3, 1, "EVENING"),
+        (4, 2, "MORNING"),
+        (6, 2, "EVENING"),
+        (7, 3, "MORNING"),
+        (9, 3, "EVENING"),
+        (10, 4, "MORNING"),
+    ],
+)
+def test_tick_position_boundaries(tick, day, block):
+    assert tick_position(tick) == (day, Block(block))
+
+
+@pytest.mark.parametrize("bad", [0, -1, -3])
+def test_tick_position_rejects_non_positive(bad):
+    with pytest.raises(ValueError, match="positive"):
+        tick_position(bad)
+
+
+# ---------------------------------------------------------------------------
+# §4.3 Event 발생 빈도
+# ---------------------------------------------------------------------------
+def _passing_seed(event_frequency: str) -> str:
+    for tick in range(1, 500):
+        seed = f"sim:{tick}:1"
+        if _dynamic_frequency_allows(
+            scheduled_count=0,
+            event_frequency=event_frequency,
+            frequency_seed=seed,
+            daily_dynamic_count=0,
+        ):
+            return seed
+    raise AssertionError("no passing seed found")
+
+
+def test_frequency_gate_is_deterministic_for_same_seed():
+    kwargs = {
+        "scheduled_count": 0,
+        "event_frequency": "medium",
+        "frequency_seed": "sim:42:7",
+        "daily_dynamic_count": 0,
+    }
+    assert _dynamic_frequency_allows(**kwargs) == _dynamic_frequency_allows(**kwargs)
+
+
+def test_frequency_gate_blocks_when_three_or_more_scheduled():
+    assert not _dynamic_frequency_allows(
+        scheduled_count=3,
+        event_frequency="high",
+        frequency_seed=_passing_seed("high"),
+        daily_dynamic_count=0,
+    )
+
+
+@pytest.mark.parametrize("event_frequency", ["low", "medium", "high"])
+def test_frequency_gate_blocks_when_daily_cap_reached(event_frequency):
+    cap = DYNAMIC_DAILY_MAX[event_frequency]
+    assert not _dynamic_frequency_allows(
+        scheduled_count=0,
+        event_frequency=event_frequency,
+        frequency_seed=_passing_seed(event_frequency),
+        daily_dynamic_count=cap,
+    )
+
+
+def test_high_daily_cap_is_two_not_three():
+    assert DYNAMIC_DAILY_MAX["high"] == 2
+
+
+def _colocated_students(major: str = "고대 마법", location: str = "library", count: int = 2):
+    return [
+        AgentSummary(
+            agent_id=f"s{i}",
+            name=f"학생-{i}",
+            role="student",
+            major_id=major,
+            year=1,
+            active_status=True,
+            current_location_id=location,
+            mood=0,
+            stress=10,
+            fatigue=10,
+        )
+        for i in range(1, count + 1)
+    ]
+
+
+def test_legacy_path_without_seed_is_unchanged():
+    """frequency_seed 없이 호출하면 빈도 정책이 적용되지 않는다 (Slice 5 동작)."""
+    events = EventMaster().generate(tick=3, agent_summaries=_colocated_students())
+    assert [e.event_type for e in events] == ["GROUP_PROJECT"]
+
+
+def test_seeded_path_emits_at_most_one_dynamic_event():
+    summaries = _colocated_students(count=2)
+    relationships = [RelationshipSummary("s1", "s2", affection=20, closeness=20)]
+    events = EventMaster().generate(
+        tick=3,
+        agent_summaries=summaries,
+        relationship_summaries=relationships,
+        event_frequency="high",
+        frequency_seed=_passing_seed("high"),
+    )
+    dynamic = [e for e in events if e.event_type in {"GROUP_PROJECT", "MEETING"}]
+    assert len(dynamic) <= 1
+
+
+def test_seeded_path_daily_cap_reached_emits_no_dynamic_event():
+    events = EventMaster().generate(
+        tick=5,
+        agent_summaries=_colocated_students(),
+        event_frequency="medium",
+        frequency_seed=_passing_seed("medium"),
+        daily_dynamic_count=2,
+    )
+    assert [e for e in events if e.event_type in {"GROUP_PROJECT", "MEETING"}] == []
+
+
+def test_cooldown_excludes_only_named_agents_from_group_project():
+    summaries = _colocated_students(count=3)
+    events = EventMaster().generate(
+        tick=5,
+        agent_summaries=summaries,
+        event_frequency="high",
+        frequency_seed=_passing_seed("high"),
+        cooldown_excluded_agent_ids={"GROUP_PROJECT": frozenset({"s1"})},
+    )
+    group = [e for e in events if e.event_type == "GROUP_PROJECT"]
+    assert group and "s1" not in group[0].participant_agent_ids
+    assert {"s2", "s3"} <= set(group[0].participant_agent_ids)
+
+
+def test_high_impact_today_agent_excluded_only_for_high_events():
+    summaries = _colocated_students(count=3)
+    high = EventMaster().generate(
+        tick=5,
+        agent_summaries=summaries,
+        event_frequency="high",
+        event_impact="high",
+        frequency_seed=_passing_seed("high"),
+        high_impact_agent_ids_today=frozenset({"s1"}),
+    )
+    group = [e for e in high if e.event_type == "GROUP_PROJECT"]
+    assert group and "s1" not in group[0].participant_agent_ids
+
+    medium = EventMaster().generate(
+        tick=5,
+        agent_summaries=summaries,
+        event_impact="medium",
+        frequency_seed=_passing_seed("medium"),
+        high_impact_agent_ids_today=frozenset({"s1"}),
+    )
+    group_medium = [e for e in medium if e.event_type == "GROUP_PROJECT"]
+    assert group_medium and "s1" in group_medium[0].participant_agent_ids
+
+
+@pytest.mark.parametrize(
+    ("event_impact", "importance", "cap"),
+    [("low", 30, 2), ("medium", 50, 4), ("high", 80, 5)],
+)
+def test_dynamic_event_importance_and_participant_cap_by_impact(event_impact, importance, cap):
+    summaries = _colocated_students(count=6)
+    events = EventMaster().generate(
+        tick=5,
+        agent_summaries=summaries,
+        event_impact=event_impact,
+        event_frequency="high",
+        frequency_seed=_passing_seed("high"),
+    )
+    group = [e for e in events if e.event_type == "GROUP_PROJECT"]
+    assert group
+    assert group[0].importance == importance
+    assert len(group[0].participant_agent_ids) == cap
+
+
+# ---------------------------------------------------------------------------
+# §4.4 Event 영향도 배율
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("multiplier", "expected"),
+    [(0.5, 4), (1.0, 8), (1.5, 12)],  # EXAM stress 기본 delta 8
+)
+def test_impact_multiplier_scales_and_rounds_base_effect(multiplier, expected):
+    event = EventMaster().generate(
+        tick=1,
+        agent_summaries=[
+            AgentSummary(
+                agent_id="s1", name="s1", role="student", major_id=None, year=1,
+                active_status=True, current_location_id="c1", mood=0, stress=0, fatigue=0,
+            )
+        ],
+        scheduled_events=[
+            ScheduledEventInput(
+                event_id="e1", event_type="EXAM", location_id="c1",
+                participant_agent_ids=("s1",), impact_level=ImpactLevel.MEDIUM,
+            )
+        ],
+    )[0]
+    snapshot = {"s1": PolicyAgentSnapshot(agent_id="s1", hunger=0, fatigue=0, stress=0, satisfaction=0)}
+    candidates = build_event_effect_candidates(
+        event, run_id="r1", agent_snapshots=snapshot, impact_multiplier=multiplier
+    )
+    stress = next(c for c in candidates if c.metric == "stress")
+    assert stress.delta == expected
+
+
+def test_impact_multiplier_map_matches_spec():
+    assert IMPACT_MULTIPLIER_BY_NAME == {"low": 0.5, "medium": 1.0, "high": 1.5}
+
+
+def test_run_event_and_magic_phase_applies_low_impact_multiplier():
+    result = run_event_and_magic_phase(
+        run_id="r1",
+        tick=1,
+        agent_summaries=[
+            AgentSummary(
+                agent_id="s1", name="s1", role="student", major_id="방어 마법", year=1,
+                active_status=True, current_location_id="classroom", mood=0, stress=10, fatigue=10,
+            )
+        ],
+        agent_state_snapshots={
+            "s1": PolicyAgentSnapshot(agent_id="s1", hunger=0, fatigue=10, stress=10, satisfaction=0)
+        },
+        magic_agent_snapshots=[
+            MagicAgentSnapshot(
+                agent_id="s1", agent_type="student", active_status=True,
+                current_location_id="classroom", fatigue=10, is_cursed=False,
+            )
+        ],
+        scheduled_events=[
+            ScheduledEventInput(
+                event_id="e1", event_type="CLASS", location_id="classroom",
+                participant_agent_ids=("s1",),
+            )
+        ],
+        event_parameters=EventParameters(event_impact="low"),
+    )
+    # CLASS stress 기본 delta 1 × 0.5 -> round(0.5) == 0
+    stress = [e for e in result.resolved_effects if e.metric == "stress"]
+    assert stress == [] or stress[0].delta == 0
+
+
+# ---------------------------------------------------------------------------
+# §4.2 야간 전환 / night skip
+# ---------------------------------------------------------------------------
+class _FakeSession:
+    """skip_night용 최소 세션 — advisory lock은 항상 획득 성공."""
+
+    def __init__(self, *, lock: bool = True) -> None:
+        self._lock = lock
+        self.flush_count = 0
+
+    def scalar(self, *_args, **_kwargs) -> bool:
+        return self._lock
+
+    def refresh(self, _obj, *, with_for_update: bool = False) -> None:
+        return None
+
+    def flush(self) -> None:
+        self.flush_count += 1
+
+
+def _sim(**overrides):
+    base = {
+        "id": uuid4(),
+        "status": "running",
+        "night_waiting": False,
+        "current_tick": 3,
+        "current_day": 1,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_apply_night_transition_advances_day_and_clears_flag():
+    sim = _sim(night_waiting=True, current_day=1, current_tick=3)
+    apply_night_transition(_FakeSession(), sim)
+    assert sim.current_day == 2
+    assert sim.current_tick == 3
+    assert sim.night_waiting is False
+
+
+def test_skip_night_transitions_when_night_waiting():
+    sim = _sim(night_waiting=True, current_day=1, current_tick=3)
+    outcome = skip_night(_FakeSession(), sim)
+    assert outcome.transitioned is True
+    assert sim.current_day == 2
+    assert sim.current_tick == 3
+    assert sim.night_waiting is False
+
+
+def test_skip_night_is_idempotent_after_completed_transition():
+    # 정상 전환 완료 상태 B: current_day == derived_day + 1
+    sim = _sim(night_waiting=False, current_tick=3, current_day=2)
+    outcome = skip_night(_FakeSession(), sim)
+    assert outcome.transitioned is False
+    assert sim.current_day == 2
+
+
+def test_skip_night_conflicts_on_inconsistent_evening_state():
+    # 상태 C: EVENING인데 night_waiting=False 이고 전환 흔적 없음
+    sim = _sim(night_waiting=False, current_tick=3, current_day=1)
+    with pytest.raises(NightSkipConflictError):
+        skip_night(_FakeSession(), sim)
+
+
+@pytest.mark.parametrize("current_tick", [1, 2, 4, 5])
+def test_skip_night_conflicts_mid_day(current_tick):
+    sim = _sim(night_waiting=False, current_tick=current_tick, current_day=(current_tick - 1) // 3 + 1)
+    with pytest.raises(NightSkipConflictError):
+        skip_night(_FakeSession(), sim)
+
+
+@pytest.mark.parametrize("status", ["ready", "completed", "failed"])
+def test_skip_night_not_allowed_for_non_running_statuses(status):
+    sim = _sim(status=status, night_waiting=True)
+    with pytest.raises(NightSkipNotAllowedError):
+        skip_night(_FakeSession(), sim)
+
+
+def test_skip_night_conflicts_when_lock_unavailable():
+    sim = _sim(night_waiting=True)
+    with pytest.raises(NightSkipConflictError):
+        skip_night(_FakeSession(lock=False), sim)

--- a/backend/tests/test_mvp_tick_event_policy_db.py
+++ b/backend/tests/test_mvp_tick_event_policy_db.py
@@ -1,0 +1,189 @@
+"""MVP Tick 시간 및 Event 발생 정책 — DB 통합 테스트.
+
+계약: docs/04-feature-specs/mvp-tick-event-policy.md
+TEST_DATABASE_URL 이 있어야 실행된다 (CI: alembic upgrade head 후 pytest).
+"""
+
+import asyncio
+import os
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from app.domain.models import Simulation, User
+from app.repositories.simulation_snapshots import (
+    SimulationConfigRepository,
+    SimulationSnapshotRepository,
+)
+from app.services.event_frequency_history import build_event_parameters
+from app.services.fixtures import seed_slice_zero
+from app.services.manual_tick import advance_manual_tick, tick_position
+from app.services.night_transition import (
+    NightSkipConflictError,
+    NightSkipNotAllowedError,
+    skip_night,
+)
+from app.simulation.agent_runtime import AgentRuntime, Block, MockLLMClient
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(
+    not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required"
+)
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(TEST_DATABASE_URL)
+    with engine.connect() as connection:
+        outer = connection.begin()
+        with Session(connection, join_transaction_mode="create_savepoint") as session:
+            yield session
+        outer.rollback()
+    engine.dispose()
+
+
+def _new_simulation(db, *, status: str = "running") -> Simulation:
+    user = User(
+        id=uuid4(),
+        username=str(uuid4()),
+        display_name="mvp-tick",
+        password_hash="x",
+        roles=["USER"],
+    )
+    db.add(user)
+    db.flush()
+    simulation = Simulation(
+        id=uuid4(), owner_id=user.id, name="mvp-tick", status=status
+    )
+    db.add(simulation)
+    db.flush()
+    seed_slice_zero(db, simulation.id)
+    db.flush()
+    return simulation
+
+
+def _advance(db, simulation) -> None:
+    runtime = AgentRuntime(MockLLMClient(), model="mvp-tick-policy")
+    asyncio.run(advance_manual_tick(db, simulation, runtime=runtime))
+
+
+# ---------------------------------------------------------------------------
+# §4.2 야간 대기 불변식 + night skip
+# ---------------------------------------------------------------------------
+def test_evening_tick_sets_night_waiting_and_skip_transitions(db):
+    simulation = _new_simulation(db)
+    for _ in range(3):  # MORNING, AFTERNOON, EVENING
+        _advance(db, simulation)
+
+    db.refresh(simulation)
+    assert simulation.current_tick == 3
+    assert tick_position(3)[1] == Block.EVENING
+    assert simulation.night_waiting is True
+    assert simulation.current_day == 1
+
+    outcome = skip_night(db, simulation)
+    assert outcome.transitioned is True
+    db.refresh(simulation)
+    assert simulation.current_tick == 3  # 증가하지 않는다
+    assert simulation.current_day == 2
+    assert simulation.night_waiting is False
+
+    # 멱등 재호출 — 상태 변경 없이 성공
+    outcome2 = skip_night(db, simulation)
+    assert outcome2.transitioned is False
+    db.refresh(simulation)
+    assert simulation.current_day == 2
+
+
+def test_advance_after_evening_passes_through_night_transition(db):
+    simulation = _new_simulation(db)
+    for _ in range(3):
+        _advance(db, simulation)
+    db.refresh(simulation)
+    assert simulation.night_waiting is True
+
+    _advance(db, simulation)  # night_waiting 이면 야간 전환 후 MORNING Tick
+    db.refresh(simulation)
+    assert simulation.current_tick == 4
+    assert simulation.current_day == 2
+    assert simulation.night_waiting is False
+
+
+def test_skip_night_conflicts_mid_day(db):
+    simulation = _new_simulation(db)
+    _advance(db, simulation)  # tick 1, MORNING
+    db.refresh(simulation)
+    assert simulation.night_waiting is False
+    with pytest.raises(NightSkipConflictError):
+        skip_night(db, simulation)
+
+
+@pytest.mark.parametrize("status", ["ready", "completed", "failed"])
+def test_skip_night_not_allowed_for_non_running_status(db, status):
+    simulation = _new_simulation(db, status=status)
+    with pytest.raises(NightSkipNotAllowedError):
+        skip_night(db, simulation)
+
+
+# ---------------------------------------------------------------------------
+# §4.5 config_version 은 Tick 시작 시 고정된다
+# ---------------------------------------------------------------------------
+def test_tick_snapshot_pins_config_version_from_tick_start(db):
+    simulation = _new_simulation(db)
+    _advance(db, simulation)  # tick 1 -> config v1 자동 생성 + snapshot
+    configs = SimulationConfigRepository()
+    v1 = configs.latest(db, simulation.id)
+    assert v1 is not None and v1.version == 1
+
+    # 진행 중이 아닐 때 파라미터를 바꿔 새 버전을 만든다
+    configs.create_version(
+        db,
+        simulation,
+        event_frequency="high",
+        event_impact="high",
+        magic_enabled=simulation.magic_enabled,
+        user_persona_settings={},
+        policy_version=None,
+        resolver_version=None,
+    )
+    db.flush()
+    assert configs.latest(db, simulation.id).version == 2
+
+    _advance(db, simulation)  # tick 2 -> v2 로 고정되어야 한다
+    db.refresh(simulation)
+    snapshot = SimulationSnapshotRepository().get_at_tick(
+        db, simulation.id, simulation.current_tick
+    )
+    assert snapshot is not None
+    assert snapshot.config_version == 2
+
+
+# ---------------------------------------------------------------------------
+# §4.3 빈도 파라미터 재구성
+# ---------------------------------------------------------------------------
+def test_build_event_parameters_without_config_is_inert(db):
+    simulation = _new_simulation(db)
+    params = build_event_parameters(
+        db,
+        simulation_id=simulation.id,
+        current_tick=1,
+        current_day=1,
+        config=None,
+    )
+    assert params.frequency_seed is None
+
+
+def test_build_event_parameters_seed_is_stable(db):
+    simulation = _new_simulation(db)
+    _advance(db, simulation)
+    config = SimulationConfigRepository().latest(db, simulation.id)
+    first = build_event_parameters(
+        db, simulation_id=simulation.id, current_tick=2, current_day=1, config=config
+    )
+    second = build_event_parameters(
+        db, simulation_id=simulation.id, current_tick=2, current_day=1, config=config
+    )
+    assert first.frequency_seed == second.frequency_seed
+    assert first.frequency_seed == f"{simulation.id}:2:{config.version}"

--- a/docs/04-feature-specs/mvp-tick-event-policy.md
+++ b/docs/04-feature-specs/mvp-tick-event-policy.md
@@ -1,0 +1,477 @@
+---
+title: MVP Tick 시간 및 Event 발생 정책
+status: draft
+updated: 2026-08-27
+visibility: public
+source:
+  - docs/02-domain/time-and-space.md
+  - docs/02-domain/events.md
+  - docs/03-system-design/tick-engine.md §2
+  - docs/03-system-design/event-master.md §4.3
+  - "GitHub Issue #182 ([Feature] 1단계 미포함 MVP 기능 백엔드 지원)"
+관련 PRD: F4-04(이벤트 파라미터 설정) · F5-01(Tick 상태 표시) · F5-03(밤 시간 스킵)
+---
+
+# MVP Tick 시간 및 Event 발생 정책
+
+> **이 문서가 구현 단일 계약이다.** 아래 §9에 열거한 기존 문서의 직접 충돌 조항은
+> 구현 단계에서 이 스펙에 맞춰 정합화한다. 그 밖의 기존 문서 내용은 이 스펙이
+> 변경하지 않는다.
+
+## 1. 목적
+
+MVP 스코프에는 있으나 Slice 0~7에서 구현되지 않은 세 가지 백엔드 규칙을 채운다.
+
+1. Tick 시간 구조(MORNING / AFTERNOON / EVENING · 24분 = 1일)를 계약으로 고정한다.
+2. 저녁 블록 이후 야간을 스킵하고 다음 날 아침으로 전환하는 수동 경로를 만든다.
+3. 사용자가 설정한 `event_frequency` / `event_impact` 파라미터가 실제 동적 Event
+   생성 빈도와 효과 크기에 반영되게 한다.
+
+## 2. 범위
+
+**포함**
+
+- `tick_position()` 계약 회귀 테스트 (day / block 파생 규칙 고정)
+- `Simulation.night_waiting` boolean 필드 추가 및 Alembic 마이그레이션
+- EVENING Tick batch commit 성공 시 `night_waiting = true` 설정
+- `advance_manual_tick`이 시작 시 `night_waiting == true`이면 야간 전환을 먼저 수행
+  하도록 통합 (§4.2)
+- `POST /simulations/{simulation_id}/night/skip` 엔드포인트 + 야간 전환 서비스
+  (수동·자동 경로 공용)
+- `advance_manual_tick`이 Tick 시작 시 해당 simulation의 최신 `SimulationConfig`
+  (`event_frequency` / `event_impact` / `version`)를 읽어 Tick 종료까지 고정 사용
+- Event Master 동적 Event 후보 생성에 `event_frequency` 빈도 판정(확률 · 일일 상한 ·
+  Tick당 상한) 반영
+- Policy Engine / Event Master에 `event_impact` 효과 강도 배율 · importance · 참여
+  Agent 상한 · 쿨다운 · Reflection 적격 · 당일 high 참여 제외 반영
+- 각 Tick 스냅샷에 그 Tick에서 고정 사용한 `config_version` 기록
+  (`SimulationSnapshot.config_version` 재사용, 단 "종료 시 latest"가 아니라 "시작 시
+  고정값"으로 변경)
+- Event 파라미터 생명주기(Draft `PUT /parameters` ↔ 실행 중 `PATCH /parameters`)와
+  Event 정책의 연결 명문화 (§4.5) — 기존 3.11 API 계약은 코드로 바꾸지 않음
+- 구현 단계에서 함께 갱신: `docs/00-start-here/what-is-pending.md` · `events.md` ·
+  `time-and-space.md`의 "이벤트 발생 빈도" 미정 표기 (§9)
+- Slice 0~7 회귀 테스트 무결
+
+**제외**
+
+- APScheduler 자동 Tick 진행 및 자동 야간 타이머 → §8-1
+- 야간 회복 Policy의 상태값 변경(피로도 / 스트레스 회복 등) 및 수치 → §8-2
+- 블록별 실제 시각 범위(아침 08:00~ 등) 정의 및 블록별 Event 매핑 — MVP 기계 동작에
+  불필요, `what-is-pending.md`의 해당 행은 그대로 둔다
+- Magic Layer 특수 사건의 빈도 / 영향도(`magic_frequency` / `magic_impact`) — Issue
+  #182의 다른 하위 작업
+- FE 화면(F4-04 / F5-03 UI)
+
+## 3. 입력 / 출력
+
+| 항목 | 설명 |
+|---|---|
+| 입력 (Tick) | `current_tick`, `simulation.status`, `simulation.night_waiting`, Tick 시작 시 고정한 `SimulationConfig`(event_frequency / event_impact / version), 예정 Event 목록, 활성 Agent 요약, 당일 동적 Event·high 참여 이력(기존 `events`/`event_participants` 조회) |
+| 출력 (Tick) | 동적 Event 0~1개(예정 Event와 합쳐 Tick당 ≤ 3), 스냅샷에 기록된 적용 `config_version` |
+| 입력 (night/skip) | `simulation_id` (path), 본문 `{}` |
+| 출력 (night/skip) | `{ "data": { "id", "status", "current_day", "current_tick" } }` — `current_tick` 불변 |
+| 저장 | `simulations.current_day`, `simulations.night_waiting`, `simulation_snapshots.config_version` |
+
+### 3.1 night/skip 상태 전이 · 응답 매트릭스
+
+| 조건 (순서대로 평가) | 응답 |
+|---|---|
+| 미인증 | 401 UNAUTHORIZED |
+| Simulation 없음 | 404 RESOURCE_NOT_FOUND |
+| 소유자 아님 | 403 FORBIDDEN |
+| `status ∈ {ready, completed, failed}` | 422 BUSINESS_RULE_VIOLATION |
+| Tick 실행용 advisory lock 획득 실패 (대개 Tick 진행 중, 드물게 동시 night/skip) | 409 CONFLICT |
+| `night_waiting == true` | **야간 전환 수행** → 200 |
+| `night_waiting == false` **且** `current_tick > 0` **且** `current_tick % 3 == 0` **且** `current_day == derived_day + 1` (이미 전환 완료 = 멱등 재호출) | 상태 변경 없이 200 |
+| 그 외 (`night_waiting == false` 이고 위 멱등 조건 불성립: 하루 중간, 또는 EVENING 직후인데 `night_waiting`이 false인 상태 불일치) | 409 CONFLICT (상태 불일치 시 경고 로그) |
+
+`derived_day = ((current_tick - 1) // 3) + 1` (= `tick_position(current_tick)`의 day).
+
+## 4. 핵심 동작
+
+### 4.1 Tick 시간 구조 (기구현 — 계약 고정만)
+
+- `tick_position(n) → (day, block)`:
+  `day = ((n - 1) // 3) + 1`, `block = [MORNING, AFTERNOON, EVENING][(n - 1) % 3]`
+- 1 Tick = 1 블록 = 8분, 1일 = 3 Tick = 24분
+- `advance_manual_tick`은 이 파생값으로 `current_tick` / `current_day`를 갱신한다
+  (파생 규칙 자체는 변경 없음).
+- 신규: 경계값(3 → 1일 EVENING, 4 → 2일 MORNING, 6 → 2일 EVENING, 7 → 3일 MORNING …)
+  과 `tick_position(0)` / 음수 → `ValueError` 를 회귀 테스트로 고정한다.
+
+### 4.2 야간 스킵 / 다음 날 전환 (신규)
+
+**야간 대기 상태 (`Simulation.night_waiting`)**
+
+- 야간 대기 여부는 `night_waiting` 필드로만 판단한다. 블록 값만으로 추론하지 않는다.
+- 불변식: EVENING Tick(`current_tick % 3 == 0`, `current_tick > 0`)의 batch commit이
+  성공하면 **같은 transaction에서** `night_waiting = true`로 설정한다.
+- MORNING / AFTERNOON Tick commit은 `night_waiting`을 건드리지 않는다 (항상 false).
+- 야간 전환(수동 skip 또는 `advance_manual_tick` 통과) 성공 시 `night_waiting = false`.
+
+**야간 전환 로직 (수동·자동 공용 서비스)**
+
+1. Agent Runtime · Event Master · Magic Layer를 호출하지 않는다.
+2. `current_tick`을 변경하지 않는다.
+3. `current_day += 1`.
+4. `night_waiting = false`.
+5. 다음 블록은 자연히 MORNING이다 (블록은 `tick_position(current_tick + 1)`로 파생,
+   EVENING 다음 Tick = MORNING). 블록을 별도 컬럼에 저장하지 않는다.
+6. **MVP에서는 야간 회복을 수행하지 않는다 — Agent 상태값(피로도 / 스트레스 등)을
+   변경하지 않는다.** 회복 훅을 구현하지 않아도 된다 (§8-2, 후속).
+
+**`POST /simulations/{simulation_id}/night/skip`**
+
+- 권한: 로그인 사용자, 본인 소유 Simulation.
+- Tick과 동일한 advisory lock
+  (`pg_try_advisory_xact_lock(hashtextextended(simulation_id, 0))`)을 시도하고, 실패
+  시 409를 반환한다.
+- §3.1 매트릭스에 따라 200 / 409 / 422를 반환한다. 200(전환 수행) 시 commit 성공 후
+  WebSocket `SIMULATION_STATUS_UPDATED`를 발행한다 (payload: `id`, `status`,
+  `current_day`, `current_tick`). 멱등 200(상태 변경 없음)은 재발행하지 않는다.
+
+**`advance_manual_tick` 통합**
+
+- `advance_manual_tick`은 `night_waiting`으로 차단되지 않는다.
+- 실행 시작 시 `night_waiting == true`이면 위 "야간 전환 로직"을 같은 transaction에서
+  먼저 수행한 뒤(= `current_day += 1`, `night_waiting = false`, 회복 no-op) 다음
+  (MORNING) Tick 본문을 진행한다. `night_waiting == false`이면 야간 전환을 건너뛴다.
+- EVENING Tick의 다음 Tick은 `tick_position().day`가 이미 +1이므로, 순차 advance만
+  하는 기존 흐름의 `current_tick` / `current_day` 진행값은 이 통합 후에도 동일하다
+  (기존 Slice 회귀 무결).
+
+### 4.3 Event 발생 빈도 정책 (신규)
+
+| `event_frequency` | 동적 Event 후보 생성 확률 | 하루 최대 동적 Event | Tick당 최대 동적 Event |
+|---|---:|---:|---:|
+| low | 25% | 1 | 1 |
+| medium (기본) | 50% | 2 | 1 |
+| high | 75% | 2 | 1 |
+
+**적용 대상**: `event_frequency`는 **동적 일반 Event**(GROUP_PROJECT / MEETING)의
+후보 생성에만 적용한다. 예정 Event(CLASS / EXAM / MT / FESTIVAL / STUDENT_COUNCIL)는
+학사 일정에서 활성화되며 `event_frequency`와 무관하게 항상 생성된다. 마법 특수
+사건에는 적용하지 않는다.
+
+**Tick별 판정 (아래 순서, 모두 만족해야 동적 Event 1개 생성)**
+
+1. Tick 시작 시 예정 Event를 먼저 확정한다.
+2. **예정 Event 수 < 3** — 예정 Event가 3개 이상이면 동적 Event를 생성하지 않는다.
+   (MVP 픽스처는 예정 Event 1개(CLASS)이므로 이 분기는 방어적 조항이다.)
+3. **당일 동적 Event 누적 수 < 일일 상한** — 같은 `current_day`에 이미 확정된 동적
+   Event 수가 `event_frequency`의 하루 최대(1 / 2 / 2)에 도달했으면 그 날 남은 블록
+   에서는 확률 판정을 하지 않는다.
+   - 일일 상한은 **동적 Event에만** 적용한다. 예정 Event는 카운트하지 않는다.
+   - `high`도 하루 최대 2회다. frequency가 커지면 확률만 증가하고 상한은 최대 2회다.
+   - 당일 누적 수는 `events` 테이블에서 `source = 'event_master'` 且 `event_type ∈
+     {GROUP_PROJECT, MEETING}` 且 `tick_number`가 당일 범위 `[3*(current_day-1)+1 ..
+     current_tick)` 인 행 수로 구한다 (별도 저장소 없음). `current_day`가 바뀌면
+     (정상 진행 또는 night/skip) 당일 범위가 이동하므로 카운터는 자연히 리셋된다.
+4. **확률 통과** — 시드 문자열 `f"{simulation_id}:{tick_number}:{config_version}"`의
+   안정적 해시(예: SHA-256 선행 8바이트를 정수로)로 초기화한 `random.Random`에서
+   draw 1회를 뽑아 `draw < 확률`이면 통과한다. 같은 세 값이면 항상 같은 결과여야
+   한다. 프로세스 간 불안정한 파이썬 내장 `hash()`는 쓰지 않는다.
+5. 통과하면 Event Master가 허용 타입(GROUP_PROJECT / MEETING) 하나와 참여 Agent ·
+   장소를 결정해 동적 Event 후보 1개를 만든다. 후보 조건(참여 인원 최소 2명 등)을
+   만족하지 못하면 그 Tick에는 동적 Event가 없다.
+
+**상한 관계**: 동적 Event는 Tick당 최대 1개. 예정 Event 수 + 동적 Event 수는 기존
+계약에 따라 Tick당 3개를 넘지 않는다. MVP에서는 예정 1 + 동적 ≤ 1 이므로 실질 합계
+≤ 2다. Issue #182의 "하루 1~2회"는 기본값 medium(하루 최대 2) · low(하루 1)와 정합
+한다.
+
+### 4.4 Event 영향도 정책 (신규)
+
+| `event_impact` | importance | 효과 강도 배율 | 동적 Event 참여 Agent 상한 | 동일 참여자 쿨다운 | Reflection 적격 |
+|---|---:|---:|---:|---:|---|
+| low | 30 | 0.5 | 2 | 없음 (0 Tick) | 아니오 |
+| medium (기본) | 50 | 1.0 | 4 | 1 Tick | 아니오 |
+| high | 80 | 1.5 | 5 | 3 Tick | 예 |
+
+**효과 강도 배율**
+
+- Policy Engine은 Event 유형별 기본 delta(`EVENT_BASE_EFFECTS`)에 배율을 곱한 뒤
+  `round(base_delta × 배율)` (파이썬 내장 `round`, 0.5는 가장 가까운 짝수)로 정수화
+  하고, 그다음 기존 metric별 허용 범위로 clamp한다.
+- 적용 지점: `build_event_effect_candidates`
+  (`app/simulation/policy/registries/event_policy.py`)에서 `EVENT_BASE_EFFECTS`를
+  소비하는 위치. clamp는 기존 Conflict Resolver 단계 그대로.
+- 배율은 `EVENT_BASE_EFFECTS`의 모든 항목(예정 CLASS/EXAM/MT/FESTIVAL 및 동적
+  GROUP_PROJECT/MEETING)에 적용한다. 기본값 medium은 배율 1.0이므로 기존 효과와
+  동일하다 (회귀 무결).
+- 마법 특수 사건의 typed signal 경로에는 배율을 적용하지 않는다.
+
+**importance · 참여 Agent 상한**
+
+- `importance`(30 / 50 / 80)와 참여 Agent 상한(2 / 4 / 5)은 **동적 Event**에만
+  적용한다. Event Master가 동적 Event 후보를 만들 때 importance를 이 표로 설정하고,
+  참여 Agent 목록을 상한까지만 남긴다(정렬은 기존 코드대로 `agent_id` 오름차순).
+- 상한 적용은 아래 "당일 high 참여 제외" · "쿨다운" 제외 후에 수행한다. 제외 후
+  남은 인원이 타입 최소 인원(2명) 미만이면 그 Tick에 동적 Event를 만들지 않는다.
+- 예정 Event의 importance는 기존대로 학사 일정의 `impact_level`이 결정한다 (변경
+  없음).
+
+**Reflection 적격**
+
+- 기존대로 `event.importance >= 70` (`REFLECTION_IMPORTANCE_THRESHOLD`)으로 판정한다.
+- 동적 Event importance는 `event_impact`가 결정하므로 `event_impact = high`(80)인
+  동적 Event만 적격이고, low(30) / medium(50)은 비적격이다.
+
+**동일 참여자 쿨다운 — 정확한 정의**
+
+- **무엇을 제한하는가**: 새로 생성되는 **동적 일반 Event의 참여 Agent 선정**만
+  제한한다. Event 생성 자체를 막지 않고, 특정 Agent를 그 후보의 참여자에서 제외
+  한다. GROUP_PROJECT 쿨다운과 MEETING 쿨다운은 `event_type`별로 독립이다.
+- **규칙**: 새 동적 Event 후보의 타입이 `T`(GROUP_PROJECT 또는 MEETING)이고 현재
+  Tick이 `t`일 때, Agent `A`가 타입 `T`의 동적 Event에 tick `t'`에 참여한 이력이
+  있고 그 Event의 `event_impact` 쿨다운 `N`(low 0 / medium 1 / high 3)에 대해
+  `t - t' < N` 이면, `A`를 새 후보의 참여자에서 제외한다.
+- **적용 단계**: Event Master의 참여 Agent 선정 단계. (생성 확률 판정 이후, 참여
+  Agent 상한 적용 이전.)
+- **제한 범위**: 동적 일반 Event(GROUP_PROJECT / MEETING)만. **예정 Event
+  (CLASS/EXAM/MT/FESTIVAL/STUDENT_COUNCIL)는 쿨다운의 영향을 받지 않으며, 쿨다운
+  기간에도 항상 정상 활성화된다.** 마법 특수 사건도 무관하다.
+- **impact level 기준**: 쿨다운 길이 `N`은 **직전에 참여한 그 Event의 impact
+  level**이 정한다. 새 후보의 impact level과는 무관하다.
+- **측정 단위**: `current_tick` 차이. 야간 전환은 `current_tick`을 증가시키지 않으
+  므로 쿨다운은 밤을 사이에 두고 자연히 이어진다.
+- **이력 출처**: `events` + `event_participants` 조회(`source = 'event_master'`,
+  `event_type ∈ {GROUP_PROJECT, MEETING}`, 최근 `max(N)=3` Tick). 별도 저장소 없음.
+
+**동일 Agent 당일 high 참여 제외**
+
+- Agent `A`가 같은 `current_day`에 `event_impact = high` 동적 Event에 이미 참여했다면,
+  추가 high 동적 Event 후보의 **참여자에서 `A`만 제외**한다. Event를 medium으로
+  하향하지 않는다.
+- 당일 high 참여 이력은 `events`(`event_type ∈ {GROUP_PROJECT, MEETING}`,
+  `importance = 80`, 당일 tick 범위) + `event_participants` 조회로 판정한다.
+- `high × high` 조합 자체는 허용한다 — 제한은 이 "당일 1회" 규칙으로만 건다.
+
+### 4.5 파라미터 생명주기 (API ↔ config_version)
+
+Event 파라미터는 `event_frequency`, `event_impact` 두 개다. 허용값 `low` / `medium`
+/ `high`, 기본값은 둘 다 `medium`. API는 값을 **저장**하고, Tick / Event Master /
+Policy Engine이 그 값을 §4.3 · §4.4 정책으로 **적용**한다.
+
+기존 API 계약(3.11 API 명세, 라우트 `PUT` / `PATCH /simulations/{simulation_id}/
+parameters`)은 이 스펙에서 코드로 바꾸지 않는다 — 아래는 그 계약과 Event 정책의
+연결을 명확히 하는 것이다.
+
+#### 4.5.1 Simulation 시작 전 — Draft(`ready`)
+
+- 라우트: `PUT /simulations/{simulation_id}/parameters`
+- 본문: `event_frequency`, `event_impact`, `magic_enabled`
+  (`SimulationConfigPutRequest`, 추가 필드 금지)
+  ```json
+  { "event_frequency": "medium", "event_impact": "medium" }
+  ```
+  (Magic Layer 관련 필드·규칙은 기존 3.11 계약 그대로 유지한다. 이 스펙은
+  `event_frequency` / `event_impact` 연결만 명확히 한다.)
+- 처리:
+  - `ready` 상태에서 Event 파라미터를 저장 / 변경할 수 있다.
+  - 저장할 때마다 새 `SimulationConfig` version을 생성한다(append-only).
+  - Simulation 시작 시점부터 그 config를 사용한다.
+  - 시작 후에는 §4.5.3의 Tick별 `config_version` 정책을 따른다.
+
+#### 4.5.2 Simulation 실행 중 — `running` / `paused`
+
+- 라우트: `PATCH /simulations/{simulation_id}/parameters`
+- 본문: `event_frequency`, `event_impact` 만 (`SimulationConfigPatchRequest`, 추가
+  필드 금지)
+  ```json
+  { "event_frequency": "high", "event_impact": "low" }
+  ```
+- 변경 가능 필드: `event_frequency`, `event_impact`. **`magic_enabled` 및 Magic
+  Layer 파라미터는 이 PATCH로 바꾸지 않는다**(기존대로 최신 config 값을 승계).
+- 처리 규칙:
+  1. 요청이 성공하면 새 `SimulationConfig` version을 생성한다.
+  2. 현재 실행 중인 Tick이 있으면 그 Tick은 **Tick 시작 시 고정한 기존
+     `config_version`**으로 끝까지 실행한다.
+  3. 변경된 `event_frequency` / `event_impact`는 **다음 Tick부터** 적용한다.
+  4. Tick 중간에 설정이 부분적으로 바뀌지 않는다(§4.5.3의 원자적 고정).
+  5. Tick 시작 시 `SimulationConfig`를 snapshot하고 `config_version`을 고정한다.
+  6. Tick 결과(스냅샷)에는 실제 적용된 `config_version`을 기록한다.
+  7. `effective_tick` = 변경된 설정이 처음 적용되는 다음 Tick 번호.
+     - 변경 시점에 진행 중 Tick이 없으면 `effective_tick = current_tick + 1`.
+     - 진행 중 Tick(번호 `t`)이 있으면 그 Tick은 기존 version으로 끝나고
+       `effective_tick = t + 1`.
+  8. **Tick이 실행 중이라는 이유만으로 PATCH를 409로 거부하지 않는다.** PATCH는
+     version만 추가하고, 적용은 다음 Tick 경계에서 일어난다.
+  9. `running` / `paused` 이외 상태 및 그 밖의 에러 규칙은 기존 3.11 API 계약을
+     따른다(`completed` / `failed`는 `save_config`가 잠금 →
+     `SIMULATION_SETTINGS_LOCKED`).
+
+#### 4.5.3 Tick 적용 (config_version 고정)
+
+| 상황 | 처리 |
+|---|---|
+| Tick 시작 | 그 simulation의 최신 `SimulationConfig`를 1회 읽어 `(event_frequency, event_impact, version)`를 Tick 종료까지 고정. §4.3 확률 시드와 §4.4 배율에 이 값을 사용 |
+| Tick 실행과 PATCH 경합 | 현재 Tick은 시작 시 고정한 version으로 완료, 변경값은 `effective_tick`부터 |
+| Tick 종료 | 스냅샷에 "시작 시 고정한" `config_version`을 기록 |
+| Replay | 스냅샷의 `config_version`으로 원본 `SimulationConfig` 행을 재조회해 동일 정책 재현. Event Master · LLM 재호출 없음 |
+
+- **신규 wiring**: `advance_manual_tick`은 현재 `SimulationConfig`를 읽지 않는다. 이
+  스펙에서 Tick 시작 시 `SimulationConfigRepository.latest()`를 1회 읽어 고정한다.
+- **스냅샷 기록 변경**: `SimulationSnapshotService.create_snapshot`은 현재 "종료
+  시점 `latest`"를 스냅샷에 넣는다. 이를 "Tick 시작 시 고정한 config"를 받아 넣도록
+  바꾼다. 이래야 진행 중 PATCH 변경분이 현재 Tick 스냅샷에 새지 않는다.
+- `SimulationConfig`는 append-only(`create_version` = `max(version) + 1`)라 과거
+  version 행이 보존된다 → Replay가 스냅샷의 `config_version`으로 원본을 재조회할 수
+  있다.
+- API 레이어(`save_config`)는 이미 `ready` / `running` / `paused`에서만
+  `event_frequency` / `event_impact` 변경을 허용한다. 이 스펙은 API 레이어를 바꾸지
+  않는다.
+
+#### 4.5.4 흐름 요약
+
+```
+[Simulation 시작 전]
+  ready
+   → PUT /simulations/{simulation_id}/parameters
+   → event_frequency / event_impact 저장 (새 config_version)
+   → Simulation 시작
+   → 해당 config_version 사용
+
+[Simulation 실행 중]
+  running / paused
+   → PATCH /simulations/{simulation_id}/parameters
+   → event_frequency / event_impact 변경 (새 config_version)
+   → 현재 Tick은 시작 시 고정한 기존 config_version으로 완료
+   → effective_tick(= 다음 Tick)부터 새 설정 적용
+```
+
+## 5. 경계 조건
+
+- `tick_position(0)` 및 음수 → `ValueError`.
+- night/skip은 `night_waiting == true`에서만 상태를 전환한다. 그 외는 §3.1 매트릭스
+  (200 멱등 / 409 / 422).
+- 야간 전환(수동·자동 공용)은 `current_tick`을 절대 변경하지 않는다.
+- Tick 실행용 advisory lock을 잡지 못하면 night/skip은 항상 409.
+- 상태 불일치(EVENING 직후인데 `night_waiting == false`, 且 전환 완료 흔적 없음)는
+  409 + 경고 로그. "이미 처리됨"으로 오인해 200을 주지 않는다.
+- 예정 Event만으로 Tick당 3개면 동적 Event는 0개.
+- 예정 Event는 `event_frequency = low` · 쿨다운 기간에도 항상 활성화된다.
+- 일일 동적 Event 상한 도달 후 그 날 남은 블록에서는 확률 판정을 건너뛴다.
+- `current_day` 변경 시 "당일 동적 누적" · "당일 high 참여" 판정 범위가 새 날로
+  이동한다.
+- 진행 중 Tick의 결과는 그 Tick 시작 시 고정한 `config_version`으로만 계산된다.
+- 동일 metric UP / DOWN 충돌, stale before 등 기존 Policy Engine 계약은 유지된다
+  (이 스펙은 배율 → 정수화 → clamp 순서만 추가).
+
+## 6. 데이터 구조
+
+### 6.1 `Simulation.night_waiting` (신규 컬럼)
+
+| 항목 | 값 |
+|---|---|
+| 컬럼 | `night_waiting BOOLEAN NOT NULL DEFAULT false` |
+| 마이그레이션 | Alembic revision 신규. 기존 행은 `server_default = false`로 백필 (기존 시뮬레이션은 야간 대기 아님으로 간주. EVENING 직후였던 기존 sim은 §3.1의 409 경로로 떨어지며, `advance_manual_tick` 통합 경로로 다음 Tick 시 정상화된다.) |
+| 쓰기 시점 | EVENING Tick commit 성공 → `true`. 야간 전환(수동 skip / advance 통합) 성공 → `false`. |
+
+### 6.2 재사용 (스키마 변경 없음)
+
+- `SimulationConfig`: `event_frequency` / `event_impact`(`low|medium|high`), `version`
+  (append-only)
+- `SimulationSnapshot.config_version`: Tick별 "시작 시 고정" 파라미터 version
+- `EVENT_BASE_EFFECTS` (`event_policy.py`): 효과 강도 배율 적용 지점
+- `REFLECTION_IMPORTANCE_THRESHOLD = 70` (`event_magic_phase.py`): Reflection 적격
+  임계값
+- `events` / `event_participants`: 당일 동적 누적 · 쿨다운 · 당일 high 참여 이력 조회
+
+## 7. 완료 기준
+
+- [ ] `tick_position` 경계값 · 예외 회귀 테스트
+- [ ] Alembic 마이그레이션 up / down · 기존 데이터 `night_waiting = false` 백필 검증
+- [ ] EVENING Tick commit 성공 시 `night_waiting = true`, MORNING / AFTERNOON commit은
+      변화 없음
+- [ ] `POST /night/skip` §3.1 매트릭스 전 케이스: 200(전환) / 200(멱등, 무변경) /
+      401 / 403 / 404 / 409(하루 중간) / 409(advisory lock) / 409(EVENING 직후 상태
+      불일치) / 422(`ready`/`completed`/`failed`)
+- [ ] 야간 전환이 `current_tick` 불변 · `current_day + 1` · `night_waiting = false` ·
+      Agent Runtime / Event Master / Magic Layer 미호출 · `agent_states` 무변경
+- [ ] `SIMULATION_STATUS_UPDATED` 발행 (전환 200에서만, commit 성공 후)
+- [ ] `advance_manual_tick`이 `night_waiting == true`에서 야간 전환을 먼저 수행하고
+      MORNING Tick 진행, 순차 advance 시 `current_tick`/`current_day` 진행값이 기존과
+      동일
+- [ ] `event_frequency` low / medium / high 별 확률 · 일일 상한(1 / 2 / 2) · Tick당
+      상한(1) — 같은 `(simulation_id, tick_number, config_version)`이면 결정론적으로
+      동일 결과
+- [ ] 예정 Event ≥ 3 → 동적 Event 0개 / 예정 Event는 `event_frequency = low` ·
+      쿨다운 기간에도 항상 활성
+- [ ] 일일 상한 도달 후 같은 날 추가 동적 Event 미생성, `current_day` 변경 시 판정
+      범위 이동
+- [ ] `event_impact` 별 importance(30/50/80) · 배율(0.5/1.0/1.5) · 동적 참여 상한
+      (2/4/5) · Reflection 적격(high만)
+- [ ] `round(base_delta × 배율)` 후 metric 허용 범위 clamp 검증 (medium ×1.0은 기존
+      값과 동일)
+- [ ] 쿨다운: 타입별 독립, `t - t' < N`(N = 직전 참여 Event impact의 0/1/3),
+      해당 Agent만 참여 제외, 제외 후 2명 미만이면 동적 Event 미생성, 예정 Event는
+      영향 없음
+- [ ] 동일 Agent 당일 2회차 high 동적 Event 후보에서 해당 Agent만 제외 (Event 유지,
+      하향 없음)
+- [ ] Draft(`ready`) `PUT /parameters` → 새 `config_version` 생성, 시작 시점부터 사용
+- [ ] `running` / `paused` `PATCH /parameters` → 새 `config_version`, 현재 Tick 불변,
+      `effective_tick`(다음 Tick)부터 적용, Tick 실행 중이어도 409로 거부하지 않음
+- [ ] `PATCH`로 `magic_enabled` / Magic 파라미터 변경 불가 (기존 계약)
+- [ ] Tick 스냅샷에 "시작 시 고정" `config_version` 저장 · Replay 재현
+- [ ] `what-is-pending.md` / `events.md` / `time-and-space.md` 갱신 (§9)
+- [ ] Slice 0~7 회귀 · Ruff · Mypy 통과
+
+## 8. 후속 이슈 (이번 스펙 범위 밖 — 별도 정의)
+
+1. **자동 야간 전환 / APScheduler** — 이번 MVP는 수동 `POST .../night/skip` +
+   `advance_manual_tick` 통합만 구현한다. 야간 대기 시간 설정값은 도입하지 않는다.
+   자동 전환 추가 시 §4.2 "야간 전환 로직"을 그대로 재사용한다.
+2. **야간 회복 Policy 수치** — 야간 스킵 시 피로도 / 스트레스 등 회복량. MVP에서는
+   정의하지 않으며 야간 전환은 상태값을 변경하지 않는다(회복량 0). 별도 후속 이슈
+   에서 정의하고, 그때 §4.2 "야간 전환 로직" 안에 회복 단계를 추가한다.
+
+## 9. 기존 문서 정합화 대상 (이 스펙과 직접 충돌하는 조항만)
+
+이 Feature Spec을 구현 계약 단일 기준으로 삼는다. 구현 단계에서 아래만 이 스펙에
+맞춘다. 그 외 기존 문서 문장은 수정하지 않는다.
+
+**갱신 (이 스펙 완료 기준에 포함)**
+
+| 문서 | 현재 | 이 스펙 기준으로 |
+|---|---|---|
+| `docs/00-start-here/what-is-pending.md` | "이벤트 발생 빈도 \| 미정" 행 | 확정으로 이동. 비고: "Issue #182 — `event_frequency` low/medium/high = 하루 최대 1/2/2, Tick당 1. 계약: `docs/04-feature-specs/mvp-tick-event-policy.md`". "tick 3블록 시간대 상세" 행은 그대로 둔다 (블록 시각 범위 · 블록별 Event 매핑은 이 스펙 범위 밖). |
+| `docs/02-domain/events.md` | "### 사건 발생 빈도 > **미정** — Time Tick 최종 확정과 함께 결정 예정" | 확정 문구로 교체 + 이 Feature Spec 참조. 사건 목록·분류 표는 변경 없음. |
+| `docs/02-domain/time-and-space.md` | "> **미정**: 이벤트 발생 빈도 → `what-is-pending.md`" (Tick 정의 아래) | 확정 참조로 교체. "> **미정**: 각 블록 세부 시간 범위 및 Event 매핑" 주석은 그대로 둔다. |
+
+**정합화 필요 (별도 후속 — 이 스펙이 계약이며, 아래 문서를 이 스펙에 맞춘다)**
+
+| 문서 | 현재 | 충돌 |
+|---|---|---|
+| `docs/03-system-design/event-master.md` §4.3 빈도 표 | `high` 하루 최대 **3** | 이 스펙: `high` 하루 최대 **2**. (확률 25/50/75%, Tick당 1은 동일.) |
+| `docs/03-system-design/event-master.md` §4.3 영향도 불릿 + 검증 P6 | "동일 Agent는 하루에 high 영향도 Event 최대 1회 … 초과 후보는 **medium으로 낮추거나 생성하지 않는다**" | 이 스펙: 초과 시 **해당 Agent만 참여 후보에서 제외**, Event를 medium으로 하향하지 않음. |
+| `docs/03-system-design/event-master.md` §4.3 쿨다운(P4) | "동일 유형·조합 후보 제외" (범위가 느슨함) | 이 스펙 §4.4로 정밀화: 동적 Event 참여자 선정 단계, `event_type`별 독립, 예정 Event 무관, `N` = 직전 참여 Event impact의 0/1/3 Tick. |
+
+**보고만 (이 스펙의 문서 갱신 범위 밖 — 별도 처리 필요)**
+
+- `docs/03-system-design/architecture.md:88` "밤 시간대: tick 번호만 전진"이
+  `tick-engine.md:40` "Tick 번호 증가 없이 current_day + 1"과 모순. 이 스펙은
+  tick-engine.md(v2.2, 사용자 확인)를 따른다.
+- `docs/02-domain/world-setting.md:246` "저녁 블록 이후 다음 날 아침으로 자동 전환"
+  은 자동 전환을 전제하나 이번 MVP는 수동 `night/skip` + `advance_manual_tick` 통합
+  만 구현한다 (§8-1). 자동 전환은 후속.
+
+## 10. 관련 문서
+
+- `docs/02-domain/time-and-space.md`, `docs/02-domain/events.md`,
+  `docs/02-domain/agents.md`
+- `docs/03-system-design/tick-engine.md`, `docs/03-system-design/event-master.md`,
+  `docs/03-system-design/policy-engine.md`
+- `docs/04-feature-specs/FR-01-agent-state-policy.md`,
+  `docs/04-feature-specs/slice-5-integration.md`
+- `docs/00-start-here/what-is-pending.md`
+- GitHub Issue #182
+
+## 변경 이력
+
+| 버전 | 날짜 | 변경 내용 |
+|---|---|---|
+| 0.1.0 | 2026-08-27 | 최초 초안. Tick 시간 구조 계약 고정, 야간 스킵 / 다음 날 전환(`night_waiting` 필드 + `POST /night/skip`), `event_frequency` 빈도 정책(하루 최대 2), `event_impact` 영향도 정책, config_version 생명주기 확정. |
+| 0.2.0 | 2026-08-27 | 구현 전 최종 검토 반영. (1) night/skip 멱등성을 `current_day` vs `derived_day` 비교로 정의 — EVENING 직후 `night_waiting=false` 상태 불일치를 409로 분리, §3.1 상태·응답 매트릭스 추가. (2) `advance_manual_tick`이 `night_waiting=true`에서 야간 전환을 먼저 수행하도록 통합 정의(회귀 무결). (3) `event_impact` 쿨다운을 "동적 Event 참여자 선정 단계, `event_type`별 독립, 예정 Event 무관, N=직전 참여 impact의 0/1/3 Tick"으로 정밀화. (4) 빈도 확률 시드 알고리즘 · 배율 정수화 규칙(`round`) 명시. (5) config_version "Tick 시작 시 고정" wiring 및 스냅샷 기록 변경점 명시. (6) §9에 event-master.md §4.3 정합화 대상 3건 명시. |
+| 0.3.0 | 2026-08-27 | §4.5를 API 생명주기로 확장. Draft(`ready`) `PUT /simulations/{id}/parameters`와 실행 중(`running`/`paused`) `PATCH /simulations/{id}/parameters`를 각각 명문화 — 본문 필드, 새 `config_version` 생성, 현재 Tick은 시작 시 고정 version으로 완료, `effective_tick`(= 다음 Tick) 정의, Tick 실행 중이라는 이유만으로 PATCH를 409로 거부하지 않음, `PATCH`는 `magic_enabled`/Magic 파라미터 미변경. §4.5.4 흐름 요약 블록 추가. §2·§7 항목 보강. 기존 3.11 API 계약은 코드로 변경하지 않음. |


### PR DESCRIPTION
## 작업 개요

MVP 범위에 있으나 Slice 0~7에서 빠져 있던 세 가지 백엔드 규칙을 구현한다.

1. Tick 시간 구조(MORNING/AFTERNOON/EVENING · 24분=1일) 계약 고정
2. 저녁 블록 이후 야간 스킵 → 다음 날 아침 전환 (수동 경로)
3. `event_frequency` / `event_impact` 파라미터를 실제 동적 Event 생성 빈도·효과 크기에 반영

계약 문서: `docs/04-feature-specs/mvp-tick-event-policy.md` (이번 PR에 포함, 사전 리뷰·확정 완료).

## 관련 Issue

Related to #182

## 변경 내용

**야간 스킵 / 다음 날 전환 (§4.2)**
- `Simulation.night_waiting` 컬럼 추가 + Alembic 마이그레이션 `20260827_0013` (`server_default=false`, 단일 head 유지)
- `app/services/night_transition.py` 신규 — `apply_night_transition`(수동·자동 공용: `current_tick` 불변, `current_day += 1`, 플래그 해제, 야간 회복은 MVP no-op) + `skip_night`(§3.1 상태·응답 매트릭스: advisory lock → status → `night_waiting` → `current_day == derived_day + 1` 멱등 판별)
- `POST /simulations/{simulation_id}/night/skip` 엔드포인트 — 200 `{"data":{id,status,current_day,current_tick}}`, 전환 성공 시에만 `SIMULATION_STATUS_UPDATED` 브로드캐스트, 409/422 JSON 봉투(`advance_tick`와 동일 스타일)
- `advance_manual_tick` 통합 — 시작 시 `night_waiting`이면 야간 전환 선행 후 MORNING Tick 진행, EVENING Tick commit 시 `night_waiting = true`

**Event 발생 빈도 (§4.3)**
- `EventMaster.generate`에 빈도 게이트 추가 — 확률(25/50/75%)·일일 상한(1/2/2)·Tick당 동적 1개 상한. 확률 판정 시드 = `f"{simulation_id}:{tick}:{config_version}"`의 SHA-256 → `random.Random`
- `frequency_seed`가 없으면 기존 동작(정책 미적용) 유지 — Slice 5 단위 계약 보존
- `app/services/event_frequency_history.py` 신규 — 당일 동적 누적·쿨다운·당일 high 참여 이력을 기존 `events`/`event_participants`에서 재구성 (신규 저장소 없음)

**Event 영향도 (§4.4)**
- 동적 Event importance(30/50/80)·참여 Agent 상한(2/4/5)을 `event_impact`로 설정
- 효과 강도 배율: `build_event_effect_candidates`에서 `round(base_delta × {0.5,1.0,1.5})` 후 기존 clamp
- 동일 참여자 쿨다운(0/1/3 Tick, `event_type`별 독립, 참여자 선정 단계) · 동일 Agent 당일 high 참여 시 해당 Agent만 제외(Event 하향 없음)

**파라미터 생명주기 / config_version (§4.5)**
- `advance_manual_tick`이 Tick 시작 시 `SimulationConfig.latest()`를 읽어 그 Tick 동안 고정
- `SimulationSnapshotService.create_snapshot(db, simulation, config=None)` — 고정 config를 받아 스냅샷에 기록(기존은 "종료 시 latest")
- `EventParameters` 스냅샷 객체로 `run_event_and_magic_phase` 관통

**문서**
- `docs/04-feature-specs/mvp-tick-event-policy.md` 신규 (v0.3.0)

**테스트**
- `tests/test_mvp_tick_event_policy.py` — 단위 41개 (DB 불필요)
- `tests/test_mvp_tick_event_policy_db.py` — DB 통합 9개 (`skipif TEST_DATABASE_URL`)

## 결정 사항 및 이유

- **`night_waiting`를 별도 boolean 컬럼으로** — EVENING 블록 여부만으로 야간 대기를 추론하면 "정상 전환 완료(B)"와 "EVENING 직후 상태 불일치(C)"를 구분할 수 없다. `current_day == derived_day + 1` 비교로 B를 멱등 200, C를 409로 분리한다(추가 컬럼·idempotency key 없이).
- **`advance_manual_tick`을 `night_waiting`으로 차단하지 않고 통과** — 차단하면 순차 advance만 하는 기존 Slice 회귀 테스트가 EVENING 경계마다 깨진다. EVENING 다음 Tick의 `tick_position().day`가 이미 +1이므로 야간 전환을 관통시키면 `current_tick`/`current_day` 진행값이 기존과 동일하다.
- **`frequency_seed=None`이면 빈도 정책 미적용** — Event Master 단위 테스트(Slice 5)는 결정론적 생성을 전제한다. 시드가 없는 호출(설정 없는 시뮬레이션·단위 테스트)은 기존 경로를 그대로 탄다.
- **`high` 일일 상한 = 2** (event-master.md §4.3의 3이 아님), **high 초과 시 Event 하향 없이 해당 Agent만 제외** — Issue #182의 "하루 1~2회" 및 확정 정책에 맞춤. 관련 설계 문서(`event-master.md §4.3`) 정합화는 계약 문서 §9에 후속으로 명시.
- **이력은 신규 테이블 없이 `events`+`event_participants`에서 역산** — 코드베이스의 기존 패턴(`_reconstruct_recent_stress`)을 따름.

## 테스트 / 확인 내용

- [x] 로컬 단위/비-DB 테스트 — `pytest -q tests` → **525 passed, 203 skipped**
- [x] 정적 검증 — mypy(CI 대상 `tick_engine`/`memory_repository`/`manual_tick`/`memory_adapter`) 통과, ruff(신규 파일) 클린
- [x] Alembic — `alembic heads` 단일 head, `20260827_0012` → `0013` 선형
- [ ] **DB 통합 테스트(203 skipped)는 로컬 미실행** — 로컬 Postgres 없음(Docker 엔진 미기동). CI(`backend-e2e.yml`, `alembic upgrade head` + Postgres)에서 최초 검증. 신규 DB 테스트 9개 포함
- [x] 관련 문서 업데이트 — `docs/04-feature-specs/mvp-tick-event-policy.md` (§9의 `what-is-pending.md`/`events.md`/`time-and-space.md` 갱신 및 `event-master.md §4.3` 정합화는 별도 후속)

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: 계약 문서 초안·검토, 구현, 테스트 작성
- 사람이 검토한 내용: 야간 스킵 멱등성 판별식(B/C 상태 구분), 빈도/영향도 정책 수치, `advance_manual_tick` 통합이 기존 Tick 진행값을 바꾸지 않는지, 회귀 영향 범위

## 리뷰어가 봐야 할 부분

- **[Question] `test_slice5_tick10_campaign` 회귀** — 캠페인은 `SimulationConfig` 없이 `Simulation`을 직접 만들므로 1회차(sim tick 10)는 `pinned_config=None` → 빈도 정책 미적용 → `GROUP_PROJECT` 단언을 만족한다고 판단. 2회차부터 v1(medium) 게이트가 걸리므로 CI 결과 확인 필요.
- **`night_transition.skip_night`의 §3.1 매트릭스** — 특히 C 상태(EVENING인데 `night_waiting=false`) 409 처리와 advisory lock 실패 시 409.
- **`event_frequency_history.build_event_parameters`의 JSONB 조회** — `Event.event_metadata["tick"]/["impact_level"]` 접근, `simulation_day` 기준 당일 판정.
- **`event_policy.build_event_effect_candidates`의 배율 적용 위치** — `EVENT_BASE_EFFECTS` 소비 지점에서 `round()` 후 기존 Conflict Resolver clamp. `event_impact=medium`(×1.0)은 기존 값과 동일(회귀 무결).
- **`create_snapshot` 시그니처 변경** — 기존 호출부(`create_simulation`)는 `config=None` 기본값으로 동작 유지.
- 마이그레이션 `night_waiting` 백필(`false`)이 EVENING 직후였던 기존 시뮬레이션에 미치는 영향(§6.1 주석 참고).