### PR TITLE
[Feature] Agent Runtime 대화 영속화 및 Dialogue 조회 API 추가

### DIFF
--- a/backend/alembic/versions/20260828_0002_add_dialogue_persistence.py
+++ b/backend/alembic/versions/20260828_0002_add_dialogue_persistence.py
@@ -1,0 +1,99 @@
+"""Dialogue persistence — group mutual TALK utterances into retrievable dialogues.
+
+Revision ID: 20260828_0002
+Revises: 20260828_0001
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260828_0002"
+down_revision = "20260828_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "dialogues",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "simulation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("run_id", sa.String(length=100), nullable=False),
+        sa.Column("tick_number", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "participant_a_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "participant_b_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint("tick_number >= 0", name="ck_dialogues_tick_number"),
+        sa.CheckConstraint(
+            "participant_a_id <> participant_b_id",
+            name="ck_dialogues_distinct_participants",
+        ),
+        sa.UniqueConstraint(
+            "simulation_id",
+            "run_id",
+            "tick_number",
+            "participant_a_id",
+            "participant_b_id",
+            name="uq_dialogues_pair_per_tick",
+        ),
+    )
+    op.create_index(
+        "idx_dialogues_simulation_tick",
+        "dialogues",
+        ["simulation_id", "tick_number"],
+    )
+    op.create_table(
+        "dialogue_messages",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "dialogue_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("dialogues.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("message_order", sa.Integer(), nullable=False),
+        sa.Column(
+            "speaker_agent_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("utterance", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint("message_order >= 0", name="ck_dialogue_messages_order"),
+        sa.UniqueConstraint("dialogue_id", "message_order", name="uq_dialogue_messages_order"),
+    )
+    op.create_index(
+        "idx_dialogue_messages_dialogue",
+        "dialogue_messages",
+        ["dialogue_id", "message_order"],
+    )
+
+
+def downgrade():
+    """Refuse to silently discard persisted dialogues."""
+    connection = op.get_bind()
+    if connection.scalar(sa.text("SELECT EXISTS(SELECT 1 FROM dialogues)")):
+        raise RuntimeError("dialogue rows require an approved backfill before downgrade")
+    op.drop_index("idx_dialogue_messages_dialogue", table_name="dialogue_messages")
+    op.drop_table("dialogue_messages")
+    op.drop_index("idx_dialogues_simulation_tick", table_name="dialogues")
+    op.drop_table("dialogues")

--- a/backend/app/api/dialogues.py
+++ b/backend/app/api/dialogues.py
@@ -1,0 +1,43 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.schemas import DialogueDetailResponse, DialogueMessageResponse
+from app.core.database import get_db
+from app.core.security import require_user_role
+from app.domain.models import User
+from app.services.dialogues import DialogueNotFoundError, get_dialogue
+from app.services.simulations import require_owned_simulation
+
+router = APIRouter(prefix="/simulations/{simulation_id}/dialogues", tags=["dialogues"])
+
+
+@router.get("/{dialogue_id}", response_model=DialogueDetailResponse)
+def get_one(
+    simulation_id: UUID,
+    dialogue_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> DialogueDetailResponse:
+    require_owned_simulation(db, simulation_id, current_user)
+    try:
+        dialogue, messages = get_dialogue(db, simulation_id, dialogue_id)
+    except DialogueNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Dialogue not found"
+        ) from exc
+    return DialogueDetailResponse(
+        dialogue_id=dialogue.id,
+        simulation_id=dialogue.simulation_id,
+        tick=dialogue.tick_number,
+        participants=[dialogue.participant_a_id, dialogue.participant_b_id],
+        messages=[
+            DialogueMessageResponse(
+                speaker=message.speaker_agent_id,
+                utterance=message.utterance,
+                order=message.message_order,
+            )
+            for message in messages
+        ],
+    )

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api.agents import router as agents_router
 from app.api.auth import router as auth_router
+from app.api.dialogues import router as dialogues_router
 from app.api.events import router as events_router
 from app.api.simulation_history import router as simulation_history_router
 from app.api.simulation_imports import router as simulation_imports_router
@@ -21,6 +22,7 @@ api_router.include_router(simulation_history_router)
 api_router.include_router(simulation_shares_router)
 api_router.include_router(simulation_imports_router)
 api_router.include_router(simulation_logs_router)
+api_router.include_router(dialogues_router)
 api_router.include_router(ticks_router)
 api_router.include_router(user_persona_router)
 api_router.include_router(websockets_router)

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -196,6 +196,23 @@ class SimulationLogEntryResponse(BaseModel):
     event_id: UUID | None
 
 
+class DialogueMessageResponse(BaseModel):
+    # 한 발화. order 는 dialogue 내 안정적 순서(0부터)이며 실제 turn-taking 이
+    # 아니라 Runtime 배치 선정 순서를 따른다. Runtime 이 발화를 비우면 utterance 는 None.
+    speaker: UUID
+    utterance: str | None
+    order: int
+
+
+class DialogueDetailResponse(BaseModel):
+    # 같은 tick 안에서 성립한 mutual TALK pair 하나 = dialogue 하나.
+    dialogue_id: UUID
+    simulation_id: UUID
+    tick: int
+    participants: list[UUID]
+    messages: list[DialogueMessageResponse]
+
+
 class SimulationShareCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -545,6 +545,76 @@ class Relationship(TimestampMixin, Base):
     relationship_type: Mapped[str | None] = mapped_column(String(30))
 
 
+class Dialogue(TimestampMixin, Base):
+    """One conversation between a mutual TALK pair within a single Runtime tick.
+
+    Grouping follows ``intent_conflict.resolve_talk_conflicts`` — the only place
+    the domain binds two Agents' utterances together. ``participant_a_id`` is the
+    pair's source Agent and ``participant_b_id`` the target, as returned by
+    ``TalkConflictResolution.mutual_pairs``.
+    """
+
+    __tablename__ = "dialogues"
+    __table_args__ = (
+        UniqueConstraint(
+            "simulation_id",
+            "run_id",
+            "tick_number",
+            "participant_a_id",
+            "participant_b_id",
+            name="uq_dialogues_pair_per_tick",
+        ),
+        CheckConstraint("tick_number >= 0", name="ck_dialogues_tick_number"),
+        CheckConstraint(
+            "participant_a_id <> participant_b_id",
+            name="ck_dialogues_distinct_participants",
+        ),
+        Index("idx_dialogues_simulation_tick", "simulation_id", "tick_number"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    simulation_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("simulations.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        nullable=False,
+    )
+    run_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    tick_number: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    participant_a_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        nullable=False,
+    )
+    participant_b_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        nullable=False,
+    )
+
+
+class DialogueMessage(TimestampMixin, Base):
+    __tablename__ = "dialogue_messages"
+    __table_args__ = (
+        UniqueConstraint("dialogue_id", "message_order", name="uq_dialogue_messages_order"),
+        CheckConstraint("message_order >= 0", name="ck_dialogue_messages_order"),
+        Index("idx_dialogue_messages_dialogue", "dialogue_id", "message_order"),
+    )
+
+    id: Mapped[PythonUUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    dialogue_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dialogues.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        nullable=False,
+    )
+    message_order: Mapped[int] = mapped_column(Integer, nullable=False)
+    speaker_agent_id: Mapped[PythonUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="RESTRICT", onupdate="RESTRICT"),
+        nullable=False,
+    )
+    utterance: Mapped[str | None] = mapped_column(Text)
+
+
 class AgentMemory(TimestampMixin, Base):
     __tablename__ = "agent_memories"
     __table_args__ = (

--- a/backend/app/repositories/dialogues.py
+++ b/backend/app/repositories/dialogues.py
@@ -1,0 +1,53 @@
+from collections.abc import Sequence
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from app.domain.models import Dialogue, DialogueMessage
+
+
+def get_scoped_dialogue(
+    session: Session,
+    simulation_id: UUID,
+    dialogue_id: UUID,
+) -> Dialogue | None:
+    return session.scalar(
+        select(Dialogue).where(
+            Dialogue.id == dialogue_id,
+            Dialogue.simulation_id == simulation_id,
+        )
+    )
+
+
+def list_messages(session: Session, dialogue_id: UUID) -> list[DialogueMessage]:
+    return list(
+        session.scalars(
+            select(DialogueMessage)
+            .where(DialogueMessage.dialogue_id == dialogue_id)
+            .order_by(DialogueMessage.message_order)
+        ).all()
+    )
+
+
+def insert_dialogues_on_pair_conflict_do_nothing(
+    session: Session,
+    rows: Sequence[dict[str, Any]],
+) -> set[UUID]:
+    if not rows:
+        return set()
+    statement = (
+        insert(Dialogue)
+        .values(list(rows))
+        .on_conflict_do_nothing(constraint="uq_dialogues_pair_per_tick")
+        .returning(Dialogue.id)
+    )
+    return set(session.scalars(statement).all())
+
+
+def insert_messages(session: Session, rows: Sequence[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    session.execute(insert(DialogueMessage).values(list(rows)))

--- a/backend/app/services/database_dialogue_results.py
+++ b/backend/app/services/database_dialogue_results.py
@@ -1,0 +1,82 @@
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from uuid6 import uuid7
+
+from app.domain.models import Agent
+from app.repositories import dialogues as dialogue_repository
+from app.services.dialogue_results import (
+    DialogueBatchSaveResult,
+    DialogueDraft,
+    build_dialogue_drafts,
+)
+from app.simulation.intent_conflict import TalkConflictResolution
+
+
+class DialogueParticipantError(ValueError):
+    pass
+
+
+class DatabaseDialogueSink:
+    """Persist mutual TALK dialogues without owning commit or rollback."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def save_batch(self, resolution: TalkConflictResolution) -> DialogueBatchSaveResult:
+        drafts = build_dialogue_drafts(resolution)
+        if not drafts:
+            return DialogueBatchSaveResult(new_count=0, duplicate_count=0)
+
+        simulation_id = self._resolve_simulation_id(drafts)
+        dialogue_ids = {draft: uuid7() for draft in drafts}
+        dialogue_rows = [
+            {
+                "id": dialogue_ids[draft],
+                "simulation_id": simulation_id,
+                "run_id": draft.run_id,
+                "tick_number": draft.tick_number,
+                "participant_a_id": draft.participant_a_id,
+                "participant_b_id": draft.participant_b_id,
+            }
+            for draft in drafts
+        ]
+        inserted_ids = dialogue_repository.insert_dialogues_on_pair_conflict_do_nothing(
+            self._session, dialogue_rows
+        )
+        message_rows = [
+            {
+                "id": uuid7(),
+                "dialogue_id": dialogue_ids[draft],
+                "message_order": message.order,
+                "speaker_agent_id": message.speaker_agent_id,
+                "utterance": message.utterance,
+            }
+            for draft in drafts
+            if dialogue_ids[draft] in inserted_ids
+            for message in draft.messages
+        ]
+        dialogue_repository.insert_messages(self._session, message_rows)
+        return DialogueBatchSaveResult(
+            new_count=len(inserted_ids),
+            duplicate_count=len(drafts) - len(inserted_ids),
+        )
+
+    def _resolve_simulation_id(self, drafts: tuple[DialogueDraft, ...]) -> UUID:
+        participant_ids = {
+            participant_id
+            for draft in drafts
+            for participant_id in draft.participant_ids
+        }
+        rows = self._session.execute(
+            select(Agent.id, Agent.simulation_id).where(Agent.id.in_(participant_ids))
+        ).all()
+        if {agent_id for agent_id, _ in rows} != participant_ids:
+            raise DialogueParticipantError("dialogue participant Agent is missing")
+        simulation_ids = {simulation_id for _, simulation_id in rows}
+        if len(simulation_ids) != 1:
+            raise DialogueParticipantError(
+                "dialogue participants span multiple simulations"
+            )
+        return simulation_ids.pop()

