### PR TITLE
[Feature] Simulation 통합 로그 타임라인 API

### DIFF
--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -5,6 +5,7 @@ from app.api.auth import router as auth_router
 from app.api.events import router as events_router
 from app.api.simulation_history import router as simulation_history_router
 from app.api.simulation_imports import router as simulation_imports_router
+from app.api.simulation_logs import router as simulation_logs_router
 from app.api.simulation_shares import router as simulation_shares_router
 from app.api.simulations import router as simulations_router
 from app.api.ticks import router as ticks_router
@@ -19,6 +20,7 @@ api_router.include_router(simulations_router)
 api_router.include_router(simulation_history_router)
 api_router.include_router(simulation_shares_router)
 api_router.include_router(simulation_imports_router)
+api_router.include_router(simulation_logs_router)
 api_router.include_router(ticks_router)
 api_router.include_router(user_persona_router)
 api_router.include_router(websockets_router)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -172,6 +172,30 @@ class EventDetailResponse(EventResponse):
     related_memories: list[EventRelatedMemoryResponse]
 
 
+class SimulationLogEntryResponse(BaseModel):
+    # 통합 로그 타임라인 한 줄. 새 저장소 없이 기존에 영속화된 데이터만 모은다:
+    #   - events 테이블 (엔진 Event + 수동 Event)
+    #   - agent_memories 테이블 중 memory_type == 'conversation' (대화 기록)
+    id: UUID
+    # 엔진 Event 는 events.metadata(JSONB).tick, 대화 기록은 agent_memories.created_tick.
+    # 수동 생성 Event 에는 tick 이 없어 None 이다.
+    tick: int | None
+    # system : Magic Layer 가 남긴 Event (events.metadata.source == 'magic_layer')
+    # event  : 그 밖의 Event
+    # dialogue : memory_type == 'conversation' 인 agent_memories 행
+    type: Literal["system", "event", "dialogue"]
+    # Event 는 title, 대화 기록은 content. 요약을 새로 생성하지 않고 원문을 그대로 쓴다.
+    summary: str
+    # Event 는 event_participants, 대화 기록은 해당 기억의 agent_id.
+    target_agent_ids: list[UUID]
+    # 엔진 Event 는 events.metadata.importance, 대화 기록은 agent_memories.importance.
+    importance: int | None
+    # Event Detail API 로 연결하기 위한 참조. Event 행은 자기 id, 대화 기록은
+    # agent_memories.event_id FK (없으면 None). Dialogue 상세(dialogue_id)는
+    # 아직 Dialogue 영속화가 없어 제공하지 않는다.
+    event_id: UUID | None
+
+
 class SimulationShareCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/api/simulation_logs.py
