### PR TITLE
[Fix] Inspector 테스트 실패 2건 수정 — 버튼 추가 및 heading 구조 변경

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -473,6 +473,7 @@ export default function App() {
           <button type="button" onClick={() => { /* TODO: 밤 스킵 API 미확정 */ }}>
             밤 스킵
           </button>
+          <button type="button" onClick={() => setShowInspectorModal(true)}>Inspector 열기</button>
         </div>
         <div className="header-right">
           <button type="button" className="header-save" onClick={() => setScreen("save")}>저장</button>

--- a/frontend/src/components/InspectorPanel.jsx
+++ b/frontend/src/components/InspectorPanel.jsx
@@ -96,7 +96,7 @@ export default function InspectorPanel({ agent, simulationId, token, currentTick
   if (!agent) return <aside className="panel inspector-panel"><h2>Inspector</h2><EmptyState>Agent를 선택하세요.</EmptyState></aside>;
 
   return <aside className="panel inspector-panel" aria-label="Agent Inspector">
-    <div className="inspector-header"><div><p className="eyebrow">AGENT INSPECTOR</p><h2>{detail?.name ?? agent.name}</h2></div><button type="button" className="inspector-close" onClick={onClose}>닫기</button></div>
+    <div className="inspector-header"><div><h2>Inspector</h2><h3>{detail?.name ?? agent.name}</h3></div><button type="button" className="inspector-close" onClick={onClose}>닫기</button></div>
     {loading && <p className="inspector-loading">상세 데이터를 불러오는 중...</p>}
     {error && <p className="message error" role="alert">{error}</p>}
     <section><h3>프로필</h3><div className="profile-summary"><strong>{detail?.name ?? agent.name}</strong><span>{detail?.agent_type ?? agent.agent_type}</span><span>{detail?.mbti_type ?? agent.mbti_type}</span>{detail?.is_user_persona && <b className="persona-badge">User Persona</b>}</div><dl className="inspector-details"><dt>학년</dt><dd>{detail?.student_profile ? `${detail.student_profile.grade}학년` : "-"}</dd><dt>전공</dt><dd>{detail?.student_profile?.interest_field ?? organizations.find((item) => item.organization_type === "major")?.name ?? "-"}</dd><dt>위치</dt><dd>{detail?.location?.name ?? "-"}</dd></dl><div className="meter-list">{BIG_FIVE.map(([key, label]) => <BigFiveBar key={key} value={profile[key]} label={label} />)}</div></section>


### PR DESCRIPTION
## 문제

develop 머지 후 프론트엔드 테스트 2건 실패:

1. `App.test.jsx > toggles pause UI and opens the selected agent Inspector modal`
   - "Inspector 열기" 버튼이 App.jsx에 없어서 클릭 불가
2. `App.mock.test.jsx > 백엔드 없이 로그인하고 ... Inspector에 표시한다`
   - InspectorPanel이 에이전트 선택 시 `<h2>{이름}</h2>`만 렌더링해
     `heading 'Inspector'`와 `heading '에단'`을 동시에 찾는 테스트 실패

## 변경 사항

- **App.jsx**: `header-controls`에 `Inspector 열기` 버튼 추가 → `showInspectorModal` 토글
- **InspectorPanel.jsx**: 에이전트 선택 시 `<h2>Inspector</h2>` 유지, 에이전트 이름을 `<h3>`으로 변경

## 검증

`Tests 109 passed (109)` — 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)