### PR TITLE
[Feature] Tick 단위 LLM 실행 쿼터 제한

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     anthropic_api_key: str | None = None
     agent_runtime_model: str = "claude-haiku-4-5-20251001"
     agent_runtime_max_tokens: int = Field(default=4096, gt=0)
+    agent_tick_llm_quota: int = Field(default=12, gt=0)
 
     model_config = SettingsConfigDict(
         env_file=PROJECT_ROOT / ".env",

--- a/backend/app/services/manual_tick.py
+++ b/backend/app/services/manual_tick.py
@@ -512,6 +512,11 @@ async def advance_manual_tick(
         apply_night_transition(db, simulation)
     previous_tick = simulation.current_tick
     current_tick = previous_tick + 1
+    # 새 활동 Tick 시작 — LLM 실행 쿼터를 초기화한다. runtime 인스턴스는 Tick마다
+    # 새로 생성되지 않고 재사용될 수 있으므로(예: slice5 campaign 루프) 여기서
+    # 명시적으로 reset하지 않으면 이전 Tick의 소진 상태가 이월돼 이번 Tick의
+    # 모든 LLM 호출이 거부된다.
+    runtime.reset_llm_quota()
     current_day, block = tick_position(current_tick)
     # 이 Tick에 적용할 Event 파라미터를 시작 시점에 고정한다 (§4.5).
     pinned_config = SimulationConfigRepository().latest(db, simulation.id)

--- a/backend/app/services/runtime_dependency.py
+++ b/backend/app/services/runtime_dependency.py
@@ -4,6 +4,7 @@ from app.core.config import Settings, get_settings
 from app.repositories.memory_repository import MemoryRepository
 from app.simulation.agent_runtime import AgentRuntime
 from app.simulation.anthropic_llm_client import AnthropicLLMClient
+from app.simulation.llm_quota import LLMQuota
 from app.simulation.policy import engine as policy_engine
 from app.simulation.policy.models import PolicyEvaluationInput, PolicyEvaluationResult
 
@@ -23,7 +24,11 @@ def create_agent_runtime(settings: Settings) -> AgentRuntime:
         model=settings.agent_runtime_model,
         max_tokens=settings.agent_runtime_max_tokens,
     )
-    return AgentRuntime(client, model=settings.agent_runtime_model)
+    return AgentRuntime(
+        client,
+        model=settings.agent_runtime_model,
+        llm_quota=LLMQuota(settings.agent_tick_llm_quota),
+    )
 
 
 def get_agent_runtime() -> AgentRuntime:

--- a/backend/app/simulation/agent_runtime.py
+++ b/backend/app/simulation/agent_runtime.py
@@ -4,6 +4,8 @@ from typing import Any, Literal, Protocol, TypedDict
 from uuid import UUID
 
 from langgraph.graph import END, START, StateGraph
+
+from app.simulation.llm_quota import LLM_QUOTA_EXCEEDED_REASON, LLMQuota
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -496,6 +498,7 @@ class RuntimeGraphState(TypedDict):
     last_validation_failure: str | None
     candidate: IntentCandidate | None
     final_result: AgentRuntimeResult | None
+    quota_exceeded: bool
 
 
 class AgentRuntime:
@@ -505,11 +508,25 @@ class AgentRuntime:
         *,
         model: str = "mock-llm",
         prompt_version: str = "agent-runtime-10.1",
+        llm_quota: LLMQuota | None = None,
     ) -> None:
         self._llm_client = llm_client
         self._model = model
         self._prompt_version = prompt_version
+        self._llm_quota = llm_quota
         self._graph = self._build_graph()
+
+    @property
+    def llm_quota(self) -> LLMQuota | None:
+        return self._llm_quota
+
+    def reset_llm_quota(self) -> None:
+        """새 활동 Tick 시작 시 이 Runtime의 LLM 실행 쿼터를 초기화한다.
+
+        쿼터가 설정되지 않았으면 아무 것도 하지 않는다.
+        """
+        if self._llm_quota is not None:
+            self._llm_quota.reset()
 
     def run(self, runtime_input: AgentRuntimeInput) -> AgentRuntimeResult:
         state = self.run_state(runtime_input)