+++ b/backend/app/api/simulation_logs.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.schemas import SimulationLogEntryResponse
+from app.core.database import get_db
+from app.core.security import require_user_role
+from app.domain.models import User
+from app.services.simulation_logs import list_simulation_logs
+from app.services.simulations import require_owned_simulation
+
+router = APIRouter(prefix="/simulations/{simulation_id}/logs", tags=["logs"])
+
+
+@router.get("", response_model=list[SimulationLogEntryResponse])
+def get_all(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> list[SimulationLogEntryResponse]:
+    require_owned_simulation(db, simulation_id, current_user)
+    return list_simulation_logs(db, simulation_id)

--- a/backend/app/services/simulation_logs.py
+++ b/backend/app/services/simulation_logs.py
@@ -1,0 +1,100 @@
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.schemas import SimulationLogEntryResponse
+from app.domain.models import Agent, AgentMemory, Event, EventParticipant
+
+
+def _metadata_int(metadata: dict, key: str) -> int | None:
+    """events.metadata(JSONB) 의 숫자 값을 안전하게 읽는다 (app/api/events.py 와 동일)."""
+    value = metadata.get(key)
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def list_simulation_logs(
+    db: Session, simulation_id: UUID
+) -> list[SimulationLogEntryResponse]:
+    """요청한 Simulation 의 통합 로그 타임라인.
+
+    새 Log 저장소를 만들지 않고, 이미 영속화된 두 소스만 합친다.
+
+    * ``events`` — 엔진(persist_event_batch)이 남긴 Event 와 수동 생성 Event.
+      ``metadata.source == 'magic_layer'`` 이면 ``system``, 아니면 ``event``.
+    * ``agent_memories`` 중 ``memory_type == 'conversation'`` — ``dialogue``.
+      agent_memories 에는 simulation_id 컬럼이 없어 agents 를 통해 범위를 좁힌다.
+
+    정렬은 기존 도메인 규칙을 재사용한다: tick 오름차순(수동 Event 처럼 tick 이
+    없으면 시뮬레이션 이전의 준비 기록으로 보고 맨 앞), 같은 tick 안에서는 행 id
+    (uuid7 — 생성 시각 순) 오름차순. 새 우선순위 규칙(importance 우선 등)은
+    도입하지 않는다.
+    """
+    events = list(
+        db.scalars(select(Event).where(Event.simulation_id == simulation_id))
+    )
+
+    participants: dict[UUID, list[UUID]] = {}
+    if events:
+        rows = db.execute(
+            select(EventParticipant.event_id, EventParticipant.agent_id)
+            .where(EventParticipant.event_id.in_([event.id for event in events]))
+            .order_by(EventParticipant.event_id, EventParticipant.agent_id)
+        )
+        for event_id, agent_id in rows:
+            participants.setdefault(event_id, []).append(agent_id)
+
+    conversations = list(
+        db.scalars(
+            select(AgentMemory)
+            .join(Agent, Agent.id == AgentMemory.agent_id)
+            .where(
+                Agent.simulation_id == simulation_id,
+                AgentMemory.memory_type == "conversation",
+            )
+        )
+    )
+
+    entries: list[tuple[int, UUID, SimulationLogEntryResponse]] = []
+    for event in events:
+        metadata = event.event_metadata or {}
+        tick = _metadata_int(metadata, "tick")
+        entries.append(
+            (
+                tick if tick is not None else 0,
+                event.id,
+                SimulationLogEntryResponse(
+                    id=event.id,
+                    tick=tick,
+                    type="system"
+                    if metadata.get("source") == "magic_layer"
+                    else "event",
+                    summary=event.title,
+                    target_agent_ids=participants.get(event.id, []),
+                    importance=_metadata_int(metadata, "importance"),
+                    event_id=event.id,
+                ),
+            )
+        )
+    for memory in conversations:
+        entries.append(
+            (
+                memory.created_tick,
+                memory.id,
+                SimulationLogEntryResponse(
+                    id=memory.id,
+                    tick=memory.created_tick,
+                    type="dialogue",
+                    summary=memory.content,
+                    target_agent_ids=[memory.agent_id],
+                    importance=memory.importance,
+                    event_id=memory.event_id,
+                ),
+            )
+        )
+
+    entries.sort(key=lambda item: (item[0], item[1]))
+    return [entry for _, _, entry in entries]

--- a/backend/tests/test_simulation_logs_api.py
+++ b/backend/tests/test_simulation_logs_api.py
@@ -1,0 +1,357 @@
+"""GET /v1/simulations/{simulation_id}/logs — Issue #182-7.
+
+기존 events API 테스트 스타일(TEST_DATABASE_URL 필요, TestClient + register/login)을
+따른다. 통합 로그의 소스는 이미 영속화된 데이터뿐이다:
+  - events 테이블 (엔진 Event + 수동 Event)
+  - agent_memories 테이블 중 memory_type == 'conversation'
+엔진이 남긴 tick/importance/source/참여 Agent/대화 기억은 persist_event_batch 로 만든다.
+"""
+
+import os
+from datetime import datetime, timezone
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, delete, select, text
+from sqlalchemy.orm import sessionmaker
+from uuid6 import uuid7
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def client():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE users, simulations, locations, agents, agent_states "
+                "RESTART IDENTITY CASCADE"
+            )
+        )
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client, session_factory
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client: TestClient, username: str) -> dict[str, str]:
+    password = "Logs-password!"
+    assert (
+        client.post(
+            "/v1/auth/register",
+            json={"username": username, "display_name": username, "password": password},
+        ).status_code
+        == 201
+    )
+    login = client.post("/v1/auth/login", json={"username": username, "password": password})
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def create_simulation(client: TestClient, headers: dict[str, str], name: str) -> str:
+    return client.post("/v1/simulations", headers=headers, json={"name": name}).json()["id"]
+
+
+def post_event(client: TestClient, headers: dict[str, str], simulation_id: str, title: str) -> dict:
+    response = client.post(
+        f"/v1/simulations/{simulation_id}/events",
+        headers=headers,
+        json={"event_type": "class", "title": title, "simulation_day": 1},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def get_logs(client: TestClient, headers: dict[str, str], simulation_id: str):
+    response = client.get(f"/v1/simulations/{simulation_id}/logs", headers=headers)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def persist_engine_tick(session_factory, simulation_id: str, *, run_id: str) -> dict:
+    """persist_event_batch 로 tick=1 에:
+      - event_master Event 1건 (조별 과제)     -> log type 'event'
+      - magic_layer  Event 1건 (저주 확산)     -> log type 'system'
+      - observation 기억 1건 (로그에 안 나옴)
+      - conversation 기억 1건                    -> log type 'dialogue'
+    을 남기고 result payload 를 돌려준다.
+    """
+    from app.domain.event_persistence import EventBatch
+    from app.domain.models import Agent, AgentState
+    from app.services.event_persistence import persist_event_batch
+    from app.services.fixtures import seed_slice_zero
+
+    normal_event_id = uuid7()
+    magic_event_id = uuid7()
+    with session_factory() as session:
+        seed_slice_zero(session, UUID(simulation_id))
+        states = list(
+            session.scalars(
+                select(AgentState)
+                .join(Agent, Agent.id == AgentState.agent_id)
+                .where(AgentState.simulation_id == UUID(simulation_id))
+                .order_by(Agent.fixture_key)
+            )
+        )
+        speaker, listener = states[0], states[1]
+        batch = EventBatch.model_validate(
+            dict(
+                simulation_id=UUID(simulation_id),
+                run_id=run_id,
+                tick_number=1,
+                policy_version="logs-policy",
+                resolver_version="logs-resolver",
+                resolution_id="logs-resolution",
+                events=[
+                    dict(
+                        id=normal_event_id,
+                        event_type="GROUP_PROJECT",
+                        title="조별 과제",
+                        description="도서관에서 조별 과제를 했다.",
+                        participant_agent_ids=[speaker.agent_id, listener.agent_id],
+                        location_id=speaker.location_id,
+                        source="event_master",
+                        impact_level="medium",
+                        importance=50,
+                    ),
+                    dict(
+                        id=magic_event_id,
+                        event_type="CURSE_SPREAD",
+                        title="저주 확산",
+                        description="복도에 저주가 번졌다.",
+                        participant_agent_ids=[listener.agent_id],
+                        location_id=listener.location_id,
+                        source="magic_layer",
+                        impact_level="high",
+                        importance=80,
+                    ),
+                ],
+                resolved_effects=[
+                    dict(
+                        source_agent_id=speaker.agent_id,
+                        metric="stress",
+                        before=speaker.stress,
+                        requested_total=1,
+                        applied_delta=1,
+                        after=speaker.stress + 1,
+                        effect_ids=["e1"],
+                    )
+                ],
+                memories=[
+                    dict(
+                        agent_id=speaker.agent_id,
+                        event_id=normal_event_id,
+                        content="조별 과제가 힘들었다.",
+                        memory_type="observation",
+                        importance=40,
+                        occurred_at=datetime(2026, 1, 1, 9, 0, tzinfo=timezone.utc),
+                    ),
+                    dict(
+                        agent_id=speaker.agent_id,
+                        event_id=normal_event_id,
+                        content="리아: 이번 과제 같이 하자. / 아델: 좋아, 도서관에서 보자.",
+                        memory_type="conversation",
+                        importance=55,
+                        occurred_at=datetime(2026, 1, 1, 9, 5, tzinfo=timezone.utc),
+                    ),
+                ],
+            )
+        )
+        result = persist_event_batch(session, batch)
+        session.commit()
+        return result
+
+
+def test_logs_return_events_and_conversations_in_one_timeline(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "logs-normal")
+    simulation_id = create_simulation(test_client, headers, "normal")
+
+    # 준비: 수동 Event 1건(엔진 tick 없음) -> 그 다음 엔진 tick 1.
+    manual = post_event(test_client, headers, simulation_id, "수동 사건")
+    result = persist_engine_tick(session_factory, simulation_id, run_id="logs-normal-run")
+    normal_event = result["events"][0]
+    magic_event = result["events"][1]
+    conversation = next(
+        memory for memory in result["memories"] if memory["memory_type"] == "conversation"
+    )
+
+    logs = get_logs(test_client, headers, simulation_id)
+
+    by_id = {item["id"]: item for item in logs}
+    # seed 된 CLASS Event + 수동 Event + 엔진 Event 2건 + 대화 기억 1건.
+    # observation 기억은 로그에 포함되지 않는다.
+    assert manual["id"] in by_id
+    assert normal_event["id"] in by_id
+    assert magic_event["id"] in by_id
+    assert conversation["id"] in by_id
+    observation = next(
+        memory for memory in result["memories"] if memory["memory_type"] == "observation"
+    )
+    assert observation["id"] not in by_id
+
+    assert by_id[manual["id"]]["type"] == "event"
+    assert by_id[manual["id"]]["tick"] is None
+    assert by_id[normal_event["id"]]["type"] == "event"
+    assert by_id[normal_event["id"]]["tick"] == 1
+    assert by_id[normal_event["id"]]["importance"] == 50
+    assert by_id[magic_event["id"]]["type"] == "system"
+    assert by_id[magic_event["id"]]["importance"] == 80
+
+    dialogue = by_id[conversation["id"]]
+    assert dialogue["type"] == "dialogue"
+    assert dialogue["tick"] == 1
+    assert dialogue["summary"] == conversation["content"]
+    assert dialogue["importance"] == 55
+    # Dialogue 영속화가 없어 dialogue_id 필드는 응답에 없다.
+    assert "dialogue_id" not in dialogue
+
+
+def test_logs_are_ordered_by_tick_then_row_id(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "logs-order")
+    simulation_id = create_simulation(test_client, headers, "order")
+
+    seeded_class = test_client.get(
+        f"/v1/simulations/{simulation_id}/events", headers=headers
+    ).json()[0]
+    manual = post_event(test_client, headers, simulation_id, "수동 사건")
+    result = persist_engine_tick(session_factory, simulation_id, run_id="logs-order-run")
+    normal_event = result["events"][0]
+    magic_event = result["events"][1]
+    conversation = next(
+        memory for memory in result["memories"] if memory["memory_type"] == "conversation"
+    )
+
+    logs = get_logs(test_client, headers, simulation_id)
+
+    # tick 없는 Event(준비 기록)가 먼저, 그 뒤 tick=1 기록이 행 id(uuid7) 순으로.
+    assert [item["id"] for item in logs] == [
+        seeded_class["id"],
+        manual["id"],
+        normal_event["id"],
+        magic_event["id"],
+        conversation["id"],
+    ]
+    assert [item["tick"] for item in logs] == [None, None, 1, 1, 1]
+
+
+def test_logs_are_scoped_to_their_simulation(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "logs-scope")
+    simulation_a = create_simulation(test_client, headers, "sim-a")
+    simulation_b = create_simulation(test_client, headers, "sim-b")
+
+    post_event(test_client, headers, simulation_a, "A 수동 사건")
+    result_b = persist_engine_tick(session_factory, simulation_b, run_id="logs-scope-run-b")
+    b_ids = {result_b["events"][0]["id"], result_b["events"][1]["id"]} | {
+        memory["id"] for memory in result_b["memories"]
+    }
+
+    logs_a = get_logs(test_client, headers, simulation_a)
+    a_ids = {item["id"] for item in logs_a}
+
+    assert a_ids.isdisjoint(b_ids)
+    # A 는 seed CLASS + 수동 Event 만. 대화/시스템 로그는 없다.
+    assert all(item["type"] == "event" for item in logs_a)
+
+    logs_b = get_logs(test_client, headers, simulation_b)
+    assert {"dialogue", "system"} <= {item["type"] for item in logs_b}
+
+
+def test_event_log_item_references_its_event_id(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "logs-eventref")
+    simulation_id = create_simulation(test_client, headers, "eventref")
+
+    result = persist_engine_tick(session_factory, simulation_id, run_id="logs-eventref-run")
+    normal_event = result["events"][0]
+    conversation = next(
+        memory for memory in result["memories"] if memory["memory_type"] == "conversation"
+    )
+
+    logs = get_logs(test_client, headers, simulation_id)
+    by_id = {item["id"]: item for item in logs}
+
+    # Event 로그는 자기 자신을 event_id 로 참조한다.
+    assert by_id[normal_event["id"]]["event_id"] == normal_event["id"]
+    # 대화 로그는 그 대화가 매달린 Event 를 event_id 로 참조한다 (agent_memories.event_id FK).
+    assert by_id[conversation["id"]]["event_id"] == normal_event["id"]
+
+
+def test_logs_empty_simulation_returns_empty_list(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "logs-empty")
+    simulation_id = create_simulation(test_client, headers, "empty")
+
+    # 새 simulation 은 seed 된 CLASS Event 를 갖는다. 로그가 하나도 없는 상태를
+    # 만들기 위해 직접 제거한다 (event_participants 를 먼저 지운다).
+    from app.domain.models import Event, EventParticipant
+
+    with session_factory() as session:
+        owned = select(Event.id).where(Event.simulation_id == UUID(simulation_id))
+        session.execute(delete(EventParticipant).where(EventParticipant.event_id.in_(owned)))
+        session.execute(delete(Event).where(Event.simulation_id == UUID(simulation_id)))
+        session.commit()
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/logs", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == []
+
+
+def test_logs_enforce_ownership(client) -> None:
+    test_client, _ = client
+    owner_headers = register_and_login(test_client, "logs-owner")
+    other_headers = register_and_login(test_client, "logs-intruder")
+    simulation_id = create_simulation(test_client, owner_headers, "owned")
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/logs", headers=other_headers
+    )
+    assert response.status_code == 403, response.text
+
+
+def test_events_api_still_works_alongside_logs(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "logs-regression")
+    simulation_id = create_simulation(test_client, headers, "regression")
+
+    seeded = test_client.get(
+        f"/v1/simulations/{simulation_id}/events", headers=headers
+    ).json()
+    assert len(seeded) == 1
+
+    first = post_event(test_client, headers, simulation_id, "사건 1")
+    second = post_event(test_client, headers, simulation_id, "사건 2")
+
+    listed = test_client.get(f"/v1/simulations/{simulation_id}/events", headers=headers)
+    assert [item["id"] for item in listed.json()] == [
+        seeded[0]["id"],
+        first["id"],
+        second["id"],
+    ]
+
+    latest = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/latest", headers=headers
+    )
+    assert latest.status_code == 200, latest.text
+    assert latest.json()["id"] == second["id"]
+
+    detail = test_client.get(
+        f"/v1/simulations/{simulation_id}/events/{first['id']}", headers=headers
+    )
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["id"] == first["id"]


