### PR TITLE
[Feature] Magic 파라미터 설정 및 실행 전 잠금 구현

### DIFF
--- a/backend/alembic/versions/20260828_0001_add_magic_layer_params.py
+++ b/backend/alembic/versions/20260828_0001_add_magic_layer_params.py
@@ -1,0 +1,61 @@
+"""add simulation_configs.magic_layer_frequency / magic_layer_impact
+
+Revision ID: 20260828_0001
+Revises: 20260827_0013
+
+Magic Layer 초기 파라미터(빈도·영향도)를 기존 버전형 ``simulation_configs`` 테이블에
+컬럼으로 추가한다. 별도 테이블/스냅샷을 만들지 않고 ``event_frequency`` /
+``event_impact`` 와 동일한 저장·버전·스냅샷 경로를 그대로 재사용한다
+(docs/01-product/simulation-parameters.md §2).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260828_0001"
+down_revision = "20260827_0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "simulation_configs",
+        sa.Column(
+            "magic_layer_frequency",
+            sa.String(length=10),
+            nullable=False,
+            server_default="medium",
+        ),
+    )
+    op.add_column(
+        "simulation_configs",
+        sa.Column(
+            "magic_layer_impact",
+            sa.String(length=10),
+            nullable=False,
+            server_default="medium",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_simulation_configs_magic_layer_frequency",
+        "simulation_configs",
+        "magic_layer_frequency IN ('low', 'medium', 'high')",
+    )
+    op.create_check_constraint(
+        "ck_simulation_configs_magic_layer_impact",
+        "simulation_configs",
+        "magic_layer_impact IN ('low', 'medium', 'high')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_simulation_configs_magic_layer_impact", "simulation_configs", type_="check"
+    )
+    op.drop_constraint(
+        "ck_simulation_configs_magic_layer_frequency", "simulation_configs", type_="check"
+    )
+    op.drop_column("simulation_configs", "magic_layer_impact")
+    op.drop_column("simulation_configs", "magic_layer_frequency")

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator
 
 
 class RegisterRequest(BaseModel):
@@ -64,6 +64,14 @@ class SimulationResponse(BaseModel):
     current_tick: int
     magic_enabled: bool
     created_at: datetime
+    # 최신 simulation_config 파라미터 (없으면 None — 별도 GET /parameters 를 만들지
+    # 않고 기존 Simulation 조회 응답을 확장한다, simulation-parameters.md §10).
+    event_frequency: str | None = None
+    event_impact: str | None = None
+    magic_layer_frequency: str | None = None
+    magic_layer_impact: str | None = None
+    magic_off_eligible: bool | None = None
+    config_version: int | None = None
 
 
 class SimulationConfigPutRequest(BaseModel):
@@ -71,7 +79,9 @@ class SimulationConfigPutRequest(BaseModel):
 
     event_frequency: str
     event_impact: str
-    magic_enabled: bool
+    magic_layer_frequency: str = "medium"
+    magic_layer_impact: str = "medium"
+    magic_enabled: StrictBool
 
 
 class SimulationConfigPatchRequest(BaseModel):

--- a/backend/app/api/simulation_history.py
+++ b/backend/app/api/simulation_history.py
@@ -26,10 +26,12 @@ from app.services.simulation_replay import (
 from app.services.simulation_snapshots import (
     InitialSettingsLockedError,
     InvalidSimulationConfigError,
+    MagicOffNotEligibleError,
     SimulationConfigInput,
     SimulationSettingsLockedError,
     SimulationSnapshotService,
     UnsupportedSnapshotSchemaError,
+    magic_off_eligible,
 )
 
 
@@ -92,12 +94,17 @@ def _owned_simulation(db: Session, simulation_id: UUID, user: User) -> Simulatio
     return simulation
 
 
-def _config_data(config) -> dict[str, Any]:
+def _config_data(config, simulation: Simulation) -> dict[str, Any]:
     return {
         "event_frequency": config.event_frequency,
         "event_impact": config.event_impact,
+        "magic_layer_frequency": config.magic_layer_frequency,
+        "magic_layer_impact": config.magic_layer_impact,
         "magic_enabled": config.magic_enabled,
+        "magic_off_eligible": magic_off_eligible(config.magic_layer_impact),
         "config_version": config.version,
+        # 실행 중 PATCH 로 바뀐 값이 실제 적용되는 Tick (= 다음 Tick).
+        "effective_tick": simulation.current_tick + 1,
         "changed_at": config.created_at.isoformat(),
     }
 
@@ -111,16 +118,20 @@ def _save_config(
         config = snapshot_service.save_config(db, simulation, config_input)
         db.commit()
         db.refresh(config)
+        db.refresh(simulation)
     except SimulationSettingsLockedError as exc:
         db.rollback()
         raise Slice6APIError(409, "SIMULATION_SETTINGS_LOCKED", str(exc)) from exc
     except InitialSettingsLockedError as exc:
         db.rollback()
         raise Slice6APIError(409, "INITIAL_SETTINGS_LOCKED", str(exc)) from exc
+    except MagicOffNotEligibleError as exc:
+        db.rollback()
+        raise Slice6APIError(409, "CONFLICT", str(exc)) from exc
     except InvalidSimulationConfigError as exc:
         db.rollback()
         raise Slice6APIError(400, "INVALID_REPLAY_REQUEST", str(exc)) from exc
-    return JSONResponse(content={"data": _config_data(config)})
+    return JSONResponse(content={"data": _config_data(config, simulation)})
 
 
 @router.put("/{simulation_id}/parameters")
@@ -138,6 +149,8 @@ def put_parameters(
         SimulationConfigInput(
             event_frequency=request.event_frequency,
             event_impact=request.event_impact,
+            magic_layer_frequency=request.magic_layer_frequency,
+            magic_layer_impact=request.magic_layer_impact,
             magic_enabled=request.magic_enabled,
             user_persona_settings=(latest.user_persona_settings if latest else {}),
             policy_version=(latest.policy_version if latest else None),
@@ -163,6 +176,10 @@ def patch_parameters(
         SimulationConfigInput(
             event_frequency=request.event_frequency,
             event_impact=request.event_impact,
+            # Magic 파라미터는 PATCH 로 바꿀 수 없다 — 항상 최신 값을 그대로 이어간다
+            # (요청 본문에 Magic 필드가 오면 스키마 extra="forbid" 로 이미 거부됨).
+            magic_layer_frequency=latest.magic_layer_frequency,
+            magic_layer_impact=latest.magic_layer_impact,
             magic_enabled=latest.magic_enabled,
             user_persona_settings=latest.user_persona_settings,
             policy_version=latest.policy_version,

--- a/backend/app/api/simulations.py
+++ b/backend/app/api/simulations.py
@@ -13,10 +13,12 @@ from app.core.database import get_db
 from app.core.security import require_user_role
 from app.domain.models import User
 from app.repositories.event_results import get_event_result
+from app.repositories.simulation_snapshots import SimulationConfigRepository
 from app.services.realtime_events import (
     build_simulation_status_event,
     connection_manager,
 )
+from app.services.simulation_snapshots import magic_off_eligible
 from app.services.simulations import (
     InvalidSimulationStatusTransitionError,
     create_simulation,
@@ -58,7 +60,20 @@ def get_one(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_user_role),
 ) -> SimulationResponse:
-    return SimulationResponse.model_validate(require_owned_simulation(db, simulation_id, current_user))
+    simulation = require_owned_simulation(db, simulation_id, current_user)
+    response = SimulationResponse.model_validate(simulation)
+    # 별도 GET /parameters 를 만들지 않고 기존 Simulation 조회 응답에 최신
+    # simulation_config 파라미터를 실어 준다 (PR2 스펙 §10).
+    config = SimulationConfigRepository().latest(db, simulation.id)
+    if config is not None:
+        response.event_frequency = config.event_frequency
+        response.event_impact = config.event_impact
+        response.magic_layer_frequency = config.magic_layer_frequency
+        response.magic_layer_impact = config.magic_layer_impact
+        response.magic_enabled = config.magic_enabled
+        response.magic_off_eligible = magic_off_eligible(config.magic_layer_impact)
+        response.config_version = config.version
+    return response
 
 
 @router.patch("/{simulation_id}/status", response_model=SimulationResponse)

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -83,6 +83,14 @@ class SimulationConfig(TimestampMixin, Base):
             "event_impact IN ('low', 'medium', 'high')",
             name="ck_simulation_configs_event_impact",
         ),
+        CheckConstraint(
+            "magic_layer_frequency IN ('low', 'medium', 'high')",
+            name="ck_simulation_configs_magic_layer_frequency",
+        ),
+        CheckConstraint(
+            "magic_layer_impact IN ('low', 'medium', 'high')",
+            name="ck_simulation_configs_magic_layer_impact",
+        ),
     )
 
     id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
@@ -92,6 +100,12 @@ class SimulationConfig(TimestampMixin, Base):
     version: Mapped[int] = mapped_column(Integer, nullable=False)
     event_frequency: Mapped[str] = mapped_column(String(10), nullable=False)
     event_impact: Mapped[str] = mapped_column(String(10), nullable=False)
+    magic_layer_frequency: Mapped[str] = mapped_column(
+        String(10), nullable=False, server_default="medium"
+    )
+    magic_layer_impact: Mapped[str] = mapped_column(
+        String(10), nullable=False, server_default="medium"
+    )
     magic_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False)
     policy_version: Mapped[str | None] = mapped_column(String(100))
     resolver_version: Mapped[str | None] = mapped_column(String(100))

--- a/backend/app/repositories/simulation_snapshots.py
+++ b/backend/app/repositories/simulation_snapshots.py
@@ -70,6 +70,8 @@ class SimulationConfigRepository:
         user_persona_settings: dict[str, Any],
         policy_version: str | None,
         resolver_version: str | None,
+        magic_layer_frequency: str = "medium",
+        magic_layer_impact: str = "medium",
     ) -> SimulationConfig:
         session.execute(
             select(Simulation.id).where(Simulation.id == simulation.id).with_for_update()
@@ -88,6 +90,8 @@ class SimulationConfigRepository:
             version=version,
             event_frequency=event_frequency,
             event_impact=event_impact,
+            magic_layer_frequency=magic_layer_frequency,
+            magic_layer_impact=magic_layer_impact,
             magic_enabled=magic_enabled,
             policy_version=policy_version,
             resolver_version=resolver_version,

--- a/backend/app/services/event_frequency_history.py
+++ b/backend/app/services/event_frequency_history.py
@@ -18,6 +18,14 @@ from app.services.event_magic_phase import EventParameters
 # events.event_type은 소문자로 저장된다 (persist_event_batch).
 _DYNAMIC_EVENT_TYPES: tuple[str, ...] = ("group_project", "meeting")
 _COOLDOWN_TICKS_BY_IMPACT: dict[str, int] = {"low": 0, "medium": 1, "high": 3}
+# Magic Layer 특수 사건 (magic_layer.py SPECIAL_EVENT_PRIORITY 와 동일, 소문자).
+_MAGIC_EVENT_TYPES: tuple[str, ...] = (
+    "student_missing",
+    "curse_spread",
+    "magic_explosion",
+    "ritual_failure",
+    "magical_discovery",
+)
 
 
 def build_event_parameters(
@@ -45,6 +53,19 @@ def build_event_parameters(
             .where(
                 Event.simulation_id == simulation_id,
                 Event.event_type.in_(_DYNAMIC_EVENT_TYPES),
+                Event.simulation_day == current_day,
+            )
+        )
+        or 0
+    )
+
+    magic_daily_count = int(
+        db.scalar(
+            select(func.count())
+            .select_from(Event)
+            .where(
+                Event.simulation_id == simulation_id,
+                Event.event_type.in_(_MAGIC_EVENT_TYPES),
                 Event.simulation_day == current_day,
             )
         )
@@ -95,4 +116,9 @@ def build_event_parameters(
             key: frozenset(values) for key, values in cooldown_excluded.items()
         },
         high_impact_agent_ids_today=frozenset(high_impact_today),
+        magic_enabled=config.magic_enabled,
+        magic_frequency=config.magic_layer_frequency,
+        magic_impact=config.magic_layer_impact,
+        magic_frequency_seed=frequency_seed,
+        magic_daily_count=magic_daily_count,
     )

--- a/backend/app/services/event_magic_phase.py
+++ b/backend/app/services/event_magic_phase.py
@@ -23,6 +23,7 @@ from app.simulation.event_master import (
 from app.simulation.magic_layer import (
     AgentSnapshot as MagicAgentSnapshot,
     MagicLayer,
+    MagicLayerResult,
     SpecialEvent,
 )
 from app.simulation.policy.conflict import resolve_conflicts
@@ -39,6 +40,8 @@ class EventAndMagicResult:
     special_events: tuple[SpecialEvent, ...]
     resolved_effects: tuple[EffectCandidate, ...]
     reflection_eligible_event_keys: tuple[str, ...]
+    # 이 Tick에 적용된 Magic Layer 영향도 (특수 Event 기록용).
+    magic_impact: str = "medium"
 
 
 REFLECTION_IMPORTANCE_THRESHOLD = 70
@@ -53,9 +56,11 @@ IMPACT_MULTIPLIER_BY_NAME: dict[str, float] = {
 
 @dataclass(frozen=True)
 class EventParameters:
-    """이번 Tick에 고정된 Event 파라미터 스냅샷 (mvp-tick-event-policy.md §4.3–§4.5).
+    """이번 Tick에 고정된 Event/Magic 파라미터 스냅샷 (mvp-tick-event-policy.md
+    §4.3–§4.5, simulation-parameters.md §4).
 
-    ``frequency_seed``가 ``None``이면 Event Master는 빈도 정책 없이 기존처럼 동작한다.
+    ``frequency_seed``가 ``None``이면 Event Master는 빈도 정책 없이 기존처럼 동작하고,
+    ``magic_frequency_seed``가 ``None``이면 Magic Layer도 빈도 게이트 없이 동작한다.
     """
 
     event_frequency: str = "medium"