--- a/backend/app/services/dialogue_results.py
+++ b/backend/app/services/dialogue_results.py
@@ -1,0 +1,110 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+from uuid import UUID
+
+from app.simulation.agent_runtime import AgentRuntimeResult
+from app.simulation.intent_conflict import TalkConflictResolution
+
+
+@dataclass(frozen=True)
+class DialogueMessageDraft:
+    order: int
+    speaker_agent_id: UUID
+    utterance: str | None
+
+
+@dataclass(frozen=True)
+class DialogueDraft:
+    run_id: str
+    tick_number: int
+    participant_a_id: UUID
+    participant_b_id: UUID
+    messages: tuple[DialogueMessageDraft, ...]
+
+    @property
+    def participant_ids(self) -> tuple[UUID, ...]:
+        return (self.participant_a_id, self.participant_b_id)
+
+
+@dataclass(frozen=True)
+class DialogueBatchSaveResult:
+    new_count: int
+    duplicate_count: int
+
+
+def build_dialogue_drafts(
+    resolution: TalkConflictResolution,
+) -> tuple[DialogueDraft, ...]:
+    """One draft per mutual TALK pair, messages ordered [source, target].
+
+    The Runtime emits exactly one utterance per Agent per tick, so each dialogue
+    carries at most two messages. ``message_order`` is the position in the pair
+    as returned by ``resolve_talk_conflicts`` — a stable order, not real
+    turn-taking, which the Runtime does not model.
+    """
+    results_by_agent: dict[UUID, AgentRuntimeResult] = {
+        result.agent_id: result for result in resolution.runtime_results
+    }
+    drafts: list[DialogueDraft] = []
+    for source_id, target_id in resolution.mutual_pairs:
+        messages = tuple(
+            DialogueMessageDraft(
+                order=order,
+                speaker_agent_id=agent_id,
+                utterance=(
+                    results_by_agent[agent_id].intent.utterance
+                    if agent_id in results_by_agent
+                    else None
+                ),
+            )
+            for order, agent_id in enumerate((source_id, target_id))
+        )
+        result = results_by_agent.get(source_id) or results_by_agent.get(target_id)
+        if result is None:
+            continue
+        drafts.append(
+            DialogueDraft(
+                run_id=result.run_id,
+                tick_number=result.tick_number,
+                participant_a_id=source_id,
+                participant_b_id=target_id,
+                messages=messages,
+            )
+        )
+    return tuple(drafts)
+
+
+class DialogueSink(Protocol):
+    def save_batch(self, resolution: TalkConflictResolution) -> DialogueBatchSaveResult: ...
+
+
+class InMemoryDialogueSink:
+    def __init__(self) -> None:
+        self._drafts: list[DialogueDraft] = []
+
+    def save_batch(self, resolution: TalkConflictResolution) -> DialogueBatchSaveResult:
+        drafts = build_dialogue_drafts(resolution)
+        seen = {
+            (draft.run_id, draft.tick_number, draft.participant_a_id, draft.participant_b_id)
+            for draft in self._drafts
+        }
+        new_drafts = [
+            draft
+            for draft in drafts
+            if (
+                draft.run_id,
+                draft.tick_number,
+                draft.participant_a_id,
+                draft.participant_b_id,
+            )
+            not in seen
+        ]
+        self._drafts.extend(new_drafts)
+        return DialogueBatchSaveResult(
+            new_count=len(new_drafts),
+            duplicate_count=len(drafts) - len(new_drafts),
+        )
+
+    def list_drafts(self) -> Sequence[DialogueDraft]:
+        return tuple(self._drafts)