### PR DESCRIPTION
## 작업 개요

프론트엔드 Simulation 화면의 Event Log가 필요로 하는 통합 로그 타임라인 조회 API를 추가한다. 시스템/중요 사건과 대화 기록을 하나의 시간순 timeline으로 반환한다. 새 Log 저장소나 요약 파이프라인은 만들지 않고, 이미 영속화된 events + agent_memories(conversation) 데이터만 조합한다.

## 관련 Issue

Related to #182 

## 변경 내용
GET /v1/simulations/{simulation_id}/logs 엔드포인트 추가 (app/api/simulation_logs.py, router.py 등록)
list_simulation_logs() 서비스 추가 (app/services/simulation_logs.py) — events(엔진 + 수동)와 memory_type='conversation'인 agent_memories를 합쳐 tick 순 타임라인 생성
SimulationLogEntryResponse 스키마 추가 (app/api/schemas.py): id / tick / type / summary / target_agent_ids / importance / event_id
테스트 7건 추가 (tests/test_simulation_logs_api.py)
순수 추가(506 insertions, 코드 ~150줄 + 테스트 357줄), 기존 파일 로직 수정 없음
## 결정 사항 및 이유
새 Log 테이블 안 만듦: system/event/dialogue 통합 타임라인, tick 정렬, simulation 격리, Event 참조가 기존 events + agent_memories만으로 모두 충족됨.
RuntimeResult를 source로 쓰지 않음: DB에는 있으나 run_id 기반 내부 LLM 실행 산출물. 대화 내용의 재현 가능한 영속 형태는 agent_memories(memory_type='conversation')이므로 그것을 dialogue source로 사용.
type 매핑은 기존 source 컨벤션 재사용: events.metadata.source == 'magic_layer'(시스템 컴포넌트) → system, 그 외 Event → event, conversation 기억 → dialogue. 새 type을 늘리지 않음. "중요 사건"은 별도 type이 아니라 importance 필드로 표현.
정렬: (tick, 행 id) 오름차순. tick 없는 수동/seed Event는 0으로 취급해 앞에 둠(엔진 tick은 항상 ≥ 1). 같은 tick 내에서는 uuid7 id(생성 시각 내장) 순 → "사건 발생 → 그에 대한 기억/대화" 순서가 자연히 나옴. importance 우선 같은 새 규칙은 도입하지 않음.
dialogue_id 미제공: Dialogue/Conversation 영속화 모델이 없어 가짜 ID를 만들지 않음. 대화 로그는 agent_memories.event_id FK가 있으면 event_id로 노출.
응답 형식: 형제 Events API와 동일하게 envelope 없는 순수 배열, 빈 결과는 []. pagination 미도입(Events API에도 없음). target_agent는 이 시리즈 기존 컨벤션(LatestEventResponse.target_agent_ids)에 맞춰 복수형 리스트.
## 테스트 / 확인 내용
 전체 스위트 python -m pytest -q → 538 passed, 227 skipped, 회귀/수집 오류 없음
 app.openapi()에 /v1/simulations/{simulation_id}/logs 등록 확인
 신규 테스트 7건 수집 확인
 DB 연동 테스트 미실행 — 로컬에 Postgres/Docker 데몬이 없어 TEST_DATABASE_URL 지정 실행 불가. 신규 7건은 기존 형제 API 테스트와 동일하게 TEST_DATABASE_URL 없으면 skip → CI(backend-e2e.yml) 또는 docker compose exec backend python -m pytest -q tests/test_simulation_logs_api.py로 확인 필요
 에러 케이스: 소유자 아님 403, 빈 simulation [] (테스트 포함)

