### PR TITLE
[Feature] Event 상세 조회 API 추가

### DIFF
--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -3,14 +3,23 @@ from uuid import UUID
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.api.schemas import EventCreateRequest, EventResponse, LatestEventResponse
+from app.api.schemas import (
+    EventCreateRequest,
+    EventDetailResponse,
+    EventRelatedMemoryResponse,
+    EventResponse,
+    LatestEventResponse,
+)
 from app.core.database import get_db
 from app.core.security import require_user_role
 from app.domain.models import User
 from app.services.events import (
+    EventNotFoundError,
     InvalidEventLocationError,
     create_event,
     event_participant_agent_ids,
+    event_related_memories,
+    get_event,
     latest_event,
     list_events,
 )
@@ -101,4 +110,50 @@ def get_latest(
         tick=_metadata_int(metadata, "tick"),
         importance=_metadata_int(metadata, "importance"),
         target_agent_ids=event_participant_agent_ids(db, event.id),
+    )
+
+
+@router.get("/{event_id}", response_model=EventDetailResponse)
+def get_one(
+    simulation_id: UUID,
+    event_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> EventDetailResponse:
+    require_owned_simulation(db, simulation_id, current_user)
+    try:
+        event = get_event(db, simulation_id, event_id)
+    except EventNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        ) from exc
+    metadata = event.event_metadata or {}
+    return EventDetailResponse(
+        id=event.id,
+        simulation_id=event.simulation_id,
+        location_id=event.location_id,
+        event_type=event.event_type,
+        title=event.title,
+        description=event.description,
+        status=event.status,
+        simulation_day=event.simulation_day,
+        created_at=event.created_at,
+        tick=_metadata_int(metadata, "tick"),
+        importance=_metadata_int(metadata, "importance"),
+        impact_level=metadata.get("impact_level"),
+        source=metadata.get("source"),
+        event_subtype=metadata.get("event_subtype"),
+        target_agent_ids=event_participant_agent_ids(db, event.id),
+        related_memories=[
+            EventRelatedMemoryResponse(
+                id=memory.id,
+                agent_id=memory.agent_id,
+                content=memory.content,
+                memory_type=memory.memory_type,
+                importance=memory.importance,
+                created_tick=memory.created_tick,
+                occurred_at=memory.occurred_at,
+            )
+            for memory in event_related_memories(db, event.id)
+        ],
     )

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -146,6 +146,32 @@ class LatestEventResponse(EventResponse):
     target_agent_ids: list[UUID]
 
 
+class EventRelatedMemoryResponse(BaseModel):
+    # agent_memories 행 그대로. agent_memories.event_id FK 가 이 Event 를 가리키는 기억이다.
+    id: UUID
+    agent_id: UUID
+    content: str
+    memory_type: str
+    importance: int
+    created_tick: int
+    occurred_at: datetime
+
+
+class EventDetailResponse(EventResponse):
+    # tick / importance / impact_level / source / event_subtype 는 events 테이블
+    # 컬럼이 아니라 event engine(persist_event_batch)이 events.metadata(JSONB)에
+    # 남긴 값이다. 수동 생성 Event 에는 없으므로 nullable 이다.
+    tick: int | None
+    importance: int | None
+    impact_level: str | None
+    source: str | None
+    event_subtype: str | None
+    # 참여(대상) Agent 는 event_participants 테이블에서 조회한다.
+    target_agent_ids: list[UUID]
+    # 이 Event 를 참조하는 agent_memories 행.
+    related_memories: list[EventRelatedMemoryResponse]
+
+
 class SimulationShareCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -4,10 +4,14 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from uuid6 import uuid7
 
-from app.domain.models import Event, EventParticipant, Location
+from app.domain.models import AgentMemory, Event, EventParticipant, Location
 
 
 class InvalidEventLocationError(Exception):
+    pass
+
+
+class EventNotFoundError(Exception):
     pass
 
 
@@ -68,6 +72,34 @@ def latest_event(db: Session, simulation_id: UUID) -> Event | None:
         _events_for_simulation(simulation_id)
         .order_by(Event.created_at.desc(), Event.id.desc())
         .limit(1)