@@ -64,6 +69,12 @@ class EventParameters:
     daily_dynamic_count: int = 0
     cooldown_excluded_agent_ids: Mapping[str, frozenset[str]] = field(default_factory=dict)
     high_impact_agent_ids_today: frozenset[str] = frozenset()
+    # Magic Layer 파라미터 (실행 전 고정 — simulation-parameters.md §5).
+    magic_enabled: bool = True
+    magic_frequency: str = "medium"
+    magic_impact: str = "medium"
+    magic_frequency_seed: str | None = None
+    magic_daily_count: int = 0
 
 
 def run_event_and_magic_phase(
@@ -92,14 +103,25 @@ def run_event_and_magic_phase(
         cooldown_excluded_agent_ids=dict(params.cooldown_excluded_agent_ids),
         high_impact_agent_ids_today=params.high_impact_agent_ids_today,
     )
-    magic_result = MagicLayer().evaluate(
-        tick=tick,
-        regular_events=events,
-        agent_snapshots=magic_agent_snapshots,
-        relationship_snapshots=magic_relationship_snapshots,
-        lab_location_ids=lab_location_ids,
-    )
+    if params.magic_enabled:
+        magic_result = MagicLayer().evaluate(
+            tick=tick,
+            regular_events=events,
+            agent_snapshots=magic_agent_snapshots,
+            relationship_snapshots=magic_relationship_snapshots,
+            lab_location_ids=lab_location_ids,
+            magic_frequency=params.magic_frequency,
+            magic_frequency_seed=params.magic_frequency_seed,
+            magic_daily_count=params.magic_daily_count,
+        )
+    else:
+        # magic_enabled=false — 이 실행에서는 Magic Layer 특수 사건을 호출하지
+        # 않는다 (simulation-parameters.md §2). 일반 Event 변환은 그대로 통과.
+        magic_result = MagicLayerResult(
+            converted_events=tuple(events), special_events=()
+        )
     impact_multiplier = IMPACT_MULTIPLIER_BY_NAME.get(params.event_impact, 1.0)
+    magic_impact_multiplier = IMPACT_MULTIPLIER_BY_NAME.get(params.magic_impact, 1.0)
     event_candidates = [
         candidate
         for event in magic_result.converted_events
@@ -111,13 +133,17 @@ def run_event_and_magic_phase(
         )
     ]
     magic_candidates = build_magic_effect_candidates(
-        magic_result.special_events, run_id=run_id, agent_snapshots=agent_state_snapshots
+        magic_result.special_events,
+        run_id=run_id,
+        agent_snapshots=agent_state_snapshots,
+        impact_multiplier=magic_impact_multiplier,
     )
     resolved = resolve_conflicts([*event_candidates, *magic_candidates])
     return EventAndMagicResult(
         events=magic_result.converted_events,
         special_events=magic_result.special_events,
         resolved_effects=tuple(resolved),
+        magic_impact=params.magic_impact,
         reflection_eligible_event_keys=tuple(
             [
                 event.event_key

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import secrets
-from typing import cast
+from typing import Literal, cast
 from uuid import UUID
 
 from sqlalchemy import select, text
@@ -411,6 +411,13 @@ def _build_event_batch(
         )
         for event in result.events
     ]
+    # Magic Layer 특수 Event 의 impact_level / importance 는 이 Tick 에 고정된
+    # magic_layer_impact 를 따른다 (simulation-parameters.md §4 영향도 기준).
+    magic_importance_by_impact = {"low": 30, "medium": 50, "high": 80}
+    magic_impact_level = cast(
+        Literal["low", "medium", "high"], result.magic_impact
+    )
+    magic_importance = magic_importance_by_impact.get(magic_impact_level, 80)
     event_writes.extend(
         EventWrite(
             id=uuid7(),
@@ -422,8 +429,8 @@ def _build_event_batch(
             ),
             location_id=UUID(event.location_id),
             source="magic_layer",
-            impact_level="high",
-            importance=80,
+            impact_level=magic_impact_level,
+            importance=magic_importance,
         )
         for event in result.special_events
         if event.location_id is not None

--- a/backend/app/services/simulation_snapshots.py
+++ b/backend/app/services/simulation_snapshots.py
@@ -24,6 +24,11 @@ class InitialSettingsLockedError(InvalidSimulationConfigError):
     pass
 
 
+class MagicOffNotEligibleError(InvalidSimulationConfigError):
+    """``magic_enabled=false`` 요청이 OFF 조건(정규화 impact >= threshold)을
+    만족하지 못한 경우 (simulation-parameters.md §6, threshold=0.7)."""
+
+
 class SnapshotAccessDeniedError(PermissionError):
     pass
 
@@ -39,6 +44,19 @@ class UnsupportedSnapshotSchemaError(ValueError):
 ALLOWED_LEVELS = {"low", "medium", "high"}
 EVENT_CONFIGURABLE_STATUSES = {"ready", "running", "paused"}
 
+# Magic OFF 조건 (simulation-parameters.md §6 / PR2 스펙 §1·§6). threshold 는
+# 0.7 로 확정되어 있으며 임의로 바꾸지 않는다.
+MAGIC_OFF_IMPACT_THRESHOLD = 0.7
+NORMALIZED_MAGIC_IMPACT: dict[str, float] = {"low": 0.3, "medium": 0.5, "high": 0.8}
+
+
+def magic_off_eligible(magic_layer_impact: str) -> bool:
+    """해당 impact 수준에서 ``magic_enabled=false`` 를 허용할 수 있는지."""
+    return (
+        NORMALIZED_MAGIC_IMPACT.get(magic_layer_impact, 0.0)
+        >= MAGIC_OFF_IMPACT_THRESHOLD
+    )
+
 
 @dataclass(frozen=True)
 class SimulationConfigInput:
@@ -48,6 +66,8 @@ class SimulationConfigInput:
     user_persona_settings: dict[str, Any]
     policy_version: str | None = None
     resolver_version: str | None = None
+    magic_layer_frequency: str = "medium"
+    magic_layer_impact: str = "medium"
 
 
 class SimulationSnapshotService:
@@ -69,21 +89,40 @@ class SimulationSnapshotService:
             raise InvalidSimulationConfigError("invalid event_frequency")
         if config_input.event_impact not in ALLOWED_LEVELS:
             raise InvalidSimulationConfigError("invalid event_impact")
+        if config_input.magic_layer_frequency not in ALLOWED_LEVELS:
+            raise InvalidSimulationConfigError("invalid magic_layer_frequency")
+        if config_input.magic_layer_impact not in ALLOWED_LEVELS:
+            raise InvalidSimulationConfigError("invalid magic_layer_impact")
         latest = self.configs.latest(session, simulation.id)
         if simulation.status != "ready":
+            # Simulation Start 이후에는 Magic 파라미터(빈도·영향도·ON/OFF)와
+            # persona 설정을 잠근다 (simulation-parameters.md §5, PR2 스펙 §5).
+            # 잠금은 값 검증(OFF 조건)보다 우선한다 — 실행 후 어떤 Magic 변경도
+            # 거부한다.
             if latest is None or (
                 config_input.magic_enabled != latest.magic_enabled
+                or config_input.magic_layer_frequency != latest.magic_layer_frequency
+                or config_input.magic_layer_impact != latest.magic_layer_impact
                 or config_input.user_persona_settings
                 != latest.user_persona_settings
             ):
                 raise InitialSettingsLockedError(
                     "initial settings are locked after simulation start"
                 )
+        if not config_input.magic_enabled and not magic_off_eligible(
+            config_input.magic_layer_impact
+        ):
+            raise MagicOffNotEligibleError(
+                "magic_enabled=false requires magic_layer_impact to meet the "
+                f"OFF threshold ({MAGIC_OFF_IMPACT_THRESHOLD})"
+            )
         return self.configs.create_version(
             session,
             simulation,
             event_frequency=config_input.event_frequency,
             event_impact=config_input.event_impact,
+            magic_layer_frequency=config_input.magic_layer_frequency,
+            magic_layer_impact=config_input.magic_layer_impact,
             magic_enabled=config_input.magic_enabled,
             user_persona_settings=config_input.user_persona_settings,
             policy_version=config_input.policy_version,

--- a/backend/app/simulation/magic_layer.py
+++ b/backend/app/simulation/magic_layer.py
@@ -14,11 +14,24 @@ EffectCandidates by the Event Policy Registry (app.simulation.policy.registries
 
 from __future__ import annotations
 
+import hashlib
+import random
 from collections.abc import Sequence
 from dataclasses import dataclass
 
 from app.simulation.event_master import Event
 from app.simulation.policy.models import RelationshipSnapshot
+
+# Magic Layer 빈도 파라미터 (simulation-parameters.md §4 / PR2 스펙 §2). 조건을
+# 충족한 후보에만 적용하며, 확률 판정 시드는 Event Master 와 동일하게
+# ``simulation_id:tick:config_version`` 구조를 재사용한다 (§5 Replay 재현성).
+MAGIC_FREQUENCY_PROBABILITY: dict[str, float] = {
+    "low": 0.25,
+    "medium": 0.50,
+    "high": 0.75,
+}
+MAGIC_DAILY_MAX: dict[str, int] = {"low": 1, "medium": 2, "high": 3}
+MAGIC_TICK_MAX = 1
 
 # magic-layer.md §3.2.1, §3.2.2 확정 우선순위.
 STUDENT_MISSING = "STUDENT_MISSING"
@@ -102,6 +115,15 @@ def _is_missing_candidate(snapshot: AgentSnapshot) -> bool:
     return hits >= STUDENT_MISSING_STREAK_REQUIRED
 
 
+def _frequency_allows(magic_frequency: str, frequency_seed: str) -> bool:
+    """빈도 확률 판정 — Event Master ``_dynamic_frequency_allows`` 와 동일한
+    seed → digest → ``random.Random`` 방식으로 Replay 시 결과가 재현된다."""
+    probability = MAGIC_FREQUENCY_PROBABILITY.get(magic_frequency, 0.50)
+    digest = hashlib.sha256(f"magic:{frequency_seed}".encode()).digest()
+    rng = random.Random(int.from_bytes(digest[:8], "big"))
+    return rng.random() < probability
+
+
 def _same_location_others(
     agent_id: str, location_id: str | None, snapshots: Sequence[AgentSnapshot]
 ) -> list[str]:
@@ -127,6 +149,9 @@ class MagicLayer:
         agent_snapshots: Sequence[AgentSnapshot],
         relationship_snapshots: Sequence[RelationshipSnapshot] = (),
         lab_location_ids: frozenset[str] = frozenset(),
+        magic_frequency: str = "medium",
+        magic_frequency_seed: str | None = None,
+        magic_daily_count: int = 0,
     ) -> MagicLayerResult:
         converted = tuple(self._convert(event) for event in regular_events)
         candidates = self._collect_candidates(
@@ -136,10 +161,41 @@ class MagicLayer:
             lab_location_ids=lab_location_ids,
         )
         selected = self._select_by_priority(candidates)
+        selected = self._apply_frequency_gate(
+            selected,
+            magic_frequency=magic_frequency,
+            magic_frequency_seed=magic_frequency_seed,
+            magic_daily_count=magic_daily_count,
+        )
         return MagicLayerResult(
             converted_events=converted,
-            special_events=tuple(selected) if selected is not None else (),
+            special_events=tuple(selected) if selected else (),
         )
+
+    @staticmethod
+    def _apply_frequency_gate(
+        selected: list[SpecialEvent] | None,
+        *,
+        magic_frequency: str,
+        magic_frequency_seed: str | None,
+        magic_daily_count: int,
+    ) -> list[SpecialEvent]:
+        """조건을 충족한 후보에 빈도 확률·일일 상한·Tick 상한을 적용한다.
+
+        ``magic_frequency_seed`` 가 ``None`` 이면(빈도 파라미터 미연결 경로)
+        기존처럼 조건 충족 후보를 그대로 통과시킨다.
+        """
+        if not selected:
+            return []
+        # Tick 당 최대 생성 수 (모든 수준 1개 — PR2 스펙 §2).
+        selected = selected[:MAGIC_TICK_MAX]
+        if magic_frequency_seed is None:
+            return selected
+        if magic_daily_count >= MAGIC_DAILY_MAX.get(magic_frequency, 2):
+            return []
+        if not _frequency_allows(magic_frequency, magic_frequency_seed):
+            return []
+        return selected
 
     @staticmethod
     def _convert(event: Event) -> Event:

--- a/backend/app/simulation/policy/registries/event_policy.py
+++ b/backend/app/simulation/policy/registries/event_policy.py
@@ -124,6 +124,7 @@ def _build_magic_signal_candidate(
     signal_type: StateSignalType,
     intensity: SignalIntensity,
     agent_snapshots: Mapping[str, AgentSnapshot],
+    impact_multiplier: float = 1.0,
 ) -> EffectCandidate | None:
     snapshot = agent_snapshots.get(agent_id)
     if snapshot is None:
@@ -137,7 +138,9 @@ def _build_magic_signal_candidate(
         StateSignalType.FATIGUE_UP: "fatigue",
     }[signal_type]
     current = _state_value(snapshot, metric)
-    delta = get_state_delta(signal_type, intensity)
+    # magic_layer_impact 효과 강도 배율 (low 0.5 / medium 1.0 / high 1.5 —
+    # simulation-parameters.md §4). event_impact 쪽과 동일하게 round 처리한다.
+    delta = round(get_state_delta(signal_type, intensity) * impact_multiplier)
     origin = special_event.participant_agent_ids[0] if special_event.participant_agent_ids else "-"
     return EffectCandidate(
         effect_id=(
@@ -161,6 +164,7 @@ def build_magic_effect_candidates(
     *,
     run_id: str,
     agent_snapshots: Mapping[str, AgentSnapshot],
+    impact_multiplier: float = 1.0,
 ) -> list[EffectCandidate]:
     """Magic Layer 특수 Event의 typed signal을 EffectCandidate로 변환한다.
 
@@ -181,6 +185,7 @@ def build_magic_effect_candidates(
                     signal_type=primary_rule[0],
                     intensity=primary_rule[1],
                     agent_snapshots=agent_snapshots,
+                    impact_multiplier=impact_multiplier,
                 )
                 if candidate is not None:
                     candidates.append(candidate)
@@ -192,6 +197,7 @@ def build_magic_effect_candidates(
                     signal_type=secondary_rule[0],
                     intensity=secondary_rule[1],
                     agent_snapshots=agent_snapshots,
+                    impact_multiplier=impact_multiplier,
                 )
                 if candidate is not None:
                     candidates.append(candidate)

--- a/backend/tests/test_magic_parameters.py
+++ b/backend/tests/test_magic_parameters.py
@@ -1,0 +1,210 @@
+"""PR2 — Magic 파라미터 연결 단위 테스트 (DB 불필요).
+
+계약: docs/01-product/simulation-parameters.md §4–§6, PR2 스펙.
+- Magic frequency 확률 게이트 (조건 충족 후보에만, seed 재현)
+- Magic impact 효과 강도 배율
+- magic_enabled=false OFF 조건 (threshold 0.7)
+"""
+
+import pytest
+
+from app.services.event_magic_phase import (
+    EventParameters,
+    run_event_and_magic_phase,
+)
+from app.services.simulation_snapshots import (
+    MAGIC_OFF_IMPACT_THRESHOLD,
+    NORMALIZED_MAGIC_IMPACT,
+    magic_off_eligible,
+)
+from app.simulation.magic_layer import (
+    MAGIC_DAILY_MAX,
+    MAGIC_FREQUENCY_PROBABILITY,
+    STUDENT_MISSING,
+    AgentSnapshot,
+    MagicLayer,
+)
+from app.simulation.policy.models import AgentSnapshot as PolicyAgentSnapshot
+from app.simulation.policy.registries.event_policy import build_magic_effect_candidates
+
+
+# ---------------------------------------------------------------------------
+# magic_off_eligible — OFF 조건 (simulation-parameters.md §6)
+# ---------------------------------------------------------------------------
+def test_magic_off_threshold_and_normalized_values_are_fixed():
+    assert MAGIC_OFF_IMPACT_THRESHOLD == 0.7
+    assert NORMALIZED_MAGIC_IMPACT == {"low": 0.3, "medium": 0.5, "high": 0.8}
+
+
+@pytest.mark.parametrize(
+    ("impact", "eligible"),
+    [("low", False), ("medium", False), ("high", True)],
+)
+def test_magic_off_eligible_only_for_high(impact, eligible):
+    assert magic_off_eligible(impact) is eligible
+
+
+# ---------------------------------------------------------------------------
+# Magic frequency 게이트 (PR2 스펙 §2)
+# ---------------------------------------------------------------------------
+def _missing_candidate(agent_id: str = "s1") -> AgentSnapshot:
+    return AgentSnapshot(
+        agent_id=agent_id,
+        agent_type="student",
+        active_status=True,
+        current_location_id="dormitory",
+        fatigue=10,
+        is_cursed=False,
+        recent_stress=tuple([95] * 10),
+    )
+
+
+def test_frequency_map_matches_spec():
+    assert MAGIC_FREQUENCY_PROBABILITY == {"low": 0.25, "medium": 0.50, "high": 0.75}
+    assert MAGIC_DAILY_MAX == {"low": 1, "medium": 2, "high": 3}
+
+
+def test_no_seed_keeps_legacy_behavior_all_condition_candidates_pass():
+    result = MagicLayer().evaluate(
+        tick=11, regular_events=[], agent_snapshots=[_missing_candidate()]
+    )
+    assert [e.event_subtype for e in result.special_events] == [STUDENT_MISSING]
+
+
+def test_frequency_gate_is_deterministic_for_same_seed():
+    kwargs = {
+        "tick": 11,
+        "regular_events": [],
+        "agent_snapshots": [_missing_candidate()],
+        "magic_frequency": "medium",
+        "magic_frequency_seed": "sim-1:11:1",
+    }
+    first = MagicLayer().evaluate(**kwargs)
+    second = MagicLayer().evaluate(**kwargs)
+    assert [e.event_subtype for e in first.special_events] == [
+        e.event_subtype for e in second.special_events
+    ]
+
+
+def test_frequency_gate_suppresses_more_at_low_than_at_high():
+    passed_low = 0
+    passed_high = 0
+    for i in range(200):
+        seed = f"sim:{i}:1"
+        if MagicLayer().evaluate(
+            tick=11,
+            regular_events=[],
+            agent_snapshots=[_missing_candidate()],
+            magic_frequency="low",
+            magic_frequency_seed=seed,
+        ).special_events:
+            passed_low += 1
+        if MagicLayer().evaluate(
+            tick=11,
+            regular_events=[],
+            agent_snapshots=[_missing_candidate()],
+            magic_frequency="high",
+            magic_frequency_seed=seed,
+        ).special_events:
+            passed_high += 1
+    # low(25%) 는 일부를 차단하고, high(75%) 는 low 보다 더 많이 통과시킨다.
+    assert 0 < passed_low < 200
+    assert passed_high > passed_low
+
+
+def test_daily_cap_blocks_when_reached():
+    result = MagicLayer().evaluate(
+        tick=11,
+        regular_events=[],
+        agent_snapshots=[_missing_candidate()],
+        magic_frequency="low",
+        magic_frequency_seed="sim:seed-pass:1",
+        magic_daily_count=1,  # low 하루 최대 1 -> 이미 도달
+    )
+    assert result.special_events == ()
+
+
+def test_tick_cap_limits_to_one_special_event():
+    snaps = [_missing_candidate("s1"), _missing_candidate("s2")]
+    result = MagicLayer().evaluate(tick=11, regular_events=[], agent_snapshots=snaps)
+    # 후보가 2명이어도 Tick 당 최대 1개.
+    assert len(result.special_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Magic impact 배율 (PR2 스펙 §3)
+# ---------------------------------------------------------------------------
+def test_magic_impact_multiplier_scales_effect_delta():
+    from app.simulation.magic_layer import SpecialEvent
+
+    special = SpecialEvent(
+        event_subtype="MAGIC_EXPLOSION",
+        participant_agent_ids=("s1",),
+        location_id="lab",
+        tick=1,
+        title="마법 폭발",
+        affected_agent_ids=("s1",),
+    )
+    snapshot = {
+        "s1": PolicyAgentSnapshot(
+            agent_id="s1", hunger=0, fatigue=0, stress=0, satisfaction=0
+        )
+    }
+    base = build_magic_effect_candidates(
+        [special], run_id="r1", agent_snapshots=snapshot, impact_multiplier=1.0
+    )
+    high = build_magic_effect_candidates(
+        [special], run_id="r1", agent_snapshots=snapshot, impact_multiplier=1.5
+    )
+    base_stress = next(c for c in base if c.metric == "stress").delta
+    high_stress = next(c for c in high if c.metric == "stress").delta
+    assert high_stress == round(base_stress * 1.5)
+
+
+def test_magic_enabled_false_skips_special_events():
+    result = run_event_and_magic_phase(
+        run_id="r1",
+        tick=11,
+        agent_summaries=[],
+        agent_state_snapshots={},
+        magic_agent_snapshots=[
+            AgentSnapshot(
+                agent_id="s1",
+                agent_type="student",
+                active_status=True,
+                current_location_id="dormitory",
+                fatigue=10,
+                is_cursed=False,
+                recent_stress=tuple([95] * 10),
+            )
+        ],
+        event_parameters=EventParameters(magic_enabled=False),
+    )
+    assert result.special_events == ()
+
+
+def test_magic_enabled_true_still_emits_special_events_without_seed():
+    result = run_event_and_magic_phase(
+        run_id="r1",
+        tick=11,
+        agent_summaries=[],
+        agent_state_snapshots={
+            "s1": PolicyAgentSnapshot(
+                agent_id="s1", hunger=0, fatigue=10, stress=95, satisfaction=0
+            )
+        },
+        magic_agent_snapshots=[
+            AgentSnapshot(
+                agent_id="s1",
+                agent_type="student",
+                active_status=True,
+                current_location_id="dormitory",
+                fatigue=10,
+                is_cursed=False,
+                recent_stress=tuple([95] * 10),
+            )
+        ],
+        event_parameters=EventParameters(magic_enabled=True, magic_impact="low"),
+    )
+    assert [e.event_subtype for e in result.special_events] == [STUDENT_MISSING]
+    assert result.magic_impact == "low"

--- a/backend/tests/test_slice6_acceptance.py
+++ b/backend/tests/test_slice6_acceptance.py
@@ -130,6 +130,8 @@ def test_settings_snapshot_replay_restore_http_golden_path(acceptance_context) -
         json={
             "event_frequency": "high",
             "event_impact": "low",
+            # magic_enabled=false 는 magic_layer_impact=high 에서만 허용된다.
+            "magic_layer_impact": "high",
             "magic_enabled": False,
         },
     )

--- a/backend/tests/test_slice6_api.py
+++ b/backend/tests/test_slice6_api.py
@@ -122,6 +122,9 @@ def test_parameters_routes_and_error_contract(api_context) -> None:
         json={
             "event_frequency": "high",
             "event_impact": "low",
+            # magic_enabled=false 는 magic_layer_impact 가 OFF threshold(0.7) 를
+            # 만족할 때만 허용된다 (simulation-parameters.md §6).
+            "magic_layer_impact": "high",
             "magic_enabled": False,
         },
     )
@@ -132,8 +135,12 @@ def test_parameters_routes_and_error_contract(api_context) -> None:
     } == {
         "event_frequency": "high",
         "event_impact": "low",
+        "magic_layer_frequency": "medium",
+        "magic_layer_impact": "high",
         "magic_enabled": False,
+        "magic_off_eligible": True,
         "config_version": 2,
+        "effective_tick": 1,
     }
     assert put_data["changed_at"]
 
@@ -202,6 +209,159 @@ def test_parameters_routes_and_error_contract(api_context) -> None:
     )
     assert missing.status_code == 404
     assert missing.json()["error"]["code"] == "REPLAY_RESOURCE_NOT_FOUND"
+
+
+def test_magic_parameters_draft_validation_and_lock(api_context) -> None:
+    """PR2 §13·§14 — Magic 파라미터 저장/검증/실행 전 잠금."""
+    client, session_factory, _ = api_context
+    owner_headers = _register(client, "magic-param-owner")
+    simulation_id = _create_simulation(client, owner_headers, "Magic Params")
+
+    # 기본값 조회 — 부트스트랩 config v1 이 medium/medium/true 다.
+    default_get = client.get(
+        f"/v1/simulations/{simulation_id}", headers=owner_headers
+    )
+    assert default_get.status_code == 200
+    default_body = default_get.json()
+    assert default_body["magic_layer_frequency"] == "medium"
+    assert default_body["magic_layer_impact"] == "medium"
+    assert default_body["magic_enabled"] is True
+    assert default_body["magic_off_eligible"] is False
+
+    # Draft 에서 Magic 파라미터 저장.
+    saved = client.put(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "medium",
+            "event_impact": "medium",
+            "magic_layer_frequency": "high",
+            "magic_layer_impact": "low",
+            "magic_enabled": True,
+        },
+    )
+    assert saved.status_code == 200
+    saved_data = saved.json()["data"]
+    assert saved_data["magic_layer_frequency"] == "high"
+    assert saved_data["magic_layer_impact"] == "low"
+    assert saved_data["magic_off_eligible"] is False
+
+    # 저장값을 다시 조회할 수 있다 (기존 Simulation 응답 확장).
+    reread = client.get(f"/v1/simulations/{simulation_id}", headers=owner_headers)
+    assert reread.json()["magic_layer_frequency"] == "high"
+    assert reread.json()["magic_layer_impact"] == "low"
+    assert reread.json()["config_version"] == saved_data["config_version"]
+
+    # Validation — 잘못된 frequency / impact / boolean 타입.
+    for bad in (
+        {"magic_layer_frequency": "invalid"},
+        {"magic_layer_impact": "invalid"},
+    ):
+        resp = client.put(
+            f"/v1/simulations/{simulation_id}/parameters",
+            headers=owner_headers,
+            json={
+                "event_frequency": "medium",
+                "event_impact": "medium",
+                "magic_enabled": True,
+                **bad,
+            },
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_REPLAY_REQUEST"
+
+    bad_bool = client.put(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "medium",
+            "event_impact": "medium",
+            "magic_enabled": "true",
+        },
+    )
+    assert bad_bool.status_code == 400
+
+    # magic_enabled=false OFF 조건 위반 (impact 가 threshold 0.7 미만) -> 409 CONFLICT.
+    off_violation = client.put(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "medium",
+            "event_impact": "medium",
+            "magic_layer_impact": "low",
+            "magic_enabled": False,
+        },
+    )
+    assert off_violation.status_code == 409
+    assert off_violation.json()["error"]["code"] == "CONFLICT"
+
+    # magic_enabled=false + impact=high 는 허용.
+    off_ok = client.put(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "medium",
+            "event_impact": "medium",
+            "magic_layer_frequency": "high",
+            "magic_layer_impact": "high",
+            "magic_enabled": False,
+        },
+    )
+    assert off_ok.status_code == 200
+    assert off_ok.json()["data"]["magic_off_eligible"] is True
+
+    # ---- Simulation Start (running) 이후 Magic 잠금 ----
+    with session_factory.begin() as session:
+        session.get(Simulation, simulation_id).status = "running"
+
+    for locked_field in (
+        {"magic_layer_frequency": "low"},
+        {"magic_layer_impact": "medium"},
+        {"magic_enabled": True},
+    ):
+        resp = client.put(
+            f"/v1/simulations/{simulation_id}/parameters",
+            headers=owner_headers,
+            json={
+                "event_frequency": "medium",
+                "event_impact": "medium",
+                "magic_layer_frequency": "high",
+                "magic_layer_impact": "high",
+                "magic_enabled": False,
+                **locked_field,
+            },
+        )
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "INITIAL_SETTINGS_LOCKED"
+
+    # 실행 중 일반 Event 파라미터 PATCH 는 성공한다.
+    patched = client.patch(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={"event_frequency": "high", "event_impact": "high"},
+    )
+    assert patched.status_code == 200
+    assert patched.json()["data"]["effective_tick"] == 1
+    assert patched.json()["data"]["magic_layer_frequency"] == "high"
+    assert patched.json()["data"]["magic_enabled"] is False
+
+    # 실행 중 PATCH 요청에 Magic 필드가 포함되면 거부한다 (extra="forbid").
+    patch_magic = client.patch(
+        f"/v1/simulations/{simulation_id}/parameters",
+        headers=owner_headers,
+        json={
+            "event_frequency": "low",
+            "event_impact": "low",
+            "magic_layer_frequency": "low",
+        },
+    )
+    assert patch_magic.status_code == 400
+
+    # 잠금 실패 후에도 기존 Magic 값이 유지된다.
+    after = client.get(f"/v1/simulations/{simulation_id}", headers=owner_headers)
+    assert after.json()["magic_layer_frequency"] == "high"
+    assert after.json()["magic_layer_impact"] == "high"
+    assert after.json()["magic_enabled"] is False
 
 
 def test_snapshot_restore_and_mismatch_are_read_only(api_context) -> None:

--- a/backend/tests/test_slice6_persistence.py
+++ b/backend/tests/test_slice6_persistence.py
@@ -92,6 +92,8 @@ def test_config_versions_are_monotonic_and_flush_without_commit(
                 {"agent_id": "student-03"},
                 policy_version="policy-mvp-0.1",
                 resolver_version="resolver-mvp-0.1",
+                # magic_enabled=false 는 magic_layer_impact=high 에서만 허용된다.
+                magic_layer_impact="high",
             ),
         )
         assert (first.version, second.version) == (1, 2)

--- a/frontend/src/components/SettingsPanel.jsx
+++ b/frontend/src/components/SettingsPanel.jsx
@@ -4,6 +4,10 @@
 // ready 상태 (초기 설정 가능 상태) → saveDraftConfig (PUT, 전체 파라미터)
 // RUNNING/PAUSED 상태 → updateRunningConfig (PATCH, event_frequency/impact만)
 //
+// Magic Layer 파라미터(빈도·영향도·ON/OFF)는 실행 전(ready)에만 변경할 수 있고,
+// 실행이 시작되면 읽기 전용이다. 프론트의 disabled 처리는 UX용이며 실제 변경
+// 방지는 Backend(PR2 스펙 §5)에서 보장한다.
+//
 // App.jsx 컨벤션에 맞춰 token은 상위(App)에서 auth.access_token으로 전달받는다.
 
 import { useState } from "react";
@@ -19,11 +23,16 @@ export default function SettingsPanel({ token, simulationId, simulationStatus })
 
   const [eventFrequency, setEventFrequency] = useState("medium");
   const [eventImpact, setEventImpact] = useState("medium");
+  const [magicLayerFrequency, setMagicLayerFrequency] = useState("medium");
+  const [magicLayerImpact, setMagicLayerImpact] = useState("medium");
   const [magicEnabled, setMagicEnabled] = useState(true);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [savedAt, setSavedAt] = useState(null);
+
+  // 실행 후 Magic 입력은 읽기 전용 (Backend 잠금과 일치).
+  const magicLocked = !isReady;
 
   async function handleSubmit(event) {
     event.preventDefault();
@@ -36,6 +45,8 @@ export default function SettingsPanel({ token, simulationId, simulationStatus })
         const result = await saveDraftConfig(token, simulationId, {
           event_frequency: eventFrequency,
           event_impact: eventImpact,
+          magic_layer_frequency: magicLayerFrequency,
+          magic_layer_impact: magicLayerImpact,
           magic_enabled: magicEnabled,
         });
         setSavedAt(result?.changed_at);
@@ -88,16 +99,55 @@ export default function SettingsPanel({ token, simulationId, simulationStatus })
           </select>
         </label>
 
-        {isReady && (
+        <fieldset className="magic-layer-settings">
+          <legend>Magic Layer {magicLocked && <span aria-label="잠김">🔒</span>}</legend>
+
+          <label>
+            Magic 빈도
+            <select
+              value={magicLayerFrequency}
+              onChange={(e) => setMagicLayerFrequency(e.target.value)}
+              disabled={magicLocked}
+            >
+              {LEVELS.map((level) => (
+                <option key={level} value={level}>
+                  {level}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label>
+            Magic 영향도
+            <select
+              value={magicLayerImpact}
+              onChange={(e) => setMagicLayerImpact(e.target.value)}
+              disabled={magicLocked}
+            >
+              {LEVELS.map((level) => (
+                <option key={level} value={level}>
+                  {level}
+                </option>
+              ))}
+            </select>
+          </label>
+
           <label>
             <input
               type="checkbox"
               checked={magicEnabled}
               onChange={(e) => setMagicEnabled(e.target.checked)}
+              disabled={magicLocked}
             />
             Magic Layer 활성화
           </label>
-        )}
+
+          {magicLocked && (
+            <p className="message" role="status">
+              실행이 시작된 시뮬레이션의 Magic 설정은 변경할 수 없습니다.
+            </p>
+          )}
+        </fieldset>
 
         <button disabled={loading || !canSubmit}>
           {loading ? "저장 중..." : "설정 저장"}

--- a/frontend/src/components/SettingsPanel.test.jsx
+++ b/frontend/src/components/SettingsPanel.test.jsx
@@ -57,4 +57,57 @@ describe("SettingsPanel", () => {
     render(<SettingsPanel token="tok" simulationId="sim_01" simulationStatus="completed" />);
     expect(screen.getByRole("button", { name: "설정 저장" })).toBeDisabled();
   });
+
+  it("ready 상태 PUT 본문에 Magic Layer 파라미터를 포함한다", async () => {
+    let sentBody = null;
+    vi.spyOn(globalThis, "fetch").mockImplementationOnce((url, options) => {
+      sentBody = JSON.parse(options.body);
+      return response({ data: { changed_at: "2026-08-27T00:00:00Z" } });
+    });
+
+    render(<SettingsPanel token="tok" simulationId="sim_01" simulationStatus="ready" />);
+    await userEvent.click(screen.getByRole("button", { name: "설정 저장" }));
+    await screen.findByText(/설정이 저장되었습니다/);
+
+    expect(sentBody).toMatchObject({
+      magic_layer_frequency: "medium",
+      magic_layer_impact: "medium",
+      magic_enabled: true,
+    });
+  });
+
+  it("running 상태에서 Magic 입력은 읽기 전용이고 PATCH 본문에 Magic 필드가 없다", async () => {
+    let sentBody = null;
+    vi.spyOn(globalThis, "fetch").mockImplementationOnce((url, options) => {
+      sentBody = JSON.parse(options.body);
+      return response({ data: { changed_at: "2026-08-27T00:00:10Z" } });
+    });
+
+    render(<SettingsPanel token="tok" simulationId="sim_01" simulationStatus="running" />);
+
+    expect(screen.getByLabelText("Magic 빈도")).toBeDisabled();
+    expect(screen.getByLabelText("Magic 영향도")).toBeDisabled();
+    expect(screen.getByLabelText("Magic Layer 활성화")).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("button", { name: "설정 저장" }));
+    await screen.findByText(/설정이 저장되었습니다/);
+
+    expect(Object.keys(sentBody)).toEqual(["event_frequency", "event_impact"]);
+  });
+
+  it("Magic 잠금 오류(409)를 사용자에게 표시한다", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementationOnce(() =>
+      response(
+        { error: { code: "INITIAL_SETTINGS_LOCKED", message: "실행 후 Magic 설정을 변경할 수 없습니다" } },
+        409
+      )
+    );
+
+    render(<SettingsPanel token="tok" simulationId="sim_01" simulationStatus="ready" />);
+    await userEvent.click(screen.getByRole("button", { name: "설정 저장" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "실행 후 Magic 설정을 변경할 수 없습니다"
+    );
+  });
 });


### PR DESCRIPTION
## 작업 개요

Simulation 실행 전(ready)에 Magic Layer 초기 조건(magic_layer_frequency / magic_layer_impact / magic_enabled)을 설정할 수 있게 하고, Start(running/paused) 이후에는 서버에서 변경을 거부한다. 일반 Event 파라미터(event_frequency / event_impact)는 기존대로 running/paused에서도 변경 가능하며 변경값은 다음 Tick부터 적용된다.

새 구조를 만들지 않고 기존 simulation_configs 버전 테이블 · save_config 잠금 분기 · Tick config 고정 · Replay seed 유틸에 Magic 파라미터를 연결하는 방식으로 구현했다.

## 관련 Issue
Related to #182 

## 변경 내용

#### DB / 모델

simulation_configs에 magic_layer_frequency / magic_layer_impact 컬럼 + CHECK 2개 추가 (migration 20260828_0001, ADD COLUMN만 — 신규 테이블·스냅샷 없음)
SimulationConfig 모델 및 SimulationConfigRepository.create_version 확장(기본값 "medium")

#### API

PUT /simulations/{id}/parameters: 요청에 magic_layer_frequency / magic_layer_impact(선택, 기본 medium) 추가. 응답 data에 magic_layer_frequency, magic_layer_impact, magic_off_eligible, effective_tick 추가. magic_enabled는 StrictBool로 문자열 거부(400)
PATCH /simulations/{id}/parameters: 계약 유지(event_frequency/event_impact만). 요청에 Magic 필드가 포함되면 스키마 extra="forbid"로 400
GET /simulations/{id}: 응답에 최신 config 파라미터(event_*, magic_layer_*, magic_off_eligible, config_version) 부착 — 별도 GET /parameters 신설하지 않음

#### 검증 / 잠금

save_config에 Magic frequency/impact enum 검증 추가
magic_enabled=false는 정규화 impact ≥ 0.7(= impact high)일 때만 허용 → 아니면 409 CONFLICT (MAGIC_OFF_IMPACT_THRESHOLD = 0.7 고정)
Start 이후 Magic 3필드 변경 시 기존 잠금 분기 재사용 → 409 INITIAL_SETTINGS_LOCKED. 잠금 검사를 값 검증보다 먼저 수행

#### Magic Layer 연결 (신규 정책은 만들지 않음)

MagicLayer.evaluate()에 빈도 게이트: 조건 충족 후보에 확률(25/50/75%) + 일일 상한(1/2/3) + Tick 상한(1). seed 미전달 시 기존 동작 그대로
확률 판정 seed = {simulation_id}:{tick}:{config_version} — 기존 Event Master _dynamic_frequency_allows와 동일한 sha256 → random.Random 재사용(Replay 재현)
Magic impact 배율(0.5/1.0/1.5)을 build_magic_effect_candidates에 연결, 특수 Event importance 30/50/80 / impact_level 반영(기존 하드코딩 high/80 제거)
magic_enabled=false면 Magic Layer 특수 사건 미호출

#### Frontend

SettingsPanel: Magic 빈도/영향도 드롭다운 + ON/OFF 체크박스. 실행 후 disabled + 🔒 표시, PUT 본문에 Magic 필드 포함. 서버 validation/lock 오류는 기존 ErrorMessage로 표시

#### 테스트

신규 backend/tests/test_magic_parameters.py (13, DB 불필요) — OFF 조건, 빈도 게이트 결정론성/상한, impact 배율, magic_enabled=false 스킵
backend/tests/test_slice6_api.py에 test_magic_parameters_draft_validation_and_lock 추가 (DB) — 기본값 조회 / Draft 저장·재조회 / 검증 400 / OFF 위반 409 / Start 후 잠금 409 / 실행 중 Event PATCH 성공 / PATCH Magic 필드 400
frontend/src/components/SettingsPanel.test.jsx 3개 추가
기존 test_slice6_api.py / test_slice6_acceptance.py의 magic_enabled: false PUT에 magic_layer_impact: "high" 추가(새 OFF 조건 준수) + PUT 응답 기대값에 신규 필드 반영
결정 사항 및 이유
컬럼 추가 방식: Magic 빈도·영향도를 담을 저장소가 전혀 없어 migration 1건 불가피. 다만 기존 simulation_configs 버전 테이블에 컬럼만 추가해 버전·스냅샷·Replay·Tick 고정 경로를 그대로 태움 → _serialize가 전 컬럼을 직렬화하므로 스냅샷/Replay는 코드 변경 없이 파라미터 포함
잠금 위치: 프로젝트의 기존 잠금 책임 위치인 SimulationSnapshotService.save_config에 조건만 추가. magic_enabled 잠금 패턴이 이미 있어 Magic 빈도·영향도를 같은 분기에 합침
에러 코드: 신규 형식 안 만들고 기존 {"error":{"code","message"}} 유지. OFF 조건 위반은 프로젝트 /start API가 이미 쓰는 CONFLICT(409) 재사용
config_version: 문서 예시("cfg_001")가 아닌 기존 정수 계약 유지
Start 스냅샷: Start 시점의 최신 config가 Tick 1의 pinned_config로 고정되는 기존 로직으로 충족 — 별도 스냅샷 레코드 없음
빈도 게이트 범위: 확률·일일/Tick 상한만 연결. 예정 Magic 사건(schedule), Magic Agent 상한·high 일일 1회·쿨다운·STUDENT_MISSING low+low 예외 등 신규 정책은 범위 제외대로 미구현

## 테스트 / 확인 내용

 로컬 실행 확인 — pytest 538 passed / 204 skipped(DB 미구동), vitest 104 passed
 주요 기능 동작 확인 — 단위 테스트로 빈도 게이트/OFF 조건/impact 배율/잠금 검증
 에러 케이스 확인 — 400(enum/boolean/PATCH Magic 필드), 409(OFF 위반 / Start 후 잠금)
 DB 통합 테스트 미실행 — 로컬에 Postgres/Docker 없음. docker compose up -d db && alembic upgrade head && TEST_DATABASE_URL=... pytest로 재검증 필요
 mypy app/ 9건 / ruff check app/ 93건 — 모두 기존 baseline과 동일(신규 0)
 관련 문서 업데이트 — magic-layer.md의 "고정 확률 기반 생성은 사용하지 않는다"가 최신 simulation-parameters.md §4와 충돌(미갱신 스냅샷). 문서 수정 규칙상 이번 PR에서 건드리지 않음

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 코드베이스 분석(기존 config/lock/tick/replay 구조 파악), 구현, 테스트 작성, PR 초안
사람이 검토한 내용: 스펙-기존코드 충돌 지점 판단, 잠금/검증 우선순위, 에러 코드 매핑, 기존 테스트 갱신 방식, DB 미검증 범위

## 리뷰어가 봐야 할 부분

에러 코드: 스펙은 잘못된 파라미터 값에 422 BUSINESS_RULE_VIOLATION, PATCH Magic 필드에 400 VALIDATION_ERROR를 명시하나, 기존 Slice6ErrorRoute·통과 테스트가 400 INVALID_REPLAY_REQUEST. "기존 error 구조 재사용 + 기존 테스트 유지" 지시를 우선해 기존 코드 유지함. 422/전용 코드로 통일할지 결정 필요
기존 테스트 갱신: test_slice6_api.py / test_slice6_acceptance.py의 magic_enabled: false 요청에 magic_layer_impact: "high"를 추가하고 PUT 응답 기대 dict에 신규 키를 넣음. 새 OFF 조건(§6)상 이전 기대값이 어긋나 갱신한 것 — 테스트 삭제/완화는 아님
save_config 검사 순서: enum 검증 → 잠금 → OFF 조건. 실행 후에는 값이 무엇이든 Magic 변경을 INITIAL_SETTINGS_LOCKED로 막기 위해 잠금을 OFF 검증보다 앞에 둠
DB 통합 검증: 신규/갱신된 DB 테스트가 CI(Postgres)에서 실제로 통과하는지 확인 필요
magic_daily_count: 오늘 생성된 Magic 사건 수를 events 테이블(소문자 subtype)에서 카운트 — 기존 daily_dynamic_count 패턴 복제. subtype 문자열 목록이 magic_layer.py 상수와 어긋나지 않는지 확인
effective_tick: PATCH/PUT 응답의 계산 필드로만 제공(= current_tick + 1), 별도 이력 테이블에 저장하지 않음. 버전 행(created_at + 단조 증가 version)을 변경 이력으로 간주 — 별도 이력 저장이 필요하면 알려주세요