테스트 커버리지: 정상 조회 / simulation 격리 / tick·id 정렬 / type 구분(system·event·dialogue) / Event reference(event_id) / Dialogue reference(가짜 ID 없음, 실제 FK 연결) / 빈 결과 / 기존 Events list·latest·detail 회귀 / 소유권.

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 코드베이스 조사(Event/AgentMemory/RuntimeResult/tick 처리/persist_event_batch), 설계 결정, 서비스·스키마·라우터·테스트 구현 초안
사람이 검토한 내용: data source 선택(RuntimeResult 제외), type 매핑, 정렬 기준, dialogue_id 미제공 결정, DB 테스트 실행 환경 한계

## 리뷰어가 봐야 할 부분
type 매핑 — magic_layer Event를 system으로 본 판단이 화면 의도("시스템 사건")와 맞는지.
정렬 — tick 없는 Event(수동 POST /events)를 0으로 취급해 맨 앞에 두는 것. mid-simulation에 수동 생성된 Event는 시간상 뒤여도 앞에 정렬됨(seed CLASS Event가 대부분의 케이스라 실제 문제는 적음).
target_agent_ids 복수형 — 스펙 예시는 target_agent(단수)였으나 LatestEventResponse 컨벤션을 따름.
후속 필요 — 화면의 openDialogueViewer('ria-kai') 대화 상세 이동에 필요한 dialogue_id와 화자-청자 쌍은 Dialogue persistence 선행 작업이 있어야 제공 가능.