--- a/backend/app/services/dialogues.py
+++ b/backend/app/services/dialogues.py
@@ -1,0 +1,25 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.domain.models import Dialogue, DialogueMessage
+from app.repositories import dialogues as dialogue_repository
+
+
+class DialogueNotFoundError(LookupError):
+    pass
+
+
+def get_dialogue(
+    db: Session, simulation_id: UUID, dialogue_id: UUID
+) -> tuple[Dialogue, list[DialogueMessage]]:
+    """Fetch a dialogue scoped to its simulation.
+
+    A dialogue that belongs to another simulation is reported as missing so
+    callers cannot probe for dialogues outside the simulation they own.
+    """
+    dialogue = dialogue_repository.get_scoped_dialogue(db, simulation_id, dialogue_id)
+    if dialogue is None:
+        raise DialogueNotFoundError(str(dialogue_id))
+    messages = dialogue_repository.list_messages(db, dialogue.id)
+    return dialogue, messages

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -31,6 +31,7 @@ from app.repositories.memory_repository import (
     MemoryRepository,
 )
 from app.repositories.simulation_snapshots import SimulationConfigRepository
+from app.services.database_dialogue_results import DatabaseDialogueSink
 from app.services.database_runtime_results import DatabaseRuntimeResultSink
 from app.services.event_frequency_history import build_event_parameters
 from app.services.event_magic_phase import (
@@ -595,6 +596,7 @@ async def advance_manual_tick(
             RuntimeOrchestrator(
                 runtime,
                 DatabaseRuntimeResultSink(db),
+                dialogue_sink=DatabaseDialogueSink(db),
             )
         )
     )

