### PR TITLE
[Feature] World Map API (학교 맵 및 Agent 위치 조회)

### DIFF
--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -12,6 +12,7 @@ from app.api.simulations import router as simulations_router
 from app.api.ticks import router as ticks_router
 from app.api.user_persona import router as user_persona_router
 from app.api.websockets import router as websockets_router
+from app.api.world_map import router as world_map_router
 
 api_router = APIRouter()
 api_router.include_router(auth_router)
@@ -26,3 +27,4 @@ api_router.include_router(dialogues_router)
 api_router.include_router(ticks_router)
 api_router.include_router(user_persona_router)
 api_router.include_router(websockets_router)
+api_router.include_router(world_map_router)

--- a/backend/app/api/world_map.py
+++ b/backend/app/api/world_map.py
@@ -1,0 +1,20 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import require_user_role
+from app.domain.models import User
+from app.services.world_map import get_world_map
+
+router = APIRouter(prefix="/simulations/{simulation_id}/world", tags=["world-map"])
+
+
+@router.get("/map")
+def get_map(
+    simulation_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_user_role),
+) -> dict:
+    return {"data": get_world_map(db, simulation_id, current_user)}

--- a/backend/app/services/world_map.py
+++ b/backend/app/services/world_map.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.domain.models import User
+from app.repositories.simulations import (
+    list_agents_with_state,
+    list_simulation_locations,
+)
+from app.services.simulations import require_owned_simulation
+
+
+def get_world_map(db: Session, simulation_id: UUID, owner: User) -> dict:
+    """학교 공간 목록과 각 공간에 위치한 Agent 를 조회한다 (API 명세 §10.1).
+
+    새 저장소를 만들지 않고 이미 영속화된 두 소스만 합친다.
+
+    * ``locations`` — 시뮬레이션 시드가 만든 공간 6종. ``id`` 는 프론트가 배경을
+      매핑하는 ``Location.code`` 를, ``name`` 은 ``Location.name`` 을 사용한다.
+    * 각 공간의 ``agents`` — ``AgentState.location_id`` 로 묶은 ``Agent.id`` (UUID
+      문자열) 목록. F5-09 상세 조회(``GET /agents/{agent_id}``)와 WebSocket
+      ``AGENT_ACTION_UPDATED`` 가 모두 UUID 를 쓰므로 형제 API 계약과 맞춘다.
+      Agent 가 한 명도 없는 공간도 빈 배열로 포함한다.
+
+    정렬은 기존 도메인 규칙을 재사용한다: 공간은 ``code`` 오름차순
+    (``list_simulation_locations``), 공간 안의 Agent 는 ``fixture_key`` 오름차순
+    (``list_agents_with_state``).
+    """
+    require_owned_simulation(db, simulation_id, owner)
+
+    agents_by_location: dict[UUID, list[str]] = {}
+    for agent, state, _location, _student, _professor in list_agents_with_state(
+        db, simulation_id
+    ):
+        agents_by_location.setdefault(state.location_id, []).append(str(agent.id))
+
+    return {
+        "locations": [
+            {
+                "id": location.code,
+                "name": location.name,
+                "agents": agents_by_location.get(location.id, []),
+            }
+            for location in list_simulation_locations(db, simulation_id)
+        ]
+    }