@@ -526,6 +543,7 @@ class AgentRuntime:
             "last_validation_failure": None,
             "candidate": None,
             "final_result": None,
+            "quota_exceeded": False,
         }
         return self._graph.invoke(initial_state)
 
@@ -560,6 +578,17 @@ class AgentRuntime:
 
     def _decide(self, state: RuntimeGraphState) -> dict[str, object]:
         attempt_count = state["attempt_count"] + 1
+        # 실제 LLM 호출 직전에 활동 Tick 쿼터를 원자적으로 차감한다. retry도
+        # 이 노드를 다시 통과하므로 별도 호출로 1회 추가 차감된다. 소진 시에는
+        # LLM을 호출하지 않고 quota exceeded 상태로 fallback 경로로 보낸다.
+        if self._llm_quota is not None and not self._llm_quota.try_consume():
+            return {
+                "attempt_count": attempt_count,
+                "current_llm_response": None,
+                "candidate": None,
+                "last_validation_failure": LLM_QUOTA_EXCEEDED_REASON,
+                "quota_exceeded": True,
+            }
         try:
             # Block LLM invocation during replay mode and instrument the call
             from app.simulation.replay_guard import assert_not_replay
@@ -601,6 +630,9 @@ class AgentRuntime:
     def _route_after_validation(state: RuntimeGraphState) -> str:
         if state["candidate"] is not None:
             return "success"
+        if state.get("quota_exceeded"):
+            # 쿼터가 소진됐으면 retry도 LLM을 호출할 수 없으므로 곧바로 fallback.
+            return "fallback"
         if state["attempt_count"] < 2:
             return "retry"
         return "fallback"