--- a/backend/app/services/runtime_orchestrator.py
+++ b/backend/app/services/runtime_orchestrator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 from uuid import UUID
 
+from app.services.dialogue_results import DialogueSink
 from app.services.runtime_results import (
     RuntimeResultBatchSaveResult,
     RuntimeResultSink,
@@ -40,9 +41,12 @@ class RuntimeOrchestrator:
         runtime: AgentRuntimeExecutor,
         result_sink: RuntimeResultSink,
         context_assembler: AgentContextAssembler | None = None,
+        *,
+        dialogue_sink: DialogueSink | None = None,
     ) -> None:
         self._runtime = runtime
         self._result_sink = result_sink
+        self._dialogue_sink = dialogue_sink
         self._context_assembler = context_assembler or AgentContextAssembler()
         self._target_selector = RuntimeTargetSelector()
 
@@ -101,8 +105,11 @@ class RuntimeOrchestrator:
             max_workers=self.MAX_CONCURRENT_RUNTIMES
         ) as executor:
             proposed_results = tuple(executor.map(self._runtime.run, runtime_inputs))
-        results = resolve_talk_conflicts(proposed_results).runtime_results
+        resolution = resolve_talk_conflicts(proposed_results)
+        results = resolution.runtime_results
         save_result = self._result_sink.save_batch(results)
+        if self._dialogue_sink is not None:
+            self._dialogue_sink.save_batch(resolution)
         return RuntimeBatchExecutionResult(
             results=results,
             save_result=save_result,

--- a/backend/tests/test_dialogue_api.py
+++ b/backend/tests/test_dialogue_api.py
@@ -1,0 +1,195 @@
+"""GET /v1/simulations/{simulation_id}/dialogues/{dialogue_id} — Dialogue Persistence.
+
+기존 events/logs API 테스트 스타일(TEST_DATABASE_URL 필요, TestClient + register/login)을
+따른다. Dialogue 는 DatabaseDialogueSink 로 미리 영속화한다.
+"""
+
+import os
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select, text
+from sqlalchemy.orm import sessionmaker
+
+from app.domain.models import Agent
+from app.services.database_dialogue_results import DatabaseDialogueSink
+from app.services.fixtures import seed_slice_zero
+from app.simulation.agent_runtime import AgentRuntimeResult
+from app.simulation.intent_conflict import resolve_talk_conflicts
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+RUN_ID = "dlg-api-run"
+TICK = 6
+
+
+@pytest.fixture()
+def client():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE users, simulations, locations, agents, agent_states, "
+                "dialogues, dialogue_messages RESTART IDENTITY CASCADE"
+            )
+        )
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client, session_factory
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client: TestClient, username: str) -> dict[str, str]:
+    password = "Dialogue-password!"
+    assert (
+        client.post(
+            "/v1/auth/register",
+            json={"username": username, "display_name": username, "password": password},
+        ).status_code
+        == 201
+    )
+    login = client.post("/v1/auth/login", json={"username": username, "password": password})
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def create_simulation(client: TestClient, headers: dict[str, str], name: str) -> str:
+    return client.post("/v1/simulations", headers=headers, json={"name": name}).json()["id"]
+
+
+def _talk(agent_id: UUID, target_id: UUID, utterance: str | None) -> AgentRuntimeResult:
+    return AgentRuntimeResult.model_validate(
+        {
+            "run_id": RUN_ID,
+            "tick_number": TICK,
+            "agent_id": agent_id,
+            "status": "PROPOSED",
+            "intent": {
+                "action_type": "TALK",
+                "target_agent_id": target_id,
+                "target_location_id": None,
+                "related_event_id": None,
+                "utterance": utterance,
+                "motivation_summary": "대화",
+                "reaction": {
+                    "valence": "NEUTRAL",
+                    "relationship_signals": [],
+                    "state_signals": [],
+                },
+                "decision_explanation": {
+                    "alternatives": [
+                        {
+                            "action_type": "TALK",
+                            "description": "대화한다.",
+                            "relative_priority": "HIGH",
+                            "selected": True,
+                        }
+                    ],
+                    "influencing_factors": [],
+                },
+                "memory_candidates": [],
+            },
+            "retry_count": 0,
+            "failure_reason": None,
+            "model": "test",
+            "prompt_version": "test",
+            "idempotency_key": f"{RUN_ID}:{TICK}:{agent_id}",
+        }
+    )
+
+
+def seed_dialogue(session_factory, simulation_id: str) -> tuple[str, list[str]]:
+    with session_factory() as session:
+        seed_slice_zero(session, UUID(simulation_id))
+        agent_ids = list(
+            session.scalars(
+                select(Agent.id)
+                .where(Agent.simulation_id == UUID(simulation_id))
+                .order_by(Agent.fixture_key)
+            )
+        )
+        speaker, listener = agent_ids[0], agent_ids[1]
+        resolution = resolve_talk_conflicts(
+            (_talk(speaker, listener, "룬 파동이 불안정해."), _talk(listener, speaker, "나도 봤어."))
+        )
+        DatabaseDialogueSink(session).save_batch(resolution)
+        session.flush()
+        from app.domain.models import Dialogue
+
+        dialogue_id = session.scalar(
+            select(Dialogue.id).where(Dialogue.simulation_id == UUID(simulation_id))
+        )
+        session.commit()
+    return str(dialogue_id), [str(speaker), str(listener)]
+
+
+def test_get_dialogue_returns_participants_and_ordered_messages(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "dlg-owner")
+    simulation_id = create_simulation(test_client, headers, "sim")
+    dialogue_id, (speaker, listener) = seed_dialogue(session_factory, simulation_id)
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/dialogues/{dialogue_id}", headers=headers
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["dialogue_id"] == dialogue_id
+    assert body["simulation_id"] == simulation_id
+    assert body["tick"] == TICK
+    assert set(body["participants"]) == {speaker, listener}
+    assert body["messages"] == [
+        {"speaker": speaker, "utterance": "룬 파동이 불안정해.", "order": 0},
+        {"speaker": listener, "utterance": "나도 봤어.", "order": 1},
+    ]
+
+
+def test_dialogue_cannot_be_read_through_another_simulation(client) -> None:
+    test_client, session_factory = client
+    headers = register_and_login(test_client, "dlg-scope")
+    simulation_a = create_simulation(test_client, headers, "sim-a")
+    simulation_b = create_simulation(test_client, headers, "sim-b")
+    dialogue_id, _ = seed_dialogue(session_factory, simulation_b)
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_a}/dialogues/{dialogue_id}", headers=headers
+    )
+
+    assert response.status_code == 404, response.text
+
+
+def test_missing_dialogue_returns_404(client) -> None:
+    test_client, _ = client
+    headers = register_and_login(test_client, "dlg-missing")
+    simulation_id = create_simulation(test_client, headers, "sim")
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/dialogues/{uuid4()}", headers=headers
+    )
+
+    assert response.status_code == 404, response.text
+
+
+def test_dialogue_enforces_ownership(client) -> None:
+    test_client, session_factory = client
+    owner_headers = register_and_login(test_client, "dlg-real-owner")
+    intruder_headers = register_and_login(test_client, "dlg-intruder")
+    simulation_id = create_simulation(test_client, owner_headers, "owned")
+    dialogue_id, _ = seed_dialogue(session_factory, simulation_id)
+
+    response = test_client.get(
+        f"/v1/simulations/{simulation_id}/dialogues/{dialogue_id}", headers=intruder_headers
+    )
+
+    assert response.status_code == 403, response.text