--- a/backend/tests/test_world_map_api.py
+++ b/backend/tests/test_world_map_api.py
@@ -1,0 +1,150 @@
+"""GET /v1/simulations/{simulation_id}/world/map — API 명세 §10.1.
+
+기존 simulation logs API 테스트 스타일(TEST_DATABASE_URL 필요, TestClient +
+register/login)을 따른다. 맵의 소스는 시뮬레이션 시드가 만든 공간·Agent·AgentState
+뿐이므로 별도 준비 없이 create_simulation 만으로 검증한다.
+"""
+
+import os
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+pytestmark = pytest.mark.skipif(not TEST_DATABASE_URL, reason="TEST_DATABASE_URL is required")
+
+
+@pytest.fixture()
+def client():
+    from app.core.database import get_db
+    from app.main import app
+
+    engine = create_engine(TEST_DATABASE_URL)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "TRUNCATE users, simulations, locations, agents, agent_states "
+                "RESTART IDENTITY CASCADE"
+            )
+        )
+
+    def override_db():
+        with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_db
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def register_and_login(client: TestClient, username: str) -> dict[str, str]:
+    password = "World-password!"
+    assert (
+        client.post(
+            "/v1/auth/register",
+            json={"username": username, "display_name": username, "password": password},
+        ).status_code
+        == 201
+    )
+    login = client.post("/v1/auth/login", json={"username": username, "password": password})
+    return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+
+def create_simulation(client: TestClient, headers: dict[str, str], name: str) -> str:
+    return client.post("/v1/simulations", headers=headers, json={"name": name}).json()["id"]
+
+
+def agent_id_by_fixture_key(
+    client: TestClient, headers: dict[str, str], simulation_id: str
+) -> dict[str, str]:
+    response = client.get(
+        f"/v1/simulations/{simulation_id}/agents", headers=headers
+    )
+    assert response.status_code == 200, response.text
+    return {agent["fixture_key"]: agent["id"] for agent in response.json()}
+
+
+def test_world_map_lists_every_location_with_its_agents(client) -> None:
+    headers = register_and_login(client, "world-map")
+    simulation_id = create_simulation(client, headers, "world")
+    ids = agent_id_by_fixture_key(client, headers, simulation_id)
+
+    response = client.get(f"/v1/simulations/{simulation_id}/world/map", headers=headers)
+    assert response.status_code == 200, response.text
+
+    locations = response.json()["data"]["locations"]
+    by_id = {location["id"]: location for location in locations}
+
+    # 시드된 공간 6종이 code 오름차순으로 전부 포함된다.
+    assert [location["id"] for location in locations] == [
+        "central_square",
+        "classroom",
+        "dormitory",
+        "lab",
+        "library",
+        "restaurant",
+    ]
+    assert by_id["dormitory"]["name"] == "기숙사"
+
+    # student fixture 5명은 dormitory, professor 1명은 classroom 에서 시작한다.
+    # agents[] 는 Agent UUID 이며, fixture_key 오름차순 순서를 유지한다.
+    assert by_id["dormitory"]["agents"] == [
+        ids["student-01"],
+        ids["student-02"],
+        ids["student-03"],
+        ids["student-04"],
+        ids["student-05"],
+    ]
+    assert by_id["classroom"]["agents"] == [ids["professor-01"]]
+
+    # Agent 가 없는 공간도 빈 배열로 포함한다.
+    assert by_id["library"]["agents"] == []
+    assert by_id["restaurant"]["agents"] == []
+
+
+def test_world_map_is_scoped_to_its_simulation(client) -> None:
+    headers = register_and_login(client, "world-scope")
+    simulation_a = create_simulation(client, headers, "sim-a")
+    simulation_b = create_simulation(client, headers, "sim-b")
+
+    map_a = client.get(
+        f"/v1/simulations/{simulation_a}/world/map", headers=headers
+    ).json()["data"]["locations"]
+    map_b = client.get(
+        f"/v1/simulations/{simulation_b}/world/map", headers=headers
+    ).json()["data"]["locations"]
+
+    # 두 맵의 공간 구성(id·name·Agent 수)은 같지만, Agent UUID 는 시뮬레이션마다
+    # 새로 시드되므로 서로 겹치지 않는다.
+    assert [(loc["id"], loc["name"], len(loc["agents"])) for loc in map_a] == [
+        (loc["id"], loc["name"], len(loc["agents"])) for loc in map_b
+    ]
+    dormitory_a = next(loc for loc in map_a if loc["id"] == "dormitory")
+    dormitory_b = next(loc for loc in map_b if loc["id"] == "dormitory")
+    assert len(dormitory_a["agents"]) == 5
+    assert set(dormitory_a["agents"]).isdisjoint(dormitory_b["agents"])
+
+
+def test_world_map_enforces_ownership(client) -> None:
+    owner_headers = register_and_login(client, "world-owner")
+    other_headers = register_and_login(client, "world-intruder")
+    simulation_id = create_simulation(client, owner_headers, "owned")
+
+    response = client.get(
+        f"/v1/simulations/{simulation_id}/world/map", headers=other_headers
+    )
+    assert response.status_code == 403, response.text
+
+
+def test_world_map_missing_simulation_returns_404(client) -> None:
+    headers = register_and_login(client, "world-missing")
+
+    response = client.get(
+        f"/v1/simulations/{uuid4()}/world/map", headers=headers
+    )
+    assert response.status_code == 404, response.text


### PR DESCRIPTION
## 작업 개요

시뮬레이션 메인 화면(S5)의 학교 맵(F5-08)에서 쓸 GET /simulations/{simulation_id}/world/map 엔드포인트를 추가한다. 학교 공간 6종과 각 공간에 위치한 Agent 목록을 한 번에 조회한다. 새 테이블·저장소 없이 기존에 영속화된 locations / agent_states 데이터만 조합한다.

## 관련 Issue

Related to #182

## 변경 내용
backend/app/services/world_map.py (신규) — get_world_map(): 소유권 검증 후, list_agents_with_state로 Agent를 AgentState.location_id 기준으로 묶고 list_simulation_locations로 공간 목록을 만들어 {"locations": [...]} 구성. Agent가 없는 공간도 빈 배열로 포함.
backend/app/api/world_map.py (신규) — GET /simulations/{simulation_id}/world/map. 응답을 {"data": {...}} 봉투로 반환. 인증은 require_user_role.
backend/app/api/router.py — world_map_router import 및 include_router 등록.
backend/tests/test_world_map_api.py (신규) — 공간 6종 목록 + Agent 배치, 시뮬레이션 스코프 격리, 소유권 403, 미존재 시뮬레이션 404.

