### PR TITLE
[Feature] 단일 전공(마법공학과) 및 MVP 공간 6종 데이터 지원

### DIFF
--- a/backend/app/api/simulations.py
+++ b/backend/app/api/simulations.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.api.schemas import (
     AgentResponse,
+    LocationResponse,
     SimulationCreateRequest,
     SimulationResponse,
     SimulationStatusUpdateRequest,
@@ -23,6 +24,7 @@ from app.services.simulations import (
     InvalidSimulationStatusTransitionError,
     create_simulation,
     get_agent_responses,
+    get_location_responses,
     require_owned_simulation,
     update_simulation_status,
 )
@@ -114,3 +116,12 @@ def get_agents(
     current_user: User = Depends(require_user_role),
 ) -> list[AgentResponse]:
     return get_agent_responses(db, simulation_id, current_user)
+
+
+@router.get("/{simulation_id}/locations", response_model=list[LocationResponse])
+def get_locations(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> list[LocationResponse]:
+    return get_location_responses(db, simulation_id, current_user)

--- a/backend/app/repositories/simulations.py
+++ b/backend/app/repositories/simulations.py
@@ -20,6 +20,16 @@ def get_simulation(db: Session, simulation_id: UUID) -> Simulation | None:
     )
 
 
+def list_simulation_locations(db: Session, simulation_id: UUID) -> list[Location]:
+    return list(
+        db.scalars(
+            select(Location)
+            .where(Location.simulation_id == simulation_id)
+            .order_by(Location.code.asc())
+        ).all()
+    )
+
+
 def list_agents_with_state(db: Session, simulation_id: UUID):
     return db.execute(
         select(Agent, AgentState, Location, StudentProfile, ProfessorProfile)

--- a/backend/app/services/fixtures.py
+++ b/backend/app/services/fixtures.py
@@ -12,6 +12,8 @@ from app.domain.models import (
     Event,
     EventParticipant,
     Location,
+    Organization,
+    OrganizationMembership,
     ProfessorProfile,
     StudentProfile,
 )
@@ -51,7 +53,19 @@ AGENT_FIXTURES = (
     AgentFixture("professor-01", "professor-fixture-v0.2", "에단", "professor", "ISTJ", "male", "classroom", -20, 40, -25, 10, 35, 20, 15, 20, 70, 20, academic_rank="통합 교수", specialty="통합마법학과 수업·시험·학생 지도"),
 )
 
-LOCATIONS = {"dormitory": "기숙사", "classroom": "교실"}
+# MVP 공간 6종 (mvp-feature-spec.md §2.5, docs/02-domain/time-and-space.md).
+# code는 기존 컨벤션(소문자 snake_case)을 따른다. 프론트는 code로 배경을 매핑한다.
+LOCATIONS = {
+    "classroom": "교실",
+    "restaurant": "식당",
+    "library": "도서관",
+    "lab": "연구실",
+    "dormitory": "기숙사",
+    "central_square": "중앙광장",
+}
+# MVP 단일 전공. 학생 5명 전원이 이 전공(ORGANIZATIONS.organization_type='major')에
+# 소속된다 (docs/02-domain/organizations.md). 여러 전공/전공 선택은 MVP 범위 밖.
+MVP_MAJOR_NAME = "마법공학과"
 SLICE_ONE_CLASS_TITLE = "통합마법학 개론"
 
 
@@ -69,6 +83,7 @@ def seed_slice_zero(db: Session, simulation_id: UUID) -> None:
         )
         location_ids[code] = db.execute(statement).scalar_one()
 
+    student_agent_ids: list[UUID] = []
     for fixture in AGENT_FIXTURES:
         agent_statement = (
             insert(Agent)
@@ -108,6 +123,7 @@ def seed_slice_zero(db: Session, simulation_id: UUID) -> None:
         )
         agent_id = db.execute(agent_statement).scalar_one()
         if fixture.agent_type == "student":
+            student_agent_ids.append(agent_id)
             profile_statement = (
                 insert(StudentProfile)
                 .values(
@@ -170,7 +186,55 @@ def seed_slice_zero(db: Session, simulation_id: UUID) -> None:
         )
         db.execute(state_statement)
 
+    seed_mvp_major(db, simulation_id, student_agent_ids)
     seed_slice_one_class_event(db, simulation_id, location_ids["classroom"])
+
+
+def seed_mvp_major(
+    db: Session, simulation_id: UUID, student_agent_ids: list[UUID]
+) -> None:
+    """MVP 단일 전공(마법공학과)과 학생 5명의 소속을 시드한다.
+
+    새 MAJORS 테이블을 만들지 않고 기존 ORGANIZATIONS(organization_type='major')
+    구조를 사용한다. interest_field(관심 분야)는 학생별로 다르게 유지하며 전공
+    소속만 organization_memberships로 표현한다.
+    """
+    organization_id = db.execute(
+        insert(Organization)
+        .values(
+            id=uuid7(),
+            simulation_id=simulation_id,
+            organization_type="major",
+            name=MVP_MAJOR_NAME,
+            is_active=True,
+        )
+        .on_conflict_do_update(
+            constraint="uq_organizations_simulation_type_name",
+            set_={"is_active": True, "deleted_at": None},
+        )
+        .returning(Organization.id)
+    ).scalar_one()
+
+    existing_member_ids = set(
+        db.scalars(
+            select(OrganizationMembership.agent_id).where(
+                OrganizationMembership.organization_id == organization_id,
+                OrganizationMembership.left_at.is_(None),
+            )
+        )
+    )
+    for agent_id in student_agent_ids:
+        if agent_id in existing_member_ids:
+            continue
+        db.add(
+            OrganizationMembership(
+                id=uuid7(),
+                simulation_id=simulation_id,
+                organization_id=organization_id,
+                agent_id=agent_id,
+                membership_role="member",
+            )
+        )
 
 
 def seed_slice_one_class_event(

--- a/backend/app/services/simulations.py
+++ b/backend/app/services/simulations.py
@@ -13,7 +13,11 @@ from app.api.schemas import (
     StudentProfileResponse,
 )
 from app.domain.models import Simulation, User
-from app.repositories.simulations import get_simulation, list_agents_with_state
+from app.repositories.simulations import (
+    get_simulation,
+    list_agents_with_state,
+    list_simulation_locations,
+)
 from app.services.fixtures import seed_slice_zero
 from app.services.simulation_snapshots import SimulationSnapshotService
 
@@ -66,6 +70,16 @@ def update_simulation_status(
     simulation.status = new_status
     db.flush()
     return simulation
+
+
+def get_location_responses(
+    db: Session, simulation_id: UUID, owner: User
+) -> list[LocationResponse]:
+    require_owned_simulation(db, simulation_id, owner)
+    return [
+        LocationResponse(id=location.id, code=location.code, name=location.name)
+        for location in list_simulation_locations(db, simulation_id)
+    ]
 
 
 def get_agent_responses(db: Session, simulation_id: UUID, owner: User) -> list[AgentResponse]:

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -53,7 +53,10 @@ def test_agent_detail_state_and_query_validation(client):
     headers = register_and_login(test_client, "agent-api-owner")
     simulation = create_simulation(test_client, headers)
     agents = test_client.get(f"/v1/simulations/{simulation['id']}/agents", headers=headers).json()
-    agent_id = agents[0]["id"]
+    # 에이전트 목록은 fixture_key 오름차순 정렬이라 agents[0]는 professor-01이다.
+    # MVP 단일 전공(마법공학과)에는 학생만 소속되므로 student-01을 명시적으로 고른다.
+    student = next(agent for agent in agents if agent["fixture_key"] == "student-01")
+    agent_id = student["id"]
 
     detail = test_client.get(f"/v1/agents/{agent_id}", headers=headers)
     state = test_client.get(f"/v1/agents/{agent_id}/state", headers=headers)
@@ -61,7 +64,7 @@ def test_agent_detail_state_and_query_validation(client):
 
     assert detail.status_code == 200
     assert detail.json()["id"] == agent_id
-    # agents[0]는 student-01 — MVP 단일 전공(마법공학과)에 소속된다.
+    # student-01은 MVP 단일 전공(마법공학과)에 소속된다.
     majors = [
         org
         for org in detail.json()["organizations"]
@@ -69,7 +72,7 @@ def test_agent_detail_state_and_query_validation(client):
     ]
     assert [org["name"] for org in majors] == ["마법공학과"]
     assert state.status_code == 200
-    assert state.json()["current_location"]["id"] == agents[0]["location"]["id"]
+    assert state.json()["current_location"]["id"] == student["location"]["id"]
     assert invalid_limit.status_code == 422
 
 

--- a/backend/tests/test_agent_api.py
+++ b/backend/tests/test_agent_api.py
@@ -61,7 +61,13 @@ def test_agent_detail_state_and_query_validation(client):
 
     assert detail.status_code == 200
     assert detail.json()["id"] == agent_id
-    assert "organizations" in detail.json()
+    # agents[0]는 student-01 — MVP 단일 전공(마법공학과)에 소속된다.
+    majors = [
+        org
+        for org in detail.json()["organizations"]
+        if org["organization_type"] == "major"
+    ]
+    assert [org["name"] for org in majors] == ["마법공학과"]
     assert state.status_code == 200
     assert state.json()["current_location"]["id"] == agents[0]["location"]["id"]
     assert invalid_limit.status_code == 422

--- a/backend/tests/test_simulation_imports.py
+++ b/backend/tests/test_simulation_imports.py
@@ -176,16 +176,17 @@ def test_import_creates_owned_simulation_with_full_roster(client) -> None:
             {"id": new_simulation_id},
         ).scalar_one()
         assert professor_count == 1
+        # 시드된 MVP 전공(마법공학과, 학생 5명 소속) + 테스트가 추가한 club 1개/멤버십 1개.
         org_count = db.execute(
             text("SELECT count(*) FROM organizations WHERE simulation_id = :id"),
             {"id": new_simulation_id},
         ).scalar_one()
-        assert org_count == 1
+        assert org_count == 2
         membership_count = db.execute(
             text("SELECT count(*) FROM organization_memberships WHERE simulation_id = :id"),
             {"id": new_simulation_id},
         ).scalar_one()
-        assert membership_count == 1
+        assert membership_count == 6
         relationship_count = db.execute(
             text("SELECT count(*) FROM relationships WHERE simulation_id = :id"),
             {"id": new_simulation_id},

--- a/backend/tests/test_simulation_shares.py
+++ b/backend/tests/test_simulation_shares.py
@@ -318,14 +318,19 @@ def test_export_payload_maps_organizations_and_relationships_by_fixture_key(clie
     share = create_share(test_client, owner_headers, simulation_id).json()
     payload = share["export_payload"]
 
-    assert len(payload["organizations"]) == 1
-    org_fixture_key = payload["organizations"][0]["fixture_key"]
+    # 시드된 MVP 전공(major) + 테스트가 추가한 club "Magic Club".
+    orgs_by_type = {org["organization_type"]: org for org in payload["organizations"]}
+    assert orgs_by_type["major"]["name"] == "마법공학과"
+    org_fixture_key = orgs_by_type["club"]["fixture_key"]
     assert org_fixture_key
 
-    assert len(payload["organization_memberships"]) == 1
-    membership = payload["organization_memberships"][0]
-    assert membership["organization_fixture_key"] == org_fixture_key
-    assert membership["agent_fixture_key"] == student_a_key
+    club_memberships = [
+        membership
+        for membership in payload["organization_memberships"]
+        if membership["organization_fixture_key"] == org_fixture_key
+    ]
+    assert len(club_memberships) == 1
+    assert club_memberships[0]["agent_fixture_key"] == student_a_key
 
     assert len(payload["relationships"]) == 1
     relationship = payload["relationships"][0]

--- a/backend/tests/test_simulation_tick_runtime.py
+++ b/backend/tests/test_simulation_tick_runtime.py
@@ -49,12 +49,14 @@ def runtime_db():
         db.flush()
         seed_slice_zero(db, simulation.id)
         seed_slice_zero(db, other_simulation.id)
-        extra_location = Location(
-            id=uuid4(),
-            simulation_id=simulation.id,
-            code="library",
-            name="도서관",
-            is_active=True,
+        # seed_slice_zero already creates the 6 MVP locations (fixtures.LOCATIONS);
+        # reuse the seeded "library" as the extra active location instead of
+        # inserting a duplicate that violates uq_locations_simulation_code.
+        extra_location = db.scalar(
+            select(Location).where(
+                Location.simulation_id == simulation.id,
+                Location.code == "library",
+            )
         )
         inactive_location = Location(
             id=uuid4(),
@@ -63,7 +65,7 @@ def runtime_db():
             name="폐쇄된 탑",
             is_active=False,
         )
-        db.add_all([extra_location, inactive_location])
+        db.add(inactive_location)
         db.commit()
         yield db, simulation, other_simulation, extra_location, inactive_location
 

--- a/backend/tests/test_slice_zero_api.py
+++ b/backend/tests/test_slice_zero_api.py
@@ -104,10 +104,12 @@ def test_registration_login_creation_and_idempotent_seed(client) -> None:
         Event,
         EventParticipant,
         Location,
+        Organization,
+        OrganizationMembership,
         ProfessorProfile,
         StudentProfile,
     )
-    from app.services.fixtures import AGENT_FIXTURES, seed_slice_zero
+    from app.services.fixtures import AGENT_FIXTURES, MVP_MAJOR_NAME, seed_slice_zero
 
     test_client, session_factory = client
     user, headers = register_and_login(test_client, "owner-a")
@@ -165,11 +167,26 @@ def test_registration_login_creation_and_idempotent_seed(client) -> None:
         db.commit()
         assert db.scalar(select(func.count()).select_from(Agent)) == 6
         assert db.scalar(select(func.count()).select_from(AgentState)) == 6
-        assert db.scalar(select(func.count()).select_from(Location)) == 2
+        # MVP 공간 6종 (mvp-feature-spec.md §2.5).
+        assert db.scalar(select(func.count()).select_from(Location)) == 6
         assert db.scalar(select(func.count()).select_from(StudentProfile)) == 5
         assert db.scalar(select(func.count()).select_from(ProfessorProfile)) == 1
         assert db.scalar(select(func.count()).select_from(Event)) == 1
         assert db.scalar(select(func.count()).select_from(EventParticipant)) == 2
+        # MVP 단일 전공: 마법공학과 1개 + 학생 5명 소속 (idempotent 재시드 후에도 안정).
+        major = db.scalar(
+            select(Organization).where(Organization.organization_type == "major")
+        )
+        assert major is not None and major.name == MVP_MAJOR_NAME
+        assert db.scalar(select(func.count()).select_from(Organization)) == 1
+        assert (
+            db.scalar(
+                select(func.count())
+                .select_from(OrganizationMembership)
+                .where(OrganizationMembership.organization_id == major.id)
+            )
+            == 5
+        )
         for stored_agent in db.scalars(select(Agent)).all():
             fixture = fixtures_by_key[stored_agent.fixture_key]
             assert (
@@ -229,6 +246,49 @@ def test_owner_gets_200_other_user_gets_403_and_missing_gets_404(client) -> None
     assert test_client.get(f"/v1/simulations/{simulation_id}", headers=other_headers).status_code == 403
     assert test_client.get(f"/v1/simulations/{uuid4()}", headers=owner_headers).status_code == 404
     assert test_client.get(f"/v1/simulations/{simulation_id}/agents", headers=other_headers).status_code == 403
+
+
+def test_locations_endpoint_returns_six_mvp_spaces_and_enforces_ownership(client) -> None:
+    from app.services.fixtures import LOCATIONS
+
+    test_client, _ = client
+    _, owner_headers = register_and_login(test_client, "loc-owner")
+    _, other_headers = register_and_login(test_client, "loc-other")
+    simulation_id = test_client.post(
+        "/v1/simulations", headers=owner_headers, json={"name": "Loc"}
+    ).json()["id"]
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/locations", headers=owner_headers
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert {location["code"]: location["name"] for location in body} == LOCATIONS
+    assert all(UUID(location["id"]).version == 7 for location in body)
+    # 학생의 현재 위치(dormitory)가 이 목록에 실제로 존재한다.
+    agents = test_client.get(
+        f"/v1/simulations/{simulation_id}/agents", headers=owner_headers
+    ).json()
+    student_location_codes = {
+        agent["location"]["code"] for agent in agents if agent["agent_type"] == "student"
+    }
+    assert student_location_codes <= set(LOCATIONS)
+
+    assert (
+        test_client.get(
+            f"/v1/simulations/{simulation_id}/locations", headers=other_headers
+        ).status_code
+        == 403
+    )
+    assert (
+        test_client.get(
+            f"/v1/simulations/{uuid4()}/locations", headers=owner_headers
+        ).status_code
+        == 404
+    )
+    assert (
+        test_client.get(f"/v1/simulations/{simulation_id}/locations").status_code == 401
+    )
 
 
 def test_duplicate_username_returns_409_and_bad_password_returns_401(client) -> None:

--- a/backend/tests/test_slice_zero_contract.py
+++ b/backend/tests/test_slice_zero_contract.py
@@ -6,7 +6,7 @@ import jwt
 from app.core.config import get_settings
 from app.core.security import create_access_token, hash_password, verify_password
 from app.domain.models import User
-from app.services.fixtures import AGENT_FIXTURES, LOCATIONS
+from app.services.fixtures import AGENT_FIXTURES, LOCATIONS, MVP_MAJOR_NAME
 
 
 def test_fixture_contract_has_exactly_five_students_and_one_professor() -> None:
@@ -18,7 +18,17 @@ def test_fixture_contract_has_exactly_five_students_and_one_professor() -> None:
     assert [fixture.key for fixture in AGENT_FIXTURES] == [
         "student-01", "student-02", "student-03", "student-04", "student-05", "professor-01"
     ]
-    assert LOCATIONS == {"dormitory": "기숙사", "classroom": "교실"}
+    # MVP 공간 6종 (mvp-feature-spec.md §2.5). code는 소문자 snake_case 컨벤션.
+    assert LOCATIONS == {
+        "classroom": "교실",
+        "restaurant": "식당",
+        "library": "도서관",
+        "lab": "연구실",
+        "dormitory": "기숙사",
+        "central_square": "중앙광장",
+    }
+    # MVP 단일 전공.
+    assert MVP_MAJOR_NAME == "마법공학과"
 
 
 def test_each_fixture_matches_the_confluence_v02_contract() -> None:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -133,6 +133,23 @@ function AuthPanel({ onLogin, notice }) {
   );
 }
 
+// MVP 공간 6종. 백엔드는 location code/name만 제공하고, 배경 표현은 프론트가
+// code로 매핑한다 (별도 배경 asset이 아직 없어 이모지로 간단히 표시).
+const LOCATION_BACKDROP = {
+  classroom: "🏫",
+  restaurant: "🍽️",
+  library: "📚",
+  lab: "⚗️",
+  dormitory: "🛏️",
+  central_square: "⛲",
+};
+
+function locationLabel(location) {
+  if (!location) return "-";
+  const backdrop = LOCATION_BACKDROP[location.code];
+  return backdrop ? `${backdrop} ${location.name}` : location.name;
+}
+
 // 서버 응답의 code/HTTP status를 프론트에서 보여줄 오류 종류로 분류한다.
 function classifyTickError(requestError) {
   const status = requestError?.status;
@@ -474,7 +491,7 @@ export default function App() {
                   <dt>종류</dt><dd>{selectedAgent.agent_type}</dd>
                   <dt>MBTI</dt><dd>{selectedAgent.mbti_type}</dd>
                   <dt>학년</dt><dd>{selectedAgent.student_profile ? `${selectedAgent.student_profile.grade}학년` : "-"}</dd>
-                  <dt>위치</dt><dd>{selectedAgent.location.name}</dd>
+                  <dt>위치</dt><dd>{locationLabel(selectedAgent.location)}</dd>
                   <dt>기분</dt><dd>{selectedAgent.state.mood}</dd>
                   <dt>배고픔</dt><dd>{selectedAgent.state.hunger}</dd>
                   <dt>피로도</dt><dd>{selectedAgent.state.fatigue}</dd>

--- a/frontend/src/App.mock.test.jsx
+++ b/frontend/src/App.mock.test.jsx
@@ -42,7 +42,7 @@ describe('Mock 모드 통합 흐름', () => {
     expect(document.querySelectorAll('[data-agent-id]')).toHaveLength(6)
     expect(screen.getByRole('heading', { name: 'Inspector' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: '에단' })).toBeInTheDocument()
-    expect(screen.getByText('교실')).toBeInTheDocument()
+    expect(screen.getByText(/교실/)).toBeInTheDocument()
     expect(fetchSpy).not.toHaveBeenCalled()
   }, 10000)
 })

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -114,7 +114,7 @@ describe('Slice 0 UI', () => {
     expect(document.querySelectorAll('[data-agent-id]')).toHaveLength(6)
     await userEvent.click(screen.getByRole('button', { name: /아델/ }))
     expect(screen.getByRole('heading', { name: '아델' })).toBeInTheDocument()
-    expect(screen.getByText('기숙사')).toBeInTheDocument()
+    expect(screen.getByText(/기숙사/)).toBeInTheDocument()
   }, 10000)
 
   it('shows a disabled loading button while enrolling', async () => {


### PR DESCRIPTION
## 작업 개요

MVP에서 확정된 단일 전공(마법공학과) 과 공간 6종(교실·식당·도서관·연구실·기숙사·중앙광장) 데이터가 시뮬레이션 생성 시 시드되도록 하고, simulation 기준으로 공간을 조회하는 최소 API 하나를 추가한다. 전공 소속은 기존 ORGANIZATIONS(organization_type='major') + organization_memberships 구조를 재사용하며, 학생 위치/전공 조회는 기존 학생 API를 그대로 활용한다. 프론트는 받은 location.code로 배경(현재는 이모지 placeholder)을 간단히 매핑한다.

새 테이블(MAJORS / Space / 배경 이미지), 다중 전공, 전공 선택·변경, 이벤트 엔진 변경은 이번 범위에서 제외한다.

## 관련 Issue
Related to #182 

## 변경 내용

#### Backend

app/services/fixtures.py
LOCATIONS를 MVP 6종으로 확장: classroom/restaurant/library/lab/dormitory/central_square (code는 기존 소문자 snake_case 컨벤션 유지)
MVP_MAJOR_NAME = "마법공학과" 상수 추가
seed_mvp_major() 추가 — seed_slice_zero에서 호출. 마법공학과 조직 1개 + 학생 5명의 organization_memberships(role member)를 idempotent하게 시드 (org는 on_conflict_do_update, 멤버십은 기존 소속 조회 후 누락분만 삽입). student_profiles.interest_field(관심 분야)는 학생별로 다르게 유지.
app/repositories/simulations.py — list_simulation_locations() 추가 (code 오름차순)
app/services/simulations.py — get_location_responses() 추가 (소유권 검증 후 LocationResponse[])
app/api/simulations.py — GET /v1/simulations/{id}/locations 엔드포인트 1개만 신규. 전공 조회는 기존 GET /agents/{id}의 organizations[] 필드 재사용 (중복 API 미생성).

#### Test

test_slice_zero_contract.py — LOCATIONS 6종 + MVP_MAJOR_NAME 계약 단언
test_slice_zero_api.py — Location count 2→6, 마법공학과 조직/멤버십(5) 단언 추가. 신규 테스트 test_locations_endpoint_returns_six_mvp_spaces_and_enforces_ownership (6공간 code/name, 학생 위치 존재 여부, 403/404/401)
test_agent_api.py — GET /agents/{id}가 마법공학과(major)를 반환하는지 단언
test_simulation_shares.py / test_simulation_imports.py — 공유/가져오기 payload의 조직·멤버십 개수 단언을 새 baseline(시드된 전공 + 테스트가 추가한 club)에 맞게 갱신 (org_count 1→2, membership_count 1→6, club을 fixture_key로 특정하도록 재작성)

#### Frontend

App.jsx — LOCATION_BACKDROP(code→이모지) + locationLabel() 추가, Inspector "위치"에 적용. 배경 asset 파일이 없어 이모지로 표현. 새 컴포넌트·화면 없음.
App.test.jsx / App.mock.test.jsx — 위치 텍스트 단언을 부분 일치(/기숙사/, /교실/)로 조정

규모: 12파일 · +216 / −18 (문서 제외, 권장 범위 내)

## 결정 사항 및 이유
기존 구조 재사용: ERD상 locations, organizations(organization_type='major')가 이미 존재하므로 새 테이블을 만들지 않고 시드만 확장. 전공 표현은 도메인 문서(docs/02-domain/organizations.md)와 mvp-feature-spec.md F5-11("전공·학년 (organizations 필드)")에 부합.
interest_field와 전공 소속 분리: Event Master의 GROUP_PROJECT 그룹핑 키는 student_profiles.interest_field이며 organization_memberships를 참조하지 않는다. 따라서 전공 조직을 추가해도 tick/이벤트 동작은 완전히 불변이고, interest_field는 학생별로 다르게 유지했다.
API 최소화: "필요 이상의 API 신규 생성 금지" 원칙에 따라 전공은 기존 GET /agents/{id}로 충족하고, 공간만 목록 조회 수단이 전혀 없어 GET /{id}/locations 하나만 추가. 소유권 검증은 기존 require_owned_simulation 재사용 → 403/404/401 규칙 일관.
시드 idempotency: seed_slice_zero는 재실행될 수 있으므로(테스트가 2회 호출) org는 upsert, 멤버십은 기존 조회 후 누락분만 삽입해 재시드 시 개수가 안정적.
테스트 단언 갱신: Slice 0/7 테스트가 "공간 2개 / 조직 0"을 하드코딩하고 있었다. MVP 확정 스펙(공간 6, 마법공학과 소속 5)에 맞춘 시드 확장이 원인이며, 값을 억지로 통과시킨 것이 아니라 스펙 변경을 반영해 baseline을 갱신했다. 각 변경에 이유 주석을 달았다.
배경 이미지: DB에 URL/path를 저장하지 않는다. 백엔드는 code/name만 제공하고 프론트가 code로 매핑. 실제 배경 asset이 없어 현재는 이모지 placeholder이며, asset 확정 시 LOCATION_BACKDROP 매핑만 교체하면 된다.

## 테스트 / 확인 내용
 로컬 단위 테스트: backend 538 passed / 205 skipped, frontend 104 passed (16 files)
 mypy(변경 파일 4종) clean
 에러 케이스: GET /{id}/locations 403(타인)/404(없는 simulation)/401(미인증) 테스트 추가
 시드 idempotency: seed_slice_zero 2회 실행 후 공간 6 / 조직 1 / 멤버십 5 유지 단언
 DB 통합 테스트(test_slice_zero_api, test_simulation_shares, test_simulation_imports, test_agent_api)는 로컬에 Postgres가 없어 skip → CI backend-e2e에서 확인 필요. 변경한 단언은 시드 결과와 정합하도록 정적 검토 완료.
 관련 문서 업데이트: 해당 없음 (도메인 문서는 이미 전공=ORGANIZATIONS, 공간 목록을 정의하고 있음)

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 저장소 조사(LOCATIONS/ORGANIZATIONS 사용처, 학생 API 응답 구조, 시드/픽스처, 관련 테스트, 이벤트 엔진의 전공/위치 참조 경로), fixtures 시드 확장, GET /{id}/locations 엔드포인트 및 repository/service 추가, 테스트 작성·갱신, 프론트 locationLabel 매핑, 로컬 테스트/mypy 실행.
사람이 검토한 내용: 시드 확장이 이벤트 엔진 동작에 영향이 없는지(interest_field vs organization_memberships 분리), 스펙과 충돌하는 기존 테스트 단언 6곳의 갱신 타당성, 신규 API 1개로 범위를 한정한 판단, DB 통합 테스트는 CI에서 검증 필요하다는 점.

## 리뷰어가 봐야 할 부분
seed_slice_zero → seed_mvp_major idempotency (app/services/fixtures.py) — 재시드 시 org/멤버십 개수가 늘지 않는지. db.add(ORM)와 core insert().on_conflict_* 혼용이 캠페인/스냅샷 시드 흐름과 충돌하지 않는지.
Slice 7 공유/가져오기 테스트 단언 변경 (test_simulation_shares.py, test_simulation_imports.py) — 시드된 전공(major)과 테스트가 넣은 club을 fixture_key로 구분하도록 재작성한 부분. _organization_fixture_key가 "major:마법공학과"를 안정적으로 생성하므로 export/import 라운드트립은 그대로 동작한다고 판단했는데, CI 결과로 확인 필요.
공간 code 네이밍 — 기존 컨벤션(classroom, dormitory)에 맞춰 소문자 snake_case(restaurant, library, lab, central_square)로 정했다. 팀 표준과 어긋나면 알려주세요.
연구실(lab) 이벤트 미배선 — 연구실 공간은 생겼지만 magic_layer의 lab_location_ids를 tick 파이프라인에 연결하는 작업은 엔진 변경이라 이번 PR에서 제외. 별도 이슈 필요.