--- a/backend/tests/test_dialogue_grouping.py
+++ b/backend/tests/test_dialogue_grouping.py
@@ -1,0 +1,127 @@
+"""Dialogue grouping — one mutual TALK pair per tick becomes one dialogue.
+
+Pure unit tests (no DB). Grouping follows
+``intent_conflict.resolve_talk_conflicts`` — see build_dialogue_drafts.
+"""
+
+from uuid import UUID
+
+from app.services.dialogue_results import (
+    InMemoryDialogueSink,
+    build_dialogue_drafts,
+)
+from app.simulation.agent_runtime import AgentRuntimeResult
+from app.simulation.intent_conflict import resolve_talk_conflicts
+
+A = UUID("00000000-0000-0000-0000-00000000000a")
+B = UUID("00000000-0000-0000-0000-00000000000b")
+C = UUID("00000000-0000-0000-0000-00000000000c")
+D = UUID("00000000-0000-0000-0000-00000000000d")
+
+
+def talk(agent_id: UUID, target_id: UUID, utterance: str | None) -> AgentRuntimeResult:
+    return AgentRuntimeResult.model_validate(
+        {
+            "run_id": "dlg-run",
+            "tick_number": 7,
+            "agent_id": agent_id,
+            "status": "PROPOSED",
+            "intent": {
+                "action_type": "TALK",
+                "target_agent_id": target_id,
+                "target_location_id": None,
+                "related_event_id": None,
+                "utterance": utterance,
+                "motivation_summary": "대화 요청",
+                "reaction": {
+                    "valence": "NEUTRAL",
+                    "relationship_signals": [],
+                    "state_signals": [],
+                },
+                "decision_explanation": {
+                    "alternatives": [
+                        {
+                            "action_type": "TALK",
+                            "description": "대화한다.",
+                            "relative_priority": "HIGH",
+                            "selected": True,
+                        }
+                    ],
+                    "influencing_factors": [],
+                },
+                "memory_candidates": [],
+            },
+            "retry_count": 0,
+            "failure_reason": None,
+            "model": "test",
+            "prompt_version": "test",
+            "idempotency_key": f"dlg-run:7:{agent_id}",
+        }
+    )
+
+
+def test_mutual_pair_becomes_one_dialogue_with_ordered_messages() -> None:
+    resolution = resolve_talk_conflicts(
+        (talk(A, B, "룬 결계가 불안정해."), talk(B, A, "나도 그렇게 느꼈어."))
+    )
+
+    drafts = build_dialogue_drafts(resolution)
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert (draft.participant_a_id, draft.participant_b_id) == (A, B)
+    assert draft.run_id == "dlg-run"
+    assert draft.tick_number == 7
+    assert [(m.order, m.speaker_agent_id, m.utterance) for m in draft.messages] == [
+        (0, A, "룬 결계가 불안정해."),
+        (1, B, "나도 그렇게 느꼈어."),
+    ]
+
+
+def test_unmatched_talk_produces_no_dialogue() -> None:
+    # C 는 상대가 자신을 향해 TALK 하지 않아 WAIT_FALLBACK 이 된다.
+    resolution = resolve_talk_conflicts(
+        (talk(A, B, "안녕"), talk(B, A, "안녕"), talk(C, A, "나도 낄래"))
+    )
+
+    drafts = build_dialogue_drafts(resolution)
+
+    assert len(drafts) == 1
+    assert {draft.participant_a_id for draft in drafts} == {A}
+    speakers = {m.speaker_agent_id for draft in drafts for m in draft.messages}
+    assert C not in speakers
+
+
+def test_two_independent_mutual_pairs_become_two_dialogues() -> None:
+    resolution = resolve_talk_conflicts(
+        (
+            talk(A, B, "1"),
+            talk(B, A, "2"),
+            talk(C, D, "3"),
+            talk(D, C, "4"),
+        )
+    )
+
+    drafts = build_dialogue_drafts(resolution)
+
+    assert {(d.participant_a_id, d.participant_b_id) for d in drafts} == {(A, B), (C, D)}
+
+
+def test_missing_utterance_is_preserved_as_none() -> None:
+    resolution = resolve_talk_conflicts((talk(A, B, None), talk(B, A, "말했어")))
+
+    draft = build_dialogue_drafts(resolution)[0]
+
+    assert [m.utterance for m in draft.messages] == [None, "말했어"]
+
+
+def test_in_memory_sink_is_idempotent_on_pair_per_tick() -> None:
+    resolution = resolve_talk_conflicts((talk(A, B, "x"), talk(B, A, "y")))
+    sink = InMemoryDialogueSink()
+
+    first = sink.save_batch(resolution)
+    second = sink.save_batch(resolution)
+
+    assert (first.new_count, first.duplicate_count) == (1, 0)
+    assert (second.new_count, second.duplicate_count) == (0, 1)
+    assert len(sink.list_drafts()) == 1

