### PR TITLE
[Feature] 시뮬레이션 최근 사건 조회 API (GET events/latest)

### DIFF
--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -3,11 +3,17 @@ from uuid import UUID
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.api.schemas import EventCreateRequest, EventResponse
+from app.api.schemas import EventCreateRequest, EventResponse, LatestEventResponse
 from app.core.database import get_db
 from app.core.security import require_user_role
 from app.domain.models import User
-from app.services.events import InvalidEventLocationError, create_event, list_events
+from app.services.events import (
+    InvalidEventLocationError,
+    create_event,
+    event_participant_agent_ids,
+    latest_event,
+    list_events,
+)
 from app.services.realtime_events import build_event_created_event, connection_manager
 from app.services.simulations import require_owned_simulation
 
@@ -61,3 +67,38 @@ def get_all(
 ) -> list[EventResponse]:
     require_owned_simulation(db, simulation_id, current_user)
     return [EventResponse.model_validate(event) for event in list_events(db, simulation_id)]
+
+
+def _metadata_int(metadata: dict, key: str) -> int | None:
+    value = metadata.get(key)
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+@router.get("/latest", response_model=LatestEventResponse)
+def get_latest(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> LatestEventResponse:
+    require_owned_simulation(db, simulation_id, current_user)
+    event = latest_event(db, simulation_id)
+    if event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No event found")
+    metadata = event.event_metadata or {}
+    return LatestEventResponse(
+        id=event.id,
+        simulation_id=event.simulation_id,
+        location_id=event.location_id,
+        event_type=event.event_type,
+        title=event.title,
+        description=event.description,
+        status=event.status,
+        simulation_day=event.simulation_day,
+        created_at=event.created_at,
+        tick=_metadata_int(metadata, "tick"),
+        importance=_metadata_int(metadata, "importance"),
+        target_agent_ids=event_participant_agent_ids(db, event.id),
+    )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -136,6 +136,16 @@ class EventResponse(BaseModel):
     created_at: datetime
 
 
+class LatestEventResponse(EventResponse):
+    # tick / importance 는 events 테이블 컬럼이 아니라 event engine 이
+    # events.metadata(JSONB)에 남긴 값이다 (persist_event_batch). 수동 생성
+    # Event 에는 없으므로 nullable 이다.
+    tick: int | None
+    importance: int | None
+    # 참여(대상) Agent 는 event_participants 테이블에서 조회한다.
+    target_agent_ids: list[UUID]
+
+
 class SimulationShareCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from uuid6 import uuid7
 
-from app.domain.models import Event, Location
+from app.domain.models import Event, EventParticipant, Location
 
 
 class InvalidEventLocationError(Exception):
@@ -46,11 +46,36 @@ def create_event(
     return event
 
 
+def _events_for_simulation(simulation_id: UUID):
+    return select(Event).where(Event.simulation_id == simulation_id)
+
+
 def list_events(db: Session, simulation_id: UUID) -> list[Event]:
     return list(
         db.scalars(
-            select(Event)
-            .where(Event.simulation_id == simulation_id)
-            .order_by(Event.created_at, Event.id)
+            _events_for_simulation(simulation_id).order_by(Event.created_at, Event.id)
+        )
+    )
+
+
+def latest_event(db: Session, simulation_id: UUID) -> Event | None:
+    """Return the most recent event of a simulation.
+
+    "Latest" reuses the ordering key of ``list_events`` (``created_at``, ``id``)
+    in reverse; no new priority rule is introduced.
+    """
+    return db.scalar(
+        _events_for_simulation(simulation_id)
+        .order_by(Event.created_at.desc(), Event.id.desc())
+        .limit(1)
+    )
+
+
+def event_participant_agent_ids(db: Session, event_id: UUID) -> list[UUID]:
+    return list(
+        db.scalars(
+            select(EventParticipant.agent_id)
+            .where(EventParticipant.event_id == event_id)
+            .order_by(EventParticipant.agent_id)
         )
     )

--- a/backend/tests/test_events_latest_api.py
+++ b/backend/tests/test_events_latest_api.py
@@ -9,7 +9,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, select, text
+from sqlalchemy import create_engine, delete, select, text
 from sqlalchemy.orm import Session, sessionmaker
 
 TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
@@ -166,9 +166,19 @@ def test_latest_event_is_scoped_to_its_simulation(client) -> None:
 
 
 def test_latest_event_absent_returns_404(client) -> None:
-    test_client, _ = client
+    test_client, session_factory = client
     headers = register_and_login(test_client, "latest-empty")
     simulation_id = create_simulation(test_client, headers, "empty")
+
+    # 새 simulation 은 seed 된 Slice 1 CLASS Event 를 갖는다. event 가 하나도
+    # 없는 상태를 만들기 위해 직접 제거한다 (event_participants 를 먼저 지운다).
+    from app.domain.models import Event, EventParticipant
+
+    with session_factory() as session:
+        owned = select(Event.id).where(Event.simulation_id == UUID(simulation_id))
+        session.execute(delete(EventParticipant).where(EventParticipant.event_id.in_(owned)))
+        session.execute(delete(Event).where(Event.simulation_id == UUID(simulation_id)))
+        session.commit()
 
     response = test_client.get(
         f"/v1/simulations/{simulation_id}/events/latest", headers=headers
@@ -215,6 +225,12 @@ def test_events_list_endpoint_still_returns_all(client) -> None:
     headers = register_and_login(test_client, "latest-regression")
     simulation_id = create_simulation(test_client, headers, "regression")
 
+    # 새 simulation 에는 seed 된 CLASS Event 1건이 이미 있다.
+    seeded = test_client.get(
+        f"/v1/simulations/{simulation_id}/events", headers=headers
+    ).json()
+    assert len(seeded) == 1
+
     first = post_event(test_client, headers, simulation_id, "사건 1")
     second = post_event(test_client, headers, simulation_id, "사건 2")
 
@@ -223,4 +239,5 @@ def test_events_list_endpoint_still_returns_all(client) -> None:
     )
     assert listed.status_code == 200, listed.text
     ids = [item["id"] for item in listed.json()]
-    assert ids == [first["id"], second["id"]]
+    # 기존 list 엔드포인트는 그대로: seed + 새 Event 2건을 created_at, id 순으로 반환.
+    assert ids == [seeded[0]["id"], first["id"], second["id"]]

--- a/backend/tests/test_events_latest_api.py
+++ b/backend/tests/test_events_latest_api.py
@@ -1,0 +1,226 @@
+"""GET /v1/simulations/{simulation_id}/events/latest — Issue #182-5.
+
+기존 events API 테스트 스타일(TEST_DATABASE_URL 필요, TestClient + register/login)을
+따른다. 엔진이 남긴 tick/importance/참여 Agent 는 persist_event_batch 로 만든다.
+"""
+
+import os
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import Session, sessionmaker
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def client():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE users, simulations, locations, agents, agent_states "
+                "RESTART IDENTITY CASCADE"
+            )
+        )
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client, session_factory
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client: TestClient, username: str) -> dict[str, str]:
+    password = "Latest-password!"
+    assert (
+        client.post(
+            "/v1/auth/register",
+            json={"username": username, "display_name": username, "password": password},
+        ).status_code
+        == 201
+    )
+    login = client.post("/v1/auth/login", json={"username": username, "password": password})
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def create_simulation(client: TestClient, headers: dict[str, str], name: str) -> str:
+    return client.post("/v1/simulations", headers=headers, json={"name": name}).json()["id"]
+
+
+def post_event(client: TestClient, headers: dict[str, str], simulation_id: str, title: str) -> dict:
+    response = client.post(
+        f"/v1/simulations/{simulation_id}/events",
+        headers=headers,
+        json={"event_type": "class", "title": title, "simulation_day": 1},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def persist_engine_event(session_factory, simulation_id: str) -> dict:
+    """엔진 경로(persist_event_batch)로 tick=1 Event 1건을 남긴다."""
+    from app.domain.event_persistence import EventBatch
+    from app.domain.models import Agent, AgentState
+    from app.services.event_persistence import persist_event_batch
+    from app.services.fixtures import seed_slice_zero
+
+    with session_factory() as session:
+        seed_slice_zero(session, UUID(simulation_id))
+        state = session.scalar(
+            select(AgentState)
+            .join(Agent, Agent.id == AgentState.agent_id)
+            .where(AgentState.simulation_id == UUID(simulation_id), Agent.fixture_key == "student-01")
+        )
+        batch = EventBatch.model_validate(
+            dict(
+                simulation_id=UUID(simulation_id),
+                run_id="latest-run",
+                tick_number=1,
+                policy_version="latest-policy",
+                resolver_version="latest-resolver",
+                resolution_id="latest-resolution",
+                events=[
+                    dict(
+                        id=uuid4(),
+                        event_type="GROUP_PROJECT",
+                        title="조별 과제",
+                        description="도서관에서 조별 과제를 했다.",
+                        participant_agent_ids=[state.agent_id],
+                        location_id=state.location_id,
+                        source="event_master",
+                        impact_level="medium",
+                        importance=50,
+                    )
+                ],
+                resolved_effects=[
+                    dict(
+                        source_agent_id=state.agent_id,
+                        metric="stress",
+                        before=state.stress,
+                        requested_total=1,
+                        applied_delta=1,
+                        after=state.stress + 1,
+                        effect_ids=["e1"],
+                    )
+                ],
+            )
+        )
+        result = persist_event_batch(session, batch)
+        session.commit()
+        return result
+
+
+def test_latest_event_returns_most_recent_ordering(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "latest-order")
+    simulation_id = create_simulation(test_client, headers, "order")
+
+    post_event(test_client, headers, simulation_id, "첫 사건")
+    post_event(test_client, headers, simulation_id, "둘째 사건")
+    newest = post_event(test_client, headers, simulation_id, "가장 최근 사건")
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/latest", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == newest["id"]
+    assert body["title"] == "가장 최근 사건"
+    # 수동 생성 Event 에는 엔진 metadata 가 없다.
+    assert body["tick"] is None
+    assert body["importance"] is None
+    assert body["target_agent_ids"] == []
+
+
+def test_latest_event_is_scoped_to_its_simulation(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "latest-scope")
+    simulation_a = create_simulation(test_client, headers, "sim-a")
+    simulation_b = create_simulation(test_client, headers, "sim-b")
+
+    event_a = post_event(test_client, headers, simulation_a, "A 사건")
+    event_b = post_event(test_client, headers, simulation_b, "B 사건")
+
+    latest_a = test_client.get(
+        f"/v1/simulations/{simulation_a}/events/latest", headers=headers
+    ).json()
+    latest_b = test_client.get(
+        f"/v1/simulations/{simulation_b}/events/latest", headers=headers
+    ).json()
+
+    assert latest_a["id"] == event_a["id"]
+    assert latest_a["simulation_id"] == simulation_a
+    assert latest_b["id"] == event_b["id"]
+    assert latest_b["simulation_id"] == simulation_b
+
+
+def test_latest_event_absent_returns_404(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "latest-empty")
+    simulation_id = create_simulation(test_client, headers, "empty")
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/latest", headers=headers
+    )
+    assert response.status_code == 404, response.text
+
+
+def test_latest_event_exposes_engine_tick_importance_and_agents(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "latest-engine")
+    simulation_id = create_simulation(test_client, headers, "engine")
+
+    result = persist_engine_event(session_factory, simulation_id)
+    expected_event = result["events"][0]
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/latest", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == expected_event["id"]
+    assert body["event_type"] == "group_project"
+    assert body["tick"] == 1
+    assert body["importance"] == 50
+    assert body["target_agent_ids"] == list(expected_event["participant_agent_ids"])
+    assert body["description"] == "도서관에서 조별 과제를 했다."
+
+
+def test_latest_event_enforces_ownership(client) -> None:
+    test_client, _ = client
+    owner_headers = register_and_login(test_client, "latest-owner")
+    other_headers = register_and_login(test_client, "latest-intruder")
+    simulation_id = create_simulation(test_client, owner_headers, "owned")
+    post_event(test_client, owner_headers, simulation_id, "사건")
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/latest", headers=other_headers
+    )
+    assert response.status_code == 403, response.text
+
+
+def test_events_list_endpoint_still_returns_all(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "latest-regression")
+    simulation_id = create_simulation(test_client, headers, "regression")
+
+    first = post_event(test_client, headers, simulation_id, "사건 1")
+    second = post_event(test_client, headers, simulation_id, "사건 2")
+
+    listed = test_client.get(
+        f"/v1/simulations/{simulation_id}/events", headers=headers
+    )
+    assert listed.status_code == 200, listed.text
+    ids = [item["id"] for item in listed.json()]
+    assert ids == [first["id"], second["id"]]