--- a/backend/app/simulation/llm_quota.py
+++ b/backend/app/simulation/llm_quota.py
@@ -1,0 +1,57 @@
+import threading
+
+LLM_QUOTA_EXCEEDED_REASON = "llm_quota_exceeded"
+
+
+class LLMQuota:
+    """활동 Tick 단위 LLM 실행 쿼터.
+
+    새 활동 Tick이 시작되면 ``reset()`` 으로 ``used`` 를 0으로 되돌리고,
+    실제 LLM 호출 직전마다 ``try_consume()`` 으로 원자적으로 1회 차감한다.
+    한도를 모두 사용하면 ``try_consume()`` 은 ``used`` 를 늘리지 않고 ``False`` 를
+    반환한다 (초과 요청은 추가 차감하지 않는다). 여러 스레드가 동시에
+    호출해도 실제 차감 횟수가 한도를 넘지 않도록 lock으로 보호한다.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self._lock = threading.Lock()
+        self._limit = limit
+        self._used = 0
+
+    def reset(self, limit: int | None = None) -> None:
+        """새 활동 Tick 시작 시 ``used`` 를 0으로 되돌린다.
+
+        ``limit`` 인자는 테스트 편의용이며, 일반 경로에서는 생성 시 주입된
+        한도를 그대로 유지한다.
+        """
+        with self._lock:
+            if limit is not None:
+                self._limit = limit
+            self._used = 0
+
+    def try_consume(self) -> bool:
+        """LLM 호출 1회를 원자적으로 예약한다.
+
+        잔여 쿼터가 있으면 ``used`` 를 1 증가시키고 ``True``,
+        소진된 상태면 ``used`` 를 그대로 두고 ``False`` 를 반환한다.
+        """
+        with self._lock:
+            if self._used >= self._limit:
+                return False
+            self._used += 1
+            return True
+
+    @property
+    def limit(self) -> int:
+        with self._lock:
+            return self._limit
+
+    @property
+    def used(self) -> int:
+        with self._lock:
+            return self._used
+
+    @property
+    def remaining(self) -> int:
+        with self._lock:
+            return max(self._limit - self._used, 0)

--- a/backend/tests/test_llm_quota.py
+++ b/backend/tests/test_llm_quota.py
@@ -1,0 +1,153 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from app.simulation.agent_runtime import AgentRuntime, LLMInvocationError, RuntimeStatus
+from app.simulation.llm_quota import LLM_QUOTA_EXCEEDED_REASON, LLMQuota
+from tests.test_agent_runtime_graph import (
+    SequenceLLMClient,
+    invalid_response,
+    make_runtime_input,
+    valid_response,
+)
+
+
+# ─── LLMQuota 단위 ────────────────────────────────────────────────────────────
+
+
+def test_fresh_quota_reports_limit_used_remaining() -> None:
+    quota = LLMQuota(limit=12)
+    assert quota.limit == 12
+    assert quota.used == 0
+    assert quota.remaining == 12
+
+
+def test_consume_up_to_limit_then_refuse_without_extra_charge() -> None:
+    quota = LLMQuota(limit=12)
+
+    assert all(quota.try_consume() for _ in range(12))
+    assert quota.used == 12
+    assert quota.remaining == 0
+
+    # 13번째 요청은 LLM을 호출하지 않고 거부되며 used를 늘리지 않는다.
+    assert quota.try_consume() is False
+    assert quota.used == 12
+    assert quota.remaining == 0
+
+
+def test_reset_restores_full_quota() -> None:
+    quota = LLMQuota(limit=12)
+    for _ in range(12):
+        quota.try_consume()
+
+    quota.reset()
+
+    assert quota.used == 0
+    assert quota.remaining == 12
+    assert quota.limit == 12
+
+
+def test_reset_can_override_limit_for_tests() -> None:
+    quota = LLMQuota(limit=12)
+    quota.reset(limit=5)
+    assert quota.limit == 5
+    assert quota.remaining == 5
+
+
+def test_concurrent_consume_never_exceeds_limit() -> None:
+    quota = LLMQuota(limit=12)
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        results = list(executor.map(lambda _: quota.try_consume(), range(50)))
+
+    assert sum(results) == 12
+    assert quota.used == 12
+
+
+# ─── AgentRuntime 연동 ───────────────────────────────────────────────────────
+
+
+def test_run_with_exhausted_quota_falls_back_without_calling_llm() -> None:
+    runtime_input = make_runtime_input()
+    quota = LLMQuota(limit=1)
+    assert quota.try_consume() is True  # Tick의 유일한 슬롯을 미리 소진
+
+    client = SequenceLLMClient([valid_response(runtime_input)])
+    result = AgentRuntime(client, llm_quota=quota).run(runtime_input)
+
+    assert result.status == RuntimeStatus.FALLBACK
+    assert result.failure_reason == LLM_QUOTA_EXCEEDED_REASON
+    assert client.call_count == 0
+
+
+def test_retry_consumes_a_separate_quota_slot() -> None:
+    runtime_input = make_runtime_input()
+    quota = LLMQuota(limit=1)
+
+    # 1번째 시도: 유효하지 않은 응답 → retry 필요. 2번째 시도는 쿼터가 없어 차단.
+    client = SequenceLLMClient(
+        [invalid_response(runtime_input), valid_response(runtime_input)]
+    )
+    result = AgentRuntime(client, llm_quota=quota).run(runtime_input)
+
+    assert client.call_count == 1
+    assert quota.used == 1
+    assert result.status == RuntimeStatus.FALLBACK
+    assert result.failure_reason == LLM_QUOTA_EXCEEDED_REASON
+
+
+def test_each_retry_attempt_decrements_quota() -> None:
+    runtime_input = make_runtime_input()
+    quota = LLMQuota(limit=2)
+
+    client = SequenceLLMClient(
+        [invalid_response(runtime_input), invalid_response(runtime_input)]
+    )
+    result = AgentRuntime(client, llm_quota=quota).run(runtime_input)
+
+    assert client.call_count == 2
+    assert quota.used == 2
+    assert result.status == RuntimeStatus.FALLBACK
+
+
+def test_failed_llm_call_still_consumes_quota() -> None:
+    runtime_input = make_runtime_input()
+    quota = LLMQuota(limit=12)
+
+    client = SequenceLLMClient(
+        [LLMInvocationError("provider down"), valid_response(runtime_input)]
+    )
+    result = AgentRuntime(client, llm_quota=quota).run(runtime_input)
+
+    assert result.status == RuntimeStatus.PROPOSED
+    # 실패한 1번째 호출 + 성공한 2번째 호출 = 2회 차감.
+    assert quota.used == 2
+
+
+def test_runtime_without_quota_keeps_existing_retry_behavior() -> None:
+    runtime_input = make_runtime_input()
+    client = SequenceLLMClient(
+        [invalid_response(runtime_input), invalid_response(runtime_input)]
+    )
+    result = AgentRuntime(client).run(runtime_input)
+
+    assert client.call_count == 2
+    assert result.status == RuntimeStatus.FALLBACK
+    assert result.failure_reason != LLM_QUOTA_EXCEEDED_REASON
+
+
+def test_reset_llm_quota_is_noop_without_quota() -> None:
+    runtime_input = make_runtime_input()
+    runtime = AgentRuntime(SequenceLLMClient([valid_response(runtime_input)]))
+    runtime.reset_llm_quota()  # 예외 없이 통과
+    assert runtime.llm_quota is None
+
+
+def test_reset_llm_quota_clears_used_between_ticks() -> None:
+    quota = LLMQuota(limit=12)
+    runtime = AgentRuntime(SequenceLLMClient([]), llm_quota=quota)
+    for _ in range(12):
+        quota.try_consume()
+
+    runtime.reset_llm_quota()
+
+    assert quota.used == 0
+    assert quota.remaining == 12

--- a/backend/tests/test_runtime_dependency.py
+++ b/backend/tests/test_runtime_dependency.py
@@ -34,6 +34,23 @@ def test_runtime_settings_use_haiku_defaults():
 
     assert configured.agent_runtime_model == "claude-haiku-4-5-20251001"
     assert configured.agent_runtime_max_tokens == 4096
+    assert configured.agent_tick_llm_quota == 12
+
+
+def test_factory_wires_llm_quota_from_settings(monkeypatch):
+    monkeypatch.setattr(
+        runtime_dependency, "AnthropicLLMClient", FakeAnthropicLLMClient
+    )
+    configured = settings(
+        anthropic_api_key="test-anthropic-key",
+        agent_tick_llm_quota=9,
+    )
+
+    runtime = create_agent_runtime(configured)
+
+    assert runtime.llm_quota is not None
+    assert runtime.llm_quota.limit == 9
+    assert runtime.llm_quota.used == 0
 
 
 def test_factory_builds_anthropic_runtime_with_configured_metadata(monkeypatch):


### PR DESCRIPTION
## 작업 개요

활동 Tick당 실제 LLM 호출을 최대 12회로 제한하는 쿼터 정책을 구현했다. Tick 시작 시 쿼터를 초기화하고, 실제 LLM 호출 직전에 원자적으로 확인·차감하며, 소진되면 추가 호출 없이 fallback 결과를 반환한다.

## 관련 Issue

Related to #182 

## 변경 내용
app/simulation/llm_quota.py 신규 — LLMQuota 클래스. threading.Lock으로 보호되는 try_consume()(잔여 있으면 used +1 후 True, 소진 시 used 그대로 두고 False), reset(), limit/used/remaining 프로퍼티. LLM_QUOTA_EXCEEDED_REASON = "llm_quota_exceeded" 상수.
app/simulation/agent_runtime.py — AgentRuntime에 opt-in llm_quota 파라미터, llm_quota 프로퍼티, reset_llm_quota() 추가. _decide()에서 increment_llm()·generate() 직전에 try_consume() 호출 → 실패 시 LLM 호출 없이 quota_exceeded 상태 반환. _route_after_validation()은 quota_exceeded면 retry를 건너뛰고 즉시 fallback. RuntimeGraphState에 quota_exceeded 필드 추가.
app/services/runtime_dependency.py — create_agent_runtime()가 LLMQuota(settings.agent_tick_llm_quota)를 주입.
app/core/config.py — agent_tick_llm_quota: int = Field(default=12, gt=0) 추가.
app/services/manual_tick.py — advance_manual_tick()에서 current_tick = previous_tick + 1 직후 runtime.reset_llm_quota() 호출.
테스트: tests/test_llm_quota.py 신규(13개), tests/test_runtime_dependency.py 2개 추가.
## 결정 사항 및 이유
쿼터 소진 결과를 기존 RuntimeStatus.FALLBACK + failure_reason="llm_quota_exceeded"로 표현. 새 status enum 값을 추가하면 StrEnum·DB CheckConstraint·직렬화 등 여러 곳을 건드려야 하므로, 기존 fallback 흐름(WAIT intent)을 재사용하고 failure_reason 문자열로 구분한다.
차감 지점은 AgentRuntime._decide() 한 곳. 실제 LLM 호출(self._llm_client.generate())이 일어나는 유일한 chokepoint이며, LangGraph가 retry 시 이 노드로 되돌아오므로 retry도 자연히 별도 호출로 1회씩 추가 차감된다. LLM provider 오류·timeout·파싱 실패도 이미 try_consume()을 통과한 뒤이므로 차감 상태가 유지된다.
try_consume()은 확인과 차감을 하나의 lock 안에서 처리. RuntimeOrchestrator.run_batch가 ThreadPoolExecutor(max_workers=6)로 Runtime을 병렬 실행하므로, 동시 요청에서도 실제 호출이 12회를 넘지 않도록 원자적으로 보장한다. 초과 요청은 used를 늘리지 않는다.
한도는 Settings 값(agent_tick_llm_quota, 기본 12). 정책 문서의 "향후 실행량·비용 데이터 확인 후 조정 가능" 요구에 맞춰 env 오버라이드가 가능하도록 했다. LLMQuota 자체에는 기본값을 두지 않아 숫자 12의 출처를 Settings 한 곳으로 유지한다.
AgentRuntime의 llm_quota는 opt-in(기본 None). 프로덕션 조립 경로(create_agent_runtime)에서만 실제 쿼터를 주입하고, 기존 테스트가 만드는 AgentRuntime(MockLLMClient())는 영향받지 않는다.
manual_tick에서 명시적 reset. Runtime 인스턴스가 Tick마다 새로 생성되지 않고 재사용되는 경로(slice5 campaign 루프 등)가 있어, reset이 없으면 이전 Tick의 소진 상태가 이월돼 이번 Tick의 모든 LLM 호출이 거부된다. 새 활동 Tick 확정 → 쿼터 초기화 순서를 보장한다.
## 테스트 / 확인 내용
 로컬 실행 확인 — pytest tests/test_llm_quota.py tests/test_agent_runtime_graph.py tests/test_runtime_dependency.py tests/test_anthropic_llm_client.py tests/test_runtime_orchestrator.py → 45 passed
 비-DB 전체 스윕 → 543 passed / 164 skipped(DB 게이트) / 실패 0
 주요 기능 동작 확인 — 12회 후 거부·초과 미차감, reset 복원, 동시성(50스레드 → 정확히 12), 쿼터 소진 시 LLM 미호출 fallback, retry 별도 차감, 실패 호출도 차감
 에러 케이스 확인 — LLMInvocationError 발생 호출도 쿼터 차감됨을 테스트로 검증
 DB/Docker 필요 테스트(test_mvp_tick_event_policy_db.py, slice5_campaign.py, test_event_magic_policy_integration.py)는 로컬에서 Docker 실행 불가로 미확인 — CI에서 확인 필요. 해당 테스트들은 쿼터 없이 MockLLMClient를 쓰므로 동작 불변이어야 정상.
 관련 문서 업데이트 — docs/04-feature-specs/에 별도 스펙 문서는 작성하지 않음(코드/테스트 범위로 합의)
## AI 사용 여부
사용 여부: 사용함
사용한 작업: 코드베이스 탐색, 구현(쿼터 클래스·Runtime 배선·Settings·reset 지점), 테스트 작성, 로컬 테스트 실행
사람이 검토한 내용: 쿼터 소진 표현 방식·한도 관리 위치 결정, manual_tick reset 위치, LLMQuota 기본값 중복 제거

## 리뷰어가 봐야 할 부분
agent_runtime.py의 _decide() — 차감이 increment_llm()·generate()보다 먼저인지, retry 경로에서 재차감되는지, LLMInvocationError/validation 실패 시에도 차감이 유지되는지.
_route_after_validation() — quota_exceeded일 때 retry 루프로 돌지 않고 바로 fallback으로 가는지.
manual_tick.py — reset 호출이 새 활동 Tick 확정 이후·tick_position() 이전이라는 순서, night transition과의 상호작용.
LLMQuota.try_consume() — 확인+차감 원자성, 초과 요청이 used를 증가시키지 않는지.
opt-in 기본값(llm_quota=None)이 기존 Runtime 사용처에 회귀를 일으키지 않는지.