--- a/backend/tests/test_dialogue_persistence.py
+++ b/backend/tests/test_dialogue_persistence.py
@@ -1,0 +1,201 @@
+"""Dialogue persistence — Runtime mutual TALK pairs are written to the DB.
+
+기존 DB 테스트 스타일(TEST_DATABASE_URL 필요)을 따른다. Runtime 이 만든 대화를
+DatabaseDialogueSink 가 simulation DB 에 영속화하고, 발화 순서/참여자/안정적 id 가
+보존되는지 검증한다.
+"""
+
+import os
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import create_engine, func, select, text
+from sqlalchemy.orm import sessionmaker
+from uuid6 import uuid7
+
+from app.domain.models import Agent, Dialogue, DialogueMessage, Simulation, User
+from app.services.database_dialogue_results import (
+    DatabaseDialogueSink,
+    DialogueParticipantError,
+)
+from app.services.dialogue_results import DialogueBatchSaveResult
+from app.services.fixtures import seed_slice_zero
+from app.simulation.agent_runtime import AgentRuntimeResult
+from app.simulation.intent_conflict import resolve_talk_conflicts
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+RUN_ID = "dlg-persist-run"
+TICK = 4
+
+
+@pytest.fixture()
+def session_factory():
+    engine = create_engine(TEST_DATABASE_URL)
+    factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE users, simulations, locations, agents, agent_states, "
+                "dialogues, dialogue_messages RESTART IDENTITY CASCADE"
+            )
+        )
+    return factory
+
+
+def _seed_simulation(session_factory) -> tuple[UUID, list[UUID]]:
+    simulation_id = uuid7()
+    with session_factory() as session:
+        user_id = uuid7()
+        session.add(
+            User(
+                id=user_id,
+                username=f"dlg-{user_id.hex[:8]}",
+                display_name="dlg",
+                password_hash="x",
+            )
+        )
+        session.add(
+            Simulation(id=simulation_id, owner_id=user_id, name="dlg", status="ready")
+        )
+        session.flush()
+        seed_slice_zero(session, simulation_id)
+        agent_ids = list(
+            session.scalars(
+                select(Agent.id)
+                .where(Agent.simulation_id == simulation_id)
+                .order_by(Agent.fixture_key)
+            )
+        )
+        session.commit()
+    return simulation_id, agent_ids
+
+
+def _talk(agent_id: UUID, target_id: UUID, utterance: str | None) -> AgentRuntimeResult:
+    return AgentRuntimeResult.model_validate(
+        {
+            "run_id": RUN_ID,
+            "tick_number": TICK,
+            "agent_id": agent_id,
+            "status": "PROPOSED",
+            "intent": {
+                "action_type": "TALK",
+                "target_agent_id": target_id,
+                "target_location_id": None,
+                "related_event_id": None,
+                "utterance": utterance,
+                "motivation_summary": "대화",
+                "reaction": {
+                    "valence": "NEUTRAL",
+                    "relationship_signals": [],
+                    "state_signals": [],
+                },
+                "decision_explanation": {
+                    "alternatives": [
+                        {
+                            "action_type": "TALK",
+                            "description": "대화한다.",
+                            "relative_priority": "HIGH",
+                            "selected": True,
+                        }
+                    ],
+                    "influencing_factors": [],
+                },
+                "memory_candidates": [],
+            },
+            "retry_count": 0,
+            "failure_reason": None,
+            "model": "test",
+            "prompt_version": "test",
+            "idempotency_key": f"{RUN_ID}:{TICK}:{agent_id}",
+        }
+    )
+
+
+def test_mutual_talk_pair_is_persisted_with_ordered_messages(session_factory) -> None:
+    simulation_id, agent_ids = _seed_simulation(session_factory)
+    speaker, listener = agent_ids[0], agent_ids[1]
+    resolution = resolve_talk_conflicts(
+        (_talk(speaker, listener, "결계가 흔들려."), _talk(listener, speaker, "확인해볼게."))
+    )
+
+    with session_factory() as session:
+        result = DatabaseDialogueSink(session).save_batch(resolution)
+        session.commit()
+
+    assert result == DialogueBatchSaveResult(new_count=1, duplicate_count=0)
+
+    with session_factory() as session:
+        dialogue = session.scalar(
+            select(Dialogue).where(Dialogue.simulation_id == simulation_id)
+        )
+        assert dialogue is not None
+        assert dialogue.run_id == RUN_ID
+        assert dialogue.tick_number == TICK
+        assert {dialogue.participant_a_id, dialogue.participant_b_id} == {speaker, listener}
+        messages = list(
+            session.scalars(
+                select(DialogueMessage)
+                .where(DialogueMessage.dialogue_id == dialogue.id)
+                .order_by(DialogueMessage.message_order)
+            )
+        )
+    assert [(m.message_order, m.speaker_agent_id, m.utterance) for m in messages] == [
+        (0, speaker, "결계가 흔들려."),
+        (1, listener, "확인해볼게."),
+    ]
+
+
+def test_dialogue_id_is_a_stable_db_uuid(session_factory) -> None:
+    _, agent_ids = _seed_simulation(session_factory)
+    resolution = resolve_talk_conflicts(
+        (_talk(agent_ids[0], agent_ids[1], "a"), _talk(agent_ids[1], agent_ids[0], "b"))
+    )
+    with session_factory() as session:
+        DatabaseDialogueSink(session).save_batch(resolution)
+        session.commit()
+    with session_factory() as session:
+        ids = list(session.scalars(select(Dialogue.id)))
+    assert len(ids) == 1
+    assert isinstance(ids[0], UUID)
+
+
+def test_save_batch_is_idempotent_for_same_pair_and_tick(session_factory) -> None:
+    _, agent_ids = _seed_simulation(session_factory)
+    resolution = resolve_talk_conflicts(
+        (_talk(agent_ids[0], agent_ids[1], "a"), _talk(agent_ids[1], agent_ids[0], "b"))
+    )
+    with session_factory() as session:
+        first = DatabaseDialogueSink(session).save_batch(resolution)
+        session.commit()
+    with session_factory() as session:
+        second = DatabaseDialogueSink(session).save_batch(resolution)
+        session.commit()
+
+    assert (first.new_count, second.new_count, second.duplicate_count) == (1, 0, 1)
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(Dialogue)) == 1
+        assert session.scalar(select(func.count()).select_from(DialogueMessage)) == 2
+
+
+def test_non_talk_batch_writes_no_dialogue(session_factory) -> None:
+    _, agent_ids = _seed_simulation(session_factory)
+    # 성립하지 않는 TALK 하나뿐 → WAIT_FALLBACK, mutual pair 없음.
+    resolution = resolve_talk_conflicts((_talk(agent_ids[0], agent_ids[1], "혼잣말"),))
+    with session_factory() as session:
+        result = DatabaseDialogueSink(session).save_batch(resolution)
+        session.commit()
+    assert result == DialogueBatchSaveResult(new_count=0, duplicate_count=0)
+    with session_factory() as session:
+        assert session.scalar(select(func.count()).select_from(Dialogue)) == 0
+
+
+def test_unknown_participant_agent_is_rejected(session_factory) -> None:
+    _, agent_ids = _seed_simulation(session_factory)
+    ghost = uuid4()
+    resolution = resolve_talk_conflicts(
+        (_talk(agent_ids[0], ghost, "a"), _talk(ghost, agent_ids[0], "b"))
+    )
+    with session_factory() as session, pytest.raises(DialogueParticipantError):
+        DatabaseDialogueSink(session).save_batch(resolution)