+    )
+
+
+def get_event(db: Session, simulation_id: UUID, event_id: UUID) -> Event:
+    """Return a single Event scoped to its Simulation.
+
+    The ``simulation_id`` filter is part of the lookup, not a post-check, so an
+    Event that belongs to another Simulation is indistinguishable from a missing
+    one and raises :class:`EventNotFoundError`.
+    """
+    event = db.scalar(_events_for_simulation(simulation_id).where(Event.id == event_id))
+    if event is None:
+        raise EventNotFoundError
+    return event
+
+
+def event_related_memories(db: Session, event_id: UUID) -> list[AgentMemory]:
+    """Return agent_memories rows whose ``event_id`` FK points at this Event.
+
+    Ordering reuses the ``agent_memories`` index key (``occurred_at``, ``id``)
+    used by the agent memories API; no new priority rule is introduced.
+    """
+    return list(
+        db.scalars(
+            select(AgentMemory)
+            .where(AgentMemory.event_id == event_id)
+            .order_by(AgentMemory.occurred_at.desc(), AgentMemory.id.desc())
+        )
     )
 
 

--- a/backend/tests/test_event_detail_api.py
+++ b/backend/tests/test_event_detail_api.py
@@ -1,0 +1,275 @@
+"""GET /v1/simulations/{simulation_id}/events/{event_id} — Issue #182-6.
+
+기존 events API 테스트 스타일(TEST_DATABASE_URL 필요, TestClient + register/login)을
+따른다. 엔진이 남긴 tick/importance/impact_level/source/참여 Agent/related_memory 는
+persist_event_batch 로 만든다.
+"""
+
+import os
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import sessionmaker
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def client():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE users, simulations, locations, agents, agent_states "
+                "RESTART IDENTITY CASCADE"
+            )
+        )
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client, session_factory
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client: TestClient, username: str) -> dict[str, str]:
+    password = "Detail-password!"
+    assert (
+        client.post(
+            "/v1/auth/register",
+            json={"username": username, "display_name": username, "password": password},
+        ).status_code
+        == 201
+    )
+    login = client.post("/v1/auth/login", json={"username": username, "password": password})
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def create_simulation(client: TestClient, headers: dict[str, str], name: str) -> str:
+    return client.post("/v1/simulations", headers=headers, json={"name": name}).json()["id"]
+
+
+def post_event(client: TestClient, headers: dict[str, str], simulation_id: str, title: str) -> dict:
+    response = client.post(
+        f"/v1/simulations/{simulation_id}/events",
+        headers=headers,
+        json={"event_type": "class", "title": title, "simulation_day": 1},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def persist_engine_event(session_factory, simulation_id: str) -> dict:
+    """엔진 경로(persist_event_batch)로 tick=1 Event 1건 + 그 Event 를 참조하는 기억 1건을 남긴다."""
+    from app.domain.event_persistence import EventBatch
+    from app.domain.models import Agent, AgentState
+    from app.services.event_persistence import persist_event_batch
+    from app.services.fixtures import seed_slice_zero
+
+    event_id = uuid4()
+    with session_factory() as session:
+        seed_slice_zero(session, UUID(simulation_id))
+        state = session.scalar(
+            select(AgentState)
+            .join(Agent, Agent.id == AgentState.agent_id)
+            .where(AgentState.simulation_id == UUID(simulation_id), Agent.fixture_key == "student-01")
+        )
+        batch = EventBatch.model_validate(
+            dict(
+                simulation_id=UUID(simulation_id),
+                run_id="detail-run",
+                tick_number=1,
+                policy_version="detail-policy",
+                resolver_version="detail-resolver",
+                resolution_id="detail-resolution",
+                events=[
+                    dict(
+                        id=event_id,
+                        event_type="GROUP_PROJECT",
+                        title="조별 과제",
+                        description="도서관에서 조별 과제를 했다.",
+                        participant_agent_ids=[state.agent_id],
+                        location_id=state.location_id,
+                        source="event_master",
+                        impact_level="medium",
+                        importance=50,
+                    )
+                ],
+                resolved_effects=[
+                    dict(
+                        source_agent_id=state.agent_id,
+                        metric="stress",
+                        before=state.stress,
+                        requested_total=1,
+                        applied_delta=1,
+                        after=state.stress + 1,
+                        effect_ids=["e1"],
+                    )
+                ],
+                memories=[
+                    dict(
+                        agent_id=state.agent_id,
+                        event_id=event_id,
+                        content="조별 과제가 힘들었다.",
+                        memory_type="observation",
+                        importance=40,
+                        occurred_at=datetime(2026, 1, 1, 9, 0, tzinfo=timezone.utc),
+                    )
+                ],
+            )
+        )
+        result = persist_event_batch(session, batch)
+        session.commit()
+        return result
+
+
+def test_event_detail_returns_manual_event(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "detail-manual")
+    simulation_id = create_simulation(test_client, headers, "manual")
+
+    created = post_event(test_client, headers, simulation_id, "수동 사건")
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/{created['id']}", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == created["id"]
+    assert body["simulation_id"] == simulation_id
+    assert body["event_type"] == "class"
+    assert body["title"] == "수동 사건"
+    assert body["status"] == "scheduled"
+    assert body["simulation_day"] == 1
+    # 수동 생성 Event 에는 엔진 metadata 가 없다.
+    assert body["tick"] is None
+    assert body["importance"] is None
+    assert body["impact_level"] is None
+    assert body["source"] is None
+    assert body["event_subtype"] is None
+    assert body["target_agent_ids"] == []
+    assert body["related_memories"] == []
+
+
+def test_event_detail_is_scoped_to_its_simulation(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "detail-scope")
+    simulation_a = create_simulation(test_client, headers, "sim-a")
+    simulation_b = create_simulation(test_client, headers, "sim-b")
+
+    event_b = post_event(test_client, headers, simulation_b, "B 사건")
+
+    # 다른 simulation 의 event_id 로는 조회할 수 없다.
+    response = test_client.get(
+        f"/v1/simulations/{simulation_a}/events/{event_b['id']}", headers=headers
+    )
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "Event not found"
+
+    # 올바른 simulation 으로는 조회된다.
+    ok = test_client.get(
+        f"/v1/simulations/{simulation_b}/events/{event_b['id']}", headers=headers
+    )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["id"] == event_b["id"]
+
+
+def test_event_detail_unknown_event_returns_404(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "detail-missing")
+    simulation_id = create_simulation(test_client, headers, "missing")
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/{uuid4()}", headers=headers
+    )
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "Event not found"
+
+
+def test_event_detail_unknown_simulation_returns_404(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "detail-nosim")
+
+    response = test_client.get(
+        f"/v1/simulations/{uuid4()}/events/{uuid4()}", headers=headers
+    )
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "Simulation not found"
+
+
+def test_event_detail_exposes_engine_fields_and_related_memories(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "detail-engine")
+    simulation_id = create_simulation(test_client, headers, "engine")
+
+    result = persist_engine_event(session_factory, simulation_id)
+    expected_event = result["events"][0]
+    expected_memory = result["memories"][0]
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/{expected_event['id']}", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == expected_event["id"]
+    assert body["event_type"] == "group_project"
+    assert body["description"] == "도서관에서 조별 과제를 했다."
+    assert body["tick"] == 1
+    assert body["importance"] == 50
+    assert body["impact_level"] == "medium"
+    assert body["source"] == "event_master"
+    assert body["event_subtype"] is None
+    participant_ids = list(expected_event["participant_agent_ids"])
+    assert body["target_agent_ids"] == participant_ids
+
+    assert len(body["related_memories"]) == 1
+    memory = body["related_memories"][0]
+    assert memory["id"] == expected_memory["id"]
+    assert memory["content"] == "조별 과제가 힘들었다."
+    assert memory["memory_type"] == "observation"
+    assert memory["importance"] == 40
+    assert memory["created_tick"] == 1
+    assert memory["agent_id"] == participant_ids[0]
+
+
+def test_event_detail_enforces_ownership(client) -> None:
+    test_client, _ = client
+    owner_headers = register_and_login(test_client, "detail-owner")
+    other_headers = register_and_login(test_client, "detail-intruder")
+    simulation_id = create_simulation(test_client, owner_headers, "owned")
+    created = post_event(test_client, owner_headers, simulation_id, "사건")
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/{created['id']}", headers=other_headers
+    )
+    assert response.status_code == 403, response.text
+
+
+def test_events_list_and_latest_endpoints_still_work(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "detail-regression")
+    simulation_id = create_simulation(test_client, headers, "regression")
+
+    first = post_event(test_client, headers, simulation_id, "사건 1")
+    second = post_event(test_client, headers, simulation_id, "사건 2")
+
+    listed = test_client.get(f"/v1/simulations/{simulation_id}/events", headers=headers)
+    assert listed.status_code == 200, listed.text
+    assert [item["id"] for item in listed.json()] == [first["id"], second["id"]]
+
+    latest = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/latest", headers=headers
+    )
+    assert latest.status_code == 200, latest.text
+    assert latest.json()["id"] == second["id"]