### PR DESCRIPTION
## 작업 개요

프론트엔드의 사건 배너/알림 UI를 위해, 시뮬레이션에서 가장 최근 발생한 사건 1건을 조회하는 GET /v1/simulations/{simulation_id}/events/latest 엔드포인트를 추가한다. 기존 events 테이블/모델과 조회 로직을 재사용하며, 새로운 event 저장 구조는 만들지 않는다. (Issue [#182](https://github.com/magic-academy-ma/Magic-Academy/issues/182) 요구사항 중 #5만 구현)

## 관련 Issue

Related to #182 

## 변경 내용
app/api/events.py: GET /simulations/{simulation_id}/events/latest 추가. 인증/소유권은 기존 require_user_role + require_owned_simulation 재사용. 사건이 없으면 404.
app/services/events.py: latest_event(), event_participant_agent_ids() 추가. list_events()와 _events_for_simulation() 쿼리 필터를 공유하고, 정렬은 list_events의 키(created_at, id)를 역순으로만 적용.
app/api/schemas.py: EventResponse를 상속한 LatestEventResponse 추가 — tick, importance, target_agent_ids 3개 필드만 확장.
tests/test_events_latest_api.py: 신규 API 테스트 6개.
## 결정 사항 및 이유
데이터 source는 events 테이블만 사용. event_batch_results(내부 event engine 결과 JSONB)는 노출하지 않는다.
tick / importance는 events 컬럼에 없어 event engine(persist_event_batch)이 events.metadata(JSONB)에 이미 영속화한 값을 읽는다. 동일 방식의 선례가 event_frequency_history.py(Event.event_metadata["tick"])에 있어 이를 따랐고, event_batch_results 구조에는 의존하지 않는다. 수동 생성 이벤트(POST /events)는 해당 값이 없어 null / []로 응답한다.
target agent는 관계형 event_participants 테이블에서 조회.
summary 필드는 어디에도 없어 새로 만들지 않았다. 의미상 가장 근접한 실제 컬럼 description을 그대로 응답에 포함한다.
latest = 가장 최근 created_at(동률 시 id 역순). tick 내 여러 사건의 우선순위(importance 등) 규칙은 기존 도메인/코드에 없어 임의로 추가하지 않았다.
없을 때 404. 단건 리소스 부재에 404를 쓰는 기존 관례(GET .../event-results/{tick}의 "Event result not found")를 따랐다. 목록의 빈 배열 관례는 목록 API에만 적용.
## 테스트 / 확인 내용
 mypy app/api/events.py app/services/events.py app/api/schemas.py → 통과
 전체 pytest --co 컬렉션 751건 (신규 6건 포함) import 오류 없음
 pytest tests/test_events_latest_api.py tests/test_simulation_events.py → test_simulation_events(회귀) 통과
 Postgres 통합 테스트 미실행 — 로컬 환경에 DB가 없어 실행하지 못함. DB 있는 환경에서 아래 실행 필요:
TEST_DATABASE_URL=postgresql+psycopg://... python -m pytest tests/test_events_latest_api.py tests/test_websocket_api.py -q
 에러 케이스: 이벤트 없음(404), 타 사용자(403), 다른 simulation 이벤트 격리 — 테스트로 커버
 회귀: 기존 GET .../events 전체·순서 유지 테스트 추가
 관련 문서 업데이트 — 이번 작업 범위에서 문서 변경 없음

추가한 테스트:

test_latest_event_returns_most_recent_ordering — 3건 중 최신 반환, 수동 이벤트라 tick/importance=null
test_latest_event_is_scoped_to_its_simulation — 다른 simulation 이벤트 미혼입
test_latest_event_absent_returns_404
test_latest_event_exposes_engine_tick_importance_and_agents — persist_event_batch로 만든 엔진 이벤트에서 tick=1, importance=50, target_agent_ids 표면화
test_latest_event_enforces_ownership — 403
test_events_list_endpoint_still_returns_all — 기존 목록 API 회귀
## AI 사용 여부
사용 여부: 사용함 (Claude Code)
사용한 작업: 코드베이스 조사(기존 events endpoint/모델/enum/schema/persistence/fixture/테스트), 엔드포인트·서비스·스키마 구현, 테스트 작성
## 사람이 검토한 내용: data source 선택(events 테이블 우선, event_batch_results 미노출), summary 미생성 결정, latest 정렬 규칙, 404 응답 컨벤션, 테스트 커버리지
## 리뷰어가 봐야 할 부분
tick / importance를 events.metadata JSONB에서 읽는 방식이 허용 가능한지. (대안: events에 컬럼 추가 마이그레이션 — 이번 범위 밖으로 판단)
summary 미제공 — description을 그대로 쓰는 게 배너 UI에 충분한지, 아니면 별도 필드/이름이 필요한지.
latest = 최신 tick 여부 — 현재는 created_at DESC, id DESC. 같은 tick 내 "가장 중요한" 사건을 골라야 한다면 우선순위 규칙 정의 필요.
응답이 단건 객체 + 404 인지, 배열 + [] 를 원하는지.