### PR TITLE
[Feature] S5 workspace 3열 레이아웃 정렬 및 밤 스킵 API 연결

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -13,8 +13,11 @@ input { padding: 10px 12px; border: 1px solid #c4b5fd; border-radius: 8px; backg
 button { border: 0; border-radius: 8px; padding: 11px 14px; background: #6d28d9; color: #fff; }
 button:disabled { opacity: .6; cursor: wait; }.link-button { background: transparent; color: #6d28d9; }
 .message { padding: 12px; border-radius: 8px; background: #f3f4f6; }.error { background: #fee2e2; color: #991b1b; }
-.workspace { display: grid; grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr); gap: 24px; max-width: 1100px; margin: auto; }
-.agent-list { display: grid; gap: 10px; }.agent { display: flex; justify-content: space-between; text-align: left; background: #f5f3ff; color: #211a2b; border: 1px solid transparent; }.agent.active { border-color: #7c3aed; background: #ede9fe; }.agent span { color: #6b7280; }
+.workspace { display: grid; grid-template-columns: 220px 1fr 280px; grid-template-rows: 1fr; height: calc(100vh - 72px - 180px); gap: 12px; overflow: hidden; padding: 12px; }
+.agent-list { grid-column: 1; grid-row: 1; display: flex; flex-direction: column; gap: 10px; overflow-y: auto; }
+.school-map-panel { grid-column: 2; grid-row: 1; overflow: hidden; }
+.agent-detail { grid-column: 3; grid-row: 1; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
+.agent { display: flex; justify-content: space-between; text-align: left; background: #f5f3ff; color: #211a2b; border: 1px solid transparent; }.agent.active { border-color: #7c3aed; background: #ede9fe; }.agent span { color: #6b7280; }
 .inspector dl { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }.inspector dt { color: #6b7280; }.inspector dd { margin: 0; text-align: right; }
 .header-right { display: flex; align-items: center; gap: 12px; }
 .header-save { background: var(--c-primary); color: var(--c-text); }
@@ -22,6 +25,5 @@ button:disabled { opacity: .6; cursor: wait; }.link-button { background: transpa
 .ws-indicator { font-size: 10px; }
 .ws-indicator.connected { color: #16a34a; }
 .ws-indicator.disconnected { color: #dc2626; }
-.school-map-panel { grid-column: 1 / -1; }
-.relationship-panel { grid-column: 1 / -1; }
-@media (max-width: 760px) { main { padding: 16px; }.workspace { grid-template-columns: 1fr; } header { padding: 0 16px; } }
+.event-log-panel { height: 180px; overflow-y: auto; flex-shrink: 0; }
+@media (max-width: 760px) { main { padding: 16px; }.workspace { grid-template-columns: 1fr; height: auto; } header { padding: 0 16px; } }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,6 @@ import ReplayPanel from "./components/ReplayPanel.jsx";
 import SnapshotPanel from "./components/SnapshotPanel.jsx";
 import SharingPanel from "./components/SharingPanel.jsx";
 import SharedBrowser from "./components/SharedBrowser.jsx";
-import RelationshipFlow from "./components/RelationshipFlow.jsx";
 import RelationshipModal from "./components/RelationshipModal.jsx";
 import EventLogPanel from "./components/EventLogPanel.jsx";
 import InspectorPanel from "./components/InspectorPanel.jsx";
@@ -226,7 +225,7 @@ export default function App() {
   const [showInspectorModal, setShowInspectorModal] = useState(false);
   const [showRelationshipModal, setShowRelationshipModal] = useState(false);
 
-  const { connected, lastTick, eventLog, wsRelationshipDeltas, agentActions } = useSimulationWS(
+  const { connected, lastTick, eventLog, agentActions } = useSimulationWS(
     simulation?.id,
     auth?.access_token,
     { onReconnect: () => refreshAgentsSilentlyRef.current?.() }
@@ -411,49 +410,16 @@ export default function App() {
     return matchesSearch && matchesType;
   });
 
-  // WS RELATIONSHIP_UPDATED가 유실 없이 들어오면 그 값을, 아니면 REST tick 결과를 사용한다.
-  const effectiveRelationshipDeltas =
-    wsRelationshipDeltas.length > 0
-      ? wsRelationshipDeltas
-      : (tickResult?.relationship_deltas ?? []);
-
-  const relationshipAgentIds = [
-    ...new Set(
-      effectiveRelationshipDeltas.flatMap((d) => [d.source_agent_id, d.target_agent_id])
-    ),
-  ];
-
-  const flowNodes = relationshipAgentIds.map((id, index) => ({
-    id: String(id),
-    position: {
-      x: (index % 4) * 200,
-      y: Math.floor(index / 4) * 150,
-    },
-    data: {
-      label: agentNameById[id] ?? String(id),
-    },
-  }));
-
-  const edgesByPair = new Map();
-  for (const delta of effectiveRelationshipDeltas) {
-    const key = `${delta.source_agent_id}->${delta.target_agent_id}`;
-
-    if (!edgesByPair.has(key)) {
-      edgesByPair.set(key, {
-        id: `e-${key}`,
-        source: String(delta.source_agent_id),
-        target: String(delta.target_agent_id),
-        type: "delta",
-        data: {
-          effects: [],
-        },
-      });
+  async function handleNightSkip() {
+    try {
+      await apiRequest(
+        `/v1/simulations/${simulation.id}/night/skip`,
+        { token: auth.access_token, method: "POST" }
+      );
+    } catch (requestError) {
+      if (requestError.status === 401) resetSession(requestError.message);
     }
-
-    edgesByPair.get(key).data.effects.push(delta);
   }
-
-  const flowEdges = [...edgesByPair.values()];
 
   function handleEventAgentSelect(agentId) {
     const agent = agents.find((a) => a.id === agentId);
@@ -471,7 +437,7 @@ export default function App() {
           <button type="button" onClick={() => setIsPaused((p) => !p)}>
             {isPaused ? "재개" : "일시정지"}
           </button>
-          <button type="button" onClick={() => { /* TODO: 밤 스킵 API 미확정 */ }}>
+          <button type="button" onClick={handleNightSkip}>
             밤 스킵
           </button>
           <button type="button" onClick={() => setShowInspectorModal(true)}>Inspector 열기</button>
@@ -542,16 +508,18 @@ export default function App() {
               onSaved={(result) => setPersonaAgentId(result.agent_id)}
             />
 
-            <InspectorPanel
-              agent={selectedAgent}
-              simulationId={simulation?.id}
-              token={auth?.access_token}
-              currentTick={lastTick?.current_tick}
-              onClose={() => setSelectedAgent(null)}
-            />
-            {selectedAgent && (
-              <button type="button" className="relationship-modal-btn" onClick={() => setShowRelationshipModal(true)}>관계 보기</button>
-            )}
+            <div className="panel agent-detail">
+              <InspectorPanel
+                agent={selectedAgent}
+                simulationId={simulation?.id}
+                token={auth?.access_token}
+                currentTick={lastTick?.current_tick}
+                onClose={() => setSelectedAgent(null)}
+              />
+              {selectedAgent && (
+                <button type="button" className="relationship-modal-btn" onClick={() => setShowRelationshipModal(true)}>관계 보기</button>
+              )}
+            </div>
 
             {/* Tick 실행 및 결과 */}
             <div className="panel tick-panel">
@@ -718,10 +686,6 @@ export default function App() {
               />
             </div>
 
-            <div className="panel relationship-panel">
-              <h4>관계 변화</h4>
-              <RelationshipFlow nodes={flowNodes} edges={flowEdges} />
-            </div>
           </section>
           <EventLogPanel
             eventLog={eventLog}


### PR DESCRIPTION
## 작업 개요

S5 시뮬레이션 메인 화면의 workspace 레이아웃을 목업 기준 3열 Grid로 재구성하고,
밤 스킵 버튼에 확정된 API를 연결한다.

## 관련 Issue

관련 Issue 없음

## 변경 내용

- `App.css`: workspace를 `220px 1fr 280px` 3열 Grid로 변경, 각 패널 grid-column 명시
- `App.css`: EventLogPanel 하단 고정(height 180px, overflow-y scroll) 추가
- `App.jsx`: InspectorPanel + 관계보기 버튼을 `.panel.agent-detail`(우열)로 통합
- `App.jsx`: `.relationship-panel` div 및 `RelationshipFlow` import, 관련 계산 코드 제거
  (RelationshipModal로 기능 이전 완료)
- `App.jsx`: `handleNightSkip` 구현 — `POST /simulations/{id}/night/skip` 연결,
  응답 200 정상 처리 / 409 무시 / 401 세션 리셋

## 결정 사항 및 이유

- **overflow: hidden on workspace**: `tick-panel`, `management-panel`, `UserPersonaSetup`이
  workspace 안에 잔존하나 목업에 없음. 해당 패널들은 암묵적 2번째 row로 밀려 overflow: hidden으로
  가려지도록 처리. 별도 정리는 후속 PR로 분리 예정.
- **agent-detail wrapper**: InspectorPanel이 grid 3열에 배치되려면 하나의 grid item이어야 하므로
  panel div로 감쌌음.

## 테스트 / 확인 내용

- [x] `npm run build` 통과
- [ ] 로컬 실행 확인 (백엔드 필요)
- [ ] 주요 기능 동작 확인
- [ ] 에러 케이스 확인
- [ ] 관련 문서 업데이트 확인

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 레이아웃 CSS 작성, handleNightSkip 구현, 미사용 코드 정리
사람이 검토한 내용: diff 전체, 빌드 결과

## 리뷰어가 봐야 할 부분

- `workspace`의 height 계산 (`calc(100vh - 72px - 180px)`)이 `main { padding: 32px }`를
  반영하지 않아 실제 화면에서 미세 높이 초과 가능. 확인 필요.
- `tick-panel`, `management-panel`, `UserPersonaSetup` 세 패널이 workspace에 잔존하나
  overflow:hidden으로 가려진 상태. 제거 여부는 별도 논의 필요.