--- a/backend/tests/test_event_detail_api.py
+++ b/backend/tests/test_event_detail_api.py
@@ -261,12 +261,23 @@ def test_events_list_and_latest_endpoints_still_work(client) -> None:
     headers = register_and_login(test_client, "detail-regression")
     simulation_id = create_simulation(test_client, headers, "regression")
 
+    # 새 simulation 에는 seed 된 CLASS Event 1건이 이미 있다 (seed_slice_zero).
+    seeded = test_client.get(
+        f"/v1/simulations/{simulation_id}/events", headers=headers
+    ).json()
+    assert len(seeded) == 1
+
     first = post_event(test_client, headers, simulation_id, "사건 1")
     second = post_event(test_client, headers, simulation_id, "사건 2")
 
     listed = test_client.get(f"/v1/simulations/{simulation_id}/events", headers=headers)
     assert listed.status_code == 200, listed.text
-    assert [item["id"] for item in listed.json()] == [first["id"], second["id"]]
+    # 기존 list 엔드포인트는 그대로: seed + 새 Event 2건을 created_at, id 순으로 반환.
+    assert [item["id"] for item in listed.json()] == [
+        seeded[0]["id"],
+        first["id"],
+        second["id"],
+    ]
 
     latest = test_client.get(
         f"/v1/simulations/{simulation_id}/events/latest", headers=headers


### PR DESCRIPTION
## 작업 개요

프론트엔드가 특정 사건을 선택했을 때 상세 정보를 조회할 수 있도록 GET /v1/simulations/{simulation_id}/events/{event_id} 엔드포인트를 추가했다. 기존 Event 모델·metadata·event_participants·agent_memories에 실제로 저장돼 있는 데이터만 매핑했고, 요구사항 문서의 factors / prediction / technical처럼 현재 소스가 없는 필드는 가짜 placeholder로 채우지 않고 제외했다.

Issue [#182](https://github.com/magic-academy-ma/Magic-Academy/issues/182) API 요구사항 6개 중 6번(Event Detail)만 구현한다. 별도 PR로 다시 쪼개지 않는다.

## 관련 Issue

Related to #182

## 변경 내용
backend/app/services/events.py
EventNotFoundError 예외 추가
get_event(db, simulation_id, event_id) — simulation_id를 조회 조건에 포함시켜, 다른 simulation에 속한 Event는 "없음"과 구분되지 않도록 처리(존재하면 EventNotFoundError)
event_related_memories(db, event_id) — agent_memories.event_id FK로 해당 Event를 참조하는 기억 조회. 정렬 키는 agent memories API와 동일(occurred_at DESC, id DESC)
backend/app/api/schemas.py
EventRelatedMemoryResponse, EventDetailResponse 추가. EventDetailResponse는 기존 EventResponse를 상속하고 tick / importance / impact_level / source / event_subtype(모두 metadata 유래, nullable) + target_agent_ids + related_memories를 확장
backend/app/api/events.py
GET /{event_id} 핸들러(get_one) 추가. 소유권 검증(require_owned_simulation) → Event 조회(404 처리) → metadata / participants / related_memories 매핑
라우트는 GET /latest 뒤에 등록해 경로 충돌 없음
backend/tests/test_event_detail_api.py (신규, 7 케이스)

기존 GET /events, GET /events/latest, POST /events, Event schema는 변경하지 않았다.

## 결정 사항 및 이유
응답 필드는 실제 data source가 있는 것만 포함
id / event_type / simulation_id / location_id / title / description / status / simulation_day / created_at → events 테이블 컬럼
tick / importance / impact_level / source / event_subtype → events.metadata(JSONB). 엔진(persist_event_batch)이 생성한 Event에만 존재하고 수동 생성 Event에는 없으므로 전부 nullable. 기존 LatestEventResponse가 tick/importance를 metadata에서 읽는 방식과 동일하게 처리
target_agent_ids → event_participants.agent_id (/latest와 동일)
related_memories → agent_memories의 event_id FK. 요구사항의 related_memory에 대응하는 유일하게 확인된 실제 소스라 이번에 추가
factors / prediction / technical은 넣지 않음
prediction 후보인 EventWrite.expected_effects는 현재 파이프라인(event_master.py, manual_tick.py)에서 항상 {}라 의미 있는 값이 아님
factors는 이벤트 단위 소스가 없음. event_batch_results.result_payload.resolved_effects는 tick 배치 단위라 이벤트별로 대응되지 않고, 내부 JSONB 구조에 API가 과하게 의존하게 됨
technical(run_id/policy/resolver 버전)은 event_batch_results에 (simulation_id, tick_number) 키로만 존재. 역조인 + JSONB 의존이 필요
simulation scope 검증을 조회 조건에 포함
event_id만으로 조회하지 않고 Event.simulation_id == simulation_id를 WHERE에 함께 걸었다. 다른 simulation의 Event는 404 "Event not found"로 응답해 존재 여부가 새지 않도록 했다
에러 처리는 기존 convention을 따름
존재하지 않는 simulation / 소유자 아님 → require_owned_simulation이 던지는 404 "Simulation not found" / 403 "Simulation access denied"
존재하지 않는 event / 다른 simulation의 event → 404 "Event not found"
events.started_at / ended_at은 제외
컬럼은 있으나 create_event·persist_event_batch 어디서도 기록하지 않아 항상 null이라, 노출하면 사실상 placeholder가 됨
## 테스트 / 확인 내용
 로컬 실행 확인 — Docker 미실행 환경이라 DB 연동 테스트는 skip됨(TEST_DATABASE_URL 없을 때 skip, sibling test_events_latest_api.py와 동일 조건). CI(backend-e2e.yml)에서는 Postgres 서비스로 실행됨
 주요 기능 동작 확인 — 테스트로 커버 (아래)
 에러 케이스 확인 — 없는 event(404), 다른 simulation의 event(404), 없는 simulation(404), 타 사용자(403)
 관련 문서 업데이트 확인 — 이번 범위에서 신규/변경 문서 없음

전체 스위트: 538 passed, 220 skipped (회귀 없음)
mypy app/api/events.py app/services/events.py: 이슈 없음

신규 테스트 (backend/tests/test_event_detail_api.py):

test_event_detail_returns_manual_event — 수동 생성 Event 정상 조회, 엔진 metadata 필드 전부 null, 참여자·기억 빈 배열
test_event_detail_is_scoped_to_its_simulation — 다른 simulation_id로 조회 시 404, 올바른 simulation은 200
test_event_detail_unknown_event_returns_404 — 없는 event_id → 404
test_event_detail_unknown_simulation_returns_404 — 없는 simulation → 404 "Simulation not found"
test_event_detail_exposes_engine_fields_and_related_memories — persist_event_batch로 만든 Event에서 tick/importance/impact_level/source/target_agent_ids/related_memories 매핑 검증
test_event_detail_enforces_ownership — 타 사용자 → 403
test_events_list_and_latest_endpoints_still_work — 기존 GET "", GET "/latest" 회귀
## AI 사용 여부

사용 여부: 사용함
사용한 작업: 코드베이스 조사(Event 모델·events API·event_persistence·fixture·테스트), GET /{event_id} 엔드포인트/서비스/스키마 구현, 테스트 작성, 실행 결과 정리
사람이 검토한 내용: 응답 필드별 실제 data source 존재 여부(특히 metadata JSONB 필드가 엔진 경로에서만 채워진다는 점), simulation scope를 조회 조건에 넣었는지, 에러 status code가 기존 convention과 일치하는지, factors/prediction/technical을 placeholder로 넣지 않았는지, 라우트 등록 순서(/latest와 /{event_id} 충돌 여부)

## 리뷰어가 봐야 할 부분
EventDetailResponse 필드 범위 — metadata 유래 필드(impact_level, source, event_subtype)를 이번에 추가했다. /latest는 tick/importance만 노출하는데, 상세 조회라 더 넣었다. 일관성 문제로 보이면 뺄 수 있음
scope 검증을 404로 처리한 점 — 다른 simulation의 event를 403이 아니라 404("Event not found")로 응답한다. 존재 노출 방지 목적이고 agents 서비스도 유사하게 404를 쓴다
related_memories 정렬/개수 제한 없음 — 현재 해당 Event를 참조하는 기억 전부를 반환한다. agent memories API는 limit(1~10)이 있는데 여기선 안 걸었다. 상한이 필요하면 코멘트 부탁
라우트 순서 의존 — GET /{event_id}가 GET /latest 뒤에 있어야 한다(event_id: UUID라 "latest"는 422로도 걸리지만 순서로도 안전장치). 파일 내 위치 유지 필요