응답 형식

{
  "data": {
    "locations": [
      { "id": "dormitory", "name": "기숙사", "agents": ["<agent-uuid>", "..."] },
      { "id": "library", "name": "도서관", "agents": [] }
    ]
  }
}
locations[].id = Location.code (프론트가 배경 매핑에 사용)
locations[].agents[] = Agent.id (UUID 문자열), fixture_key 오름차순
정렬: 공간은 code asc, 공간 내 Agent는 fixture_key asc
에러: 시뮬레이션 미존재 404 / 타 소유자 403
## 결정 사항 및 이유
agents[]에 fixture_key가 아닌 Agent UUID를 반환한다.
API 명세 §10.1 예시에는 "agents": ["student-01"]로 적혀 있으나, 같은 예시의 공간 이름("마법 도서관/마법 실험실/magic_lab")이 실제 시드 데이터("도서관/연구실/library/lab")와 불일치해 예시값은 리터럴이 아닌 자리표시자로 판단했다. 실제 계약 근거:
F5-09 상세 진입 GET /agents/{agent_id}의 경로 파라미터 타입이 UUID
맵의 실시간 행동 말풍선을 갱신하는 WebSocket AGENT_ACTION_UPDATED.data.agent_id가 UUID
동일 이슈([#182](https://github.com/magic-academy-ma/Magic-Academy/issues/182)) 계열의 형제 API(events/latest, events/{id}, logs)가 모두 target_agent_ids: list[UUID]를 사용하며, fixture_key를 Agent 식별자로 노출하는 API·테스트는 repo에 없음
world/map 응답에는 행동/상태 필드가 없어 프론트가 GET /simulations/{id}/agents 또는 WS와 join해야 하는데, 두 join 소스 모두 UUID 키
응답 구조(문자열 배열)와 locations[].id = code는 명세대로 유지한다. 식별자 의미만 UUID로 확정하는 최소 변경.
새 저장소/모델을 만들지 않는다. simulation_logs와 동일하게 기존 영속 데이터 조합만으로 구현.
소유권/에러 처리는 require_owned_simulation 재사용. 형제 엔드포인트(/logs, /agents)와 동일하게 미존재 404 / 타 소유자 403.
## 테스트 / 확인 내용
 로컬 실행 확인 — 로컬에 Postgres 없음(Docker 미사용), DB 연동 테스트 4건은 TEST_DATABASE_URL 미설정으로 skip. CI(backend-e2e)에서 실행됨
 주요 기능 동작 확인 — repo 함수를 stub한 오프라인 로직 검증으로 get_world_map 실행: agents[]가 UUID 문자열, fixture_key asc 순서 유지, Agent 없는 공간 [], location.id == code, name 정상 확인
 에러 케이스 확인 — 404/403 경로는 require_owned_simulation 재사용(로직 미변경). DB 테스트 test_world_map_enforces_ownership(403), test_world_map_missing_simulation_returns_404(404) 작성됨 (CI 실행)
 정적 검사 — ruff check 통과, mypy app/services/world_map.py 통과, 라우트 /v1/simulations/{simulation_id}/world/map OpenAPI 등록 확인
 관련 문서 업데이트 확인 — mvp-feature-spec.md F5-08에 엔드포인트 경로 이미 존재, 별도 문서 변경 없음
## AI 사용 여부

사용 여부: 사용함
사용한 작업: 명세·기존 코드베이스 계약 분석, 서비스/라우터/테스트 구현, fixture_key vs UUID 식별자 판단 근거 정리
사람이 검토한 내용: agents[] 식별자를 UUID로 확정하는 결정을 2회 재검토(형제 API 계약, F5-09 상세 API 타입, WebSocket 메시지 타입 대조), 응답 구조·location.id = code 유지 여부

## 리뷰어가 봐야 할 부분
agents[] = Agent UUID 결정이 팀이 참조하는 Confluence API 명세서 §10.1 예시("student-01")와 표기상 다르다. "결정 사항 및 이유" 근거에 동의하는지, 명세 예시를 UUID로 갱신할지 확인 필요.
locations[].id에 Location.code("library")를 넣는 부분 — 다른 API의 LocationResponse.id는 UUID다. 맵 배경 매핑 용도와 §10.1 예시를 근거로 의도적으로 code를 사용했다.
list_agents_with_state가 AgentState·Location INNER join + deleted_at IS NULL 필터라, location_id가 없는 Agent나 삭제된 Agent는 맵에 안 나온다. 이 동작이 F5-08 기대와 맞는지.
test_world_map_is_scoped_to_its_simulation에서 시뮬레이션마다 Agent UUID가 새로 시드되므로 맵 직접 비교 대신 (id, name, agent 수) 일치 + UUID 집합 isdisjoint로 검증하도록 바꿨다.