### PR TITLE
[Feature] Simulation·Agents 응답에 MVP 화면용 필드 추가 (night_waiting, active_status)

### DIFF
--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -63,6 +63,7 @@ class SimulationResponse(BaseModel):
     current_day: int
     current_tick: int
     magic_enabled: bool
+    night_waiting: bool
     created_at: datetime
     # 최신 simulation_config 파라미터 (없으면 None — 별도 GET /parameters 를 만들지
     # 않고 기존 Simulation 조회 응답을 확장한다, simulation-parameters.md §10).
@@ -204,6 +205,7 @@ class AgentResponse(BaseModel):
     fixture_version: str
     name: str
     agent_type: str
+    active_status: str
     mbti_type: str
     profile: AgentProfileResponse
     student_profile: StudentProfileResponse | None

--- a/backend/app/services/agents.py
+++ b/backend/app/services/agents.py
@@ -61,6 +61,7 @@ def _agent_response(db: Session, agent: Agent) -> AgentResponse:
         fixture_version=agent.fixture_version,
         name=agent.name,
         agent_type=agent.agent_type,
+        active_status=agent.active_status,
         mbti_type=agent.mbti_type,
         profile=AgentProfileResponse(
             openness=agent.openness,

--- a/backend/app/services/simulations.py
+++ b/backend/app/services/simulations.py
@@ -95,6 +95,7 @@ def get_agent_responses(db: Session, simulation_id: UUID, owner: User) -> list[A
                 fixture_version=agent.fixture_version,
                 name=agent.name,
                 agent_type=agent.agent_type,
+                active_status=agent.active_status,
                 mbti_type=agent.mbti_type,
                 profile=AgentProfileResponse(
                     openness=agent.openness,

--- a/backend/tests/test_slice_zero_api.py
+++ b/backend/tests/test_slice_zero_api.py
@@ -291,6 +291,45 @@ def test_locations_endpoint_returns_six_mvp_spaces_and_enforces_ownership(client
     )
 
 
+def test_simulation_detail_exposes_night_waiting(client) -> None:
+    from app.domain.models import Simulation
+
+    test_client, session_factory = client
+    _, headers = register_and_login(test_client, "night-owner")
+    simulation_id = test_client.post(
+        "/v1/simulations", headers=headers, json={"name": "Night"}
+    ).json()["id"]
+
+    fresh = test_client.get(f"/v1/simulations/{simulation_id}", headers=headers)
+    assert fresh.status_code == 200
+    assert fresh.json()["night_waiting"] is False
+
+    with session_factory() as db:
+        simulation = db.get(Simulation, UUID(simulation_id))
+        simulation.night_waiting = True
+        db.commit()
+
+    waiting = test_client.get(f"/v1/simulations/{simulation_id}", headers=headers)
+    assert waiting.status_code == 200
+    assert waiting.json()["night_waiting"] is True
+
+
+def test_agents_list_exposes_active_status_and_location(client) -> None:
+    test_client, _ = client
+    _, headers = register_and_login(test_client, "active-owner")
+    simulation_id = test_client.post(
+        "/v1/simulations", headers=headers, json={"name": "Active"}
+    ).json()["id"]
+
+    agents = test_client.get(
+        f"/v1/simulations/{simulation_id}/agents", headers=headers
+    ).json()
+    assert agents
+    for agent in agents:
+        assert agent["active_status"] == "active"
+        assert set(agent["location"]) == {"id", "code", "name"}
+
+
 def test_duplicate_username_returns_409_and_bad_password_returns_401(client) -> None:
     test_client, _ = client
     register_and_login(test_client, "duplicate")


### PR DESCRIPTION
## 작업 개요

Issue #182의 4번째 작업(182-4). 새 도메인 모델·신규 API 없이, 기존 응답 스키마를
최소 확장해 프론트엔드가 MVP 화면(시간 상태 표시, 월드 맵)을 구성하는 데 필요한
정보를 제공한다.

- `GET /v1/simulations/{id}` 응답에 `night_waiting` 노출
- `GET /v1/simulations/{id}/agents` 각 agent에 `active_status` 노출 (기존 `location` 유지)
- agent 상세(`GET /v1/agents/{agent_id}`)는 URL·구조 변경 없음 (상속으로 `active_status`만 함께 노출)

## 관련 Issue

Related to #182 (182-4 작업, 단일 PR)

## 변경 내용

- `backend/app/api/schemas.py`
  - `SimulationResponse`에 `night_waiting: bool` 추가. `get_one`이 `model_validate(simulation)`을
    사용하므로 ORM 속성에서 자동 매핑되어 엔드포인트 코드 변경 불필요.
  - `AgentResponse`에 `active_status: str` 추가. `AgentDetailResponse`가 이를 상속.
- `backend/app/services/simulations.py`
  - `get_agent_responses`의 `AgentResponse(...)` 생성부에 `active_status=agent.active_status` 전달.
- `backend/app/services/agents.py`
  - `_agent_response`의 `AgentResponse(...)` 생성부에 `active_status=agent.active_status` 전달.
- `backend/tests/test_slice_zero_api.py`
  - `test_simulation_detail_exposes_night_waiting`: 신규 simulation 응답이 `night_waiting == False`,
    fixture 값을 `True`로 변경 후 응답도 `True`인지 검증.
  - `test_agents_list_exposes_active_status_and_location`: 각 agent에 `active_status == "active"`,
    `location{id, code, name}` 존재 검증.

변경 규모: 코드 3파일 +4줄 / 테스트 1파일 +39줄 (migration 없음).

## 결정 사항 및 이유

- **신규 API를 만들지 않음.** `night_waiting`은 `Simulation` 모델·migration(`20260827_0013`)에
  이미 존재하고, agent+state+location 조회 API도 이미 있으므로 스키마 필드만 추가했다.
  `/world/map` 신규 endpoint는 만들지 않고 기존 `/agents` 응답 확장으로 FE가 location별
  그룹핑을 하도록 한다.
- **agent 상세 URL 유지.** 실제 라우팅은 `GET /v1/agents/{agent_id}`이며(`simulation` 하위 아님)
  정상 동작하므로 그대로 둔다. `AgentDetailResponse`는 `AgentResponse`를 상속하므로
  `active_status`가 상세 응답에도 함께 노출되나, 이는 추가적·비파괴적 확장이다.
- **tick → 실제 시각(`09:20`) 변환, `time`/`time_period`, `is_paused` 필드는 구현하지 않음.**
  변환 규칙이 미확정이며 이번 범위 밖. `is_paused`는 기존 `status == "paused"`로 판단 가능.

## 테스트 / 확인 내용

- [ ] 로컬 실행 확인 — 로컬에 pgvector Postgres/Docker 데몬이 없어 DB 통합 테스트는 실행 불가.
      아래 대체 검증 수행:
  - `python -m pytest --collect-only tests` → 745건 수집, 오류 없음. 신규 테스트 2건 정상 수집.
  - 스키마 introspection: `SimulationResponse.night_waiting`,
    `AgentResponse.active_status` / `AgentDetailResponse.active_status` 필드 존재 확인.
  - `app.main:app` 및 변경 모듈 임포트 정상.
- [ ] 주요 기능 동작 확인 — CI(Backend E2E)에서 실제 DB 대상 테스트 실행 필요.
- [x] 에러 케이스 확인 — 기존 ownership(403/404) 회귀 테스트에 영향 없음(필드 추가만, 전체 dict
      동등 비교 assert 없음).
- [x] 관련 문서 업데이트 확인 — 도메인/스키마 변경 없이 응답 필드만 추가하여 문서 갱신 대상 없음.
      (참고: `docs/04-feature-specs/mvp-feature-spec.md` F5-08에 `/world/map`이 적혀 있으나
      이번 이슈 지시에 따라 기존 `/agents` 확장으로 대체)

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 코드베이스 구조 확인, 스키마/서비스 필드 추가, 테스트 작성, PR 초안 작성
사람이 검토한 내용: 변경 범위(신규 모델·API 없이 최소 확장), 필드 매핑 정확성,
기존 테스트 회귀 영향, agent 상세 URL 유지 여부

## 리뷰어가 봐야 할 부분

- `AgentResponse`에 `active_status`를 추가하면 상속 관계상 `AgentDetailResponse`
  (`GET /v1/agents/{agent_id}`)에도 노출된다. 이 동작을 허용할지 확인 필요.
- `SimulationResponse.night_waiting`은 엔드포인트에서 명시적으로 세팅하지 않고
  `model_validate(simulation)`의 `from_attributes` 매핑에 의존한다.
- DB 미보유로 로컬 pytest는 전부 skip 상태 → CI E2E 결과로 최종 확인 필요.