--- a/backend/tests/test_dialogue_persistence.py
+++ b/backend/tests/test_dialogue_persistence.py
@@ -56,6 +56,7 @@ def _seed_simulation(session_factory) -> tuple[UUID, list[UUID]]:
                 password_hash="x",
             )
         )
+        session.flush()
         session.add(
             Simulation(id=simulation_id, owner_id=user_id, name="dlg", status="ready")
         )

--- a/backend/tests/test_runtime_orchestrator.py
+++ b/backend/tests/test_runtime_orchestrator.py
@@ -154,6 +154,27 @@ def test_multiple_results_are_sent_with_one_save_batch_call() -> None:
     assert len(sink.calls[0]) == 2
 
 
+def test_dialogue_sink_receives_the_resolved_talk_resolution() -> None:
+    from app.simulation.intent_conflict import TalkConflictResolution
+
+    class SpyDialogueSink:
+        def __init__(self) -> None:
+            self.calls: list[TalkConflictResolution] = []
+
+        def save_batch(self, resolution):
+            self.calls.append(resolution)
+
+    dialogue_sink = SpyDialogueSink()
+    batch = RuntimeOrchestrator(
+        SpyRuntime(), SpySink(), dialogue_sink=dialogue_sink
+    ).run_batch([make_input(0), make_input(1)])
+
+    assert len(dialogue_sink.calls) == 1
+    resolution = dialogue_sink.calls[0]
+    assert isinstance(resolution, TalkConflictResolution)
+    assert resolution.runtime_results == batch.results
+
+
 def test_proposed_fallback_and_skipped_are_saved_together() -> None:
     inputs = [make_input(0), make_input(1), make_input(2, active=False)]
     statuses = {

--- a/backend/tests/test_schema_models.py
+++ b/backend/tests/test_schema_models.py
@@ -23,6 +23,8 @@ class SchemaModelTests(unittest.TestCase):
                 "professor_profiles",
                 "agent_states",
                 "agent_memories",
+                "dialogues",
+                "dialogue_messages",
                 "relationships",
                 "runtime_results",
                 "runtime_executions",


### PR DESCRIPTION

## 작업 개요

Agent Runtime에서 발생하는 대화(mutual TALK)를 simulation DB에 영속화하고,
Simulation 화면에서 특정 dialogue를 조회할 수 있는 API를 추가한다.
개별 발화 하나를 저장하는 것이 아니라 하나의 dialogue를 안정적으로 식별하고
그 안의 발화들을 순서대로 재구성할 수 있도록 저장하는 것이 목적이다.

## 관련 Issue

Related to #182 

## 변경 내용

- `dialogues` / `dialogue_messages` 2개 테이블 신규 추가 (모델 + Alembic migration `20260828_0002`, down_revision `20260828_0001`)
- `RuntimeOrchestrator.run_batch()`에 선택적 `dialogue_sink` 추가 — 기존 `RuntimeResultSink` 패턴 미러링. 지금까지 버려지던 `resolve_talk_conflicts()`의 `TalkConflictResolution`을 sink로 전달
- `DatabaseDialogueSink`: mutual TALK pair를 `dialogues` + `dialogue_messages`로 저장. `manual_tick`에서 `DatabaseRuntimeResultSink` 옆에 주입 (동일 세션/트랜잭션, commit 경계는 기존 `ticks.py` 그대로)
- `build_dialogue_drafts()`: `TalkConflictResolution` → dialogue draft 매핑 순수 함수 (무DB 단위 테스트 가능)
- `GET /v1/simulations/{simulation_id}/dialogues/{dialogue_id}` 추가 — `require_owned_simulation`으로 소유권/simulation 격리, 응답: `dialogue_id / simulation_id / tick / participants / messages[{speaker, utterance, order}]`
- 테스트 추가: `test_dialogue_grouping.py`(순수 단위), `test_dialogue_persistence.py`(DB), `test_dialogue_api.py`(DB)
- 테스트 수정: `test_runtime_orchestrator.py`(dialogue_sink 호출 검증 1건), `test_schema_models.py`(등록 테이블 집합에 신규 2개 반영)

## 결정 사항 및 이유

- **기존 `agent_memories` 재사용 불가 → 신규 모델**: `agent_memories`는 Agent 1명의 기억 1행이라 `simulation_id`·dialogue 식별 키·speaker 순서·참여자 목록이 없고, `content`는 LLM 요약문(원문 발화 아님)이다. 두 화자를 하나의 dialogue로 묶거나 안정적 `dialogue_id`를 부여할 수 없다.
- **dialogue grouping 기준 = 같은 tick 안의 mutual TALK pair 하나**: `intent_conflict.resolve_talk_conflicts().mutual_pairs`는 코드상 두 Agent의 발화를 묶는 유일한 도메인 개념이다. 임의 규칙(같은 tick + 같은 두 Agent 등)을 새로 만들지 않았다. 성립 안 된 TALK(→ WAIT_FALLBACK)는 dialogue를 만들지 않고, dialogue당 발화는 참여자당 1개씩 최대 2개다.
- **dialogue_id = DB `uuid7()`**: 프로젝트 PK 컨벤션. 이름 조합 미사용. 조회는 `(simulation_id, dialogue_id)` 조합이며 다른 simulation의 dialogue_id로 요청하면 404(탐침 불가).
- **관계/심리 변화는 범위 제외**: policy effect(relationship/state delta)는 현재 tick별 이력 테이블 없이 행에 직접 적용되고 `PolicyCommitResult`는 transient다. 지침대로 임의의 관계 이력 시스템을 새로 만들지 않았다. `dialogues.run_id` + `tick_number`가 남아 있어 후속 작업에서 조인 가능.
- **Runtime 실행 흐름 자체는 미변경**: 기존 sink 주입 지점에 sink 하나만 추가.

## 테스트 / 확인 내용

- [x] `python -m pytest -q` → 544 passed, 236 skipped
- [x] Runtime 회귀 통과 (`test_agent_runtime`, `test_intent_conflict`, `test_runtime_orchestrator`, `test_slice4_runtime_batch`, `test_simulation_tick_runtime`)
- [x] CI mypy 대상 파일 목록 + 신규 파일 5종 mypy clean
- [ ] DB 게이트 테스트(`test_dialogue_persistence.py`, `test_dialogue_api.py` 등 9건)는 로컬 Docker/Postgres 부재로 미실행 → CI에서 검증 필요
- [ ] 관련 문서 업데이트 (해당 없음 — `docs/`에 Dialogue 스펙 없음)

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 코드베이스 조사(Runtime 실행 흐름, RuntimeResult/AgentMemory 모델, persistence·migration·API 컨벤션), 모델·migration·sink·API·테스트 초안 작성
사람이 검토한 내용: dialogue grouping 기준(mutual pair) 확정, schema 2테이블 구조 확정, 관계/심리 변화 범위 제외 결정, 최종 diff 및 테스트 결과

## 리뷰어가 봐야 할 부분

- `RuntimeOrchestrator`에 `dialogue_sink`를 추가한 방식이 적절한지 (별도 sink vs 결과 dataclass에 노출)
- `DatabaseDialogueSink._resolve_simulation_id` — 참여자 Agent에서 `simulation_id`를 역추적하는 방식. `run_runtime_phase`가 `simulation_id`를 이미 알고 있으므로 그쪽에서 넘기는 편이 나은지 논의 필요
- `uq_dialogues_pair_per_tick` 유니크 제약 컬럼 구성 (`simulation_id, run_id, tick_number, participant_a_id, participant_b_id`)이 멱등성 보장에 충분한지
- 미확정 도메인 결정: (1) `order`가 실제 turn-taking이 아니라 배치 선정 순서 기반 안정 순서라는 점, (2) `utterance=NULL`인 mutual TALK도 message 행을 남기는 처리, (3) 응답이 참여자 이름 대신 UUID를 반환하는 점, (4) `simulation_logs`의 dialogue 항목에 `dialogue_id` 연결은 이번 범위 제외(`test_simulation_logs_api.py`의 `assert "dialogue_id" not in dialogue` 유지)