### PR TITLE
[Feature] S8 SavePage·S9 MyPage 실제 API 연결

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -348,11 +348,19 @@ export default function App() {
       onMyPage={() => setScreen("my-page")}
     />
   );
-  if (screen === "my-page") return <MyPage auth={auth} onBack={() => setScreen("main")} />;
+  if (screen === "my-page") return (
+    <MyPage
+      auth={auth}
+      onBack={() => setScreen("main")}
+      onRestore={(sim) => { setSimulationId(sim.id); setSimulation(sim); loadAgents(sim.id); setScreen("simulation"); }}
+    />
+  );
   if (screen === "branding") return <BrandingPage auth={auth} onEnroll={handleEnroll} />;
   if (screen === "save") return (
     <SavePage
       simulationName={simulation?.name ?? "시뮬레이션"}
+      simulationId={simulationId}
+      token={auth.access_token}
       onComplete={() => setScreen("simulation")}
       onCancel={() => setScreen("simulation")}
     />

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -267,7 +267,7 @@ describe('Slice 0 UI', () => {
     await userEvent.click(screen.getByRole('button', { name: '마이페이지' }))
     expect(await screen.findByRole('heading', { name: '내 시뮬레이션' })).toBeInTheDocument()
     expect(screen.getByText('Magic Academy Simulation')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '불러오기 · 준비 중' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '불러오기' })).toBeEnabled()
     await userEvent.click(screen.getByRole('button', { name: '뒤로가기' }))
     expect(screen.getByRole('heading', { name: 'Owner A님, 환영합니다.' })).toBeInTheDocument()
   })

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -34,6 +34,27 @@ export async function handleMockRequest(path, options = {}) {
     };
   }
 
+  // 2-1. Simulation save / restore
+  if (/\/v1\/simulations\/[^/]+\/save$/.test(path) && method === "POST") {
+    const id = path.split("/")[3];
+    return {
+      id,
+      status: "PAUSED",
+      current_day: mockSimulations[0].current_day,
+      current_tick: mockSimulations[0].current_tick,
+      saved_at: new Date().toISOString(),
+    };
+  }
+  if (/\/v1\/simulations\/[^/]+\/restore$/.test(path) && method === "POST") {
+    const id = path.split("/")[3];
+    return {
+      id,
+      status: "RUNNING",
+      current_day: mockSimulations[0].current_day,
+      current_tick: mockSimulations[0].current_tick,
+    };
+  }
+
   // 3. World Map API
   if (/\/v1\/simulations\/[^/]+\/world\/map/.test(path) && method === "GET") {
     return mockWorldMap;

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -9,19 +9,39 @@ function formatSavedAt(simulation) {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString('ko-KR');
 }
 
-export default function MyPage({ auth, onBack }) {
+export default function MyPage({ auth, onBack, onRestore }) {
   const [simulations, setSimulations] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [restoringId, setRestoringId] = useState(null);
+  const [restoreError, setRestoreError] = useState('');
 
   useEffect(() => {
     let active = true;
     apiRequest('/v1/simulations', { token: auth.access_token })
-      .then((result) => { if (active) setSimulations(result); })
+      .then((result) => {
+        if (active) setSimulations(Array.isArray(result) ? result : (result.data ?? []));
+      })
       .catch((requestError) => { if (active) setError(requestError.message); })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
   }, [auth.access_token]);
+
+  async function handleRestore(id) {
+    setRestoringId(id);
+    setRestoreError('');
+    try {
+      const simulation = await apiRequest(`/v1/simulations/${id}/restore`, {
+        method: 'POST',
+        token: auth.access_token,
+      });
+      onRestore(simulation);
+    } catch (requestError) {
+      setRestoreError(requestError.message);
+    } finally {
+      setRestoringId(null);
+    }
+  }
 
   return (
     <main className="my-page">
@@ -32,13 +52,20 @@ export default function MyPage({ auth, onBack }) {
         </div>
         {loading && <p className="my-page__message">목록을 불러오는 중...</p>}
         {error && <p className="my-page__message my-page__error" role="alert">{error}</p>}
+        {restoreError && <p className="my-page__message my-page__error" role="alert">{restoreError}</p>}
         {!loading && !error && simulations.length === 0 && <p className="my-page__message">저장된 시뮬레이션이 없습니다.</p>}
         {!loading && !error && simulations.length > 0 && (
           <ul className="my-page__list">
             {simulations.map((item) => (
               <li key={item.id}>
                 <div><strong>{item.name}</strong><span>{formatSavedAt(item)} · {item.status}</span></div>
-                <button type="button" disabled title="준비 중">불러오기 · 준비 중</button>
+                <button
+                  type="button"
+                  disabled={restoringId !== null}
+                  onClick={() => handleRestore(item.id)}
+                >
+                  {restoringId === item.id ? '불러오는 중...' : '불러오기'}
+                </button>
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/SavePage.jsx
+++ b/frontend/src/pages/SavePage.jsx
@@ -1,9 +1,25 @@
+import { useState } from 'react';
+import { apiRequest } from '../api/client.js';
 import './SavePage.css';
 
-export default function SavePage({ simulationName, onComplete, onCancel }) {
-  function handleSave() {
-    // TODO: 저장 API 확정 후 POST /v1/simulations/{simulationId}/save 호출로 교체한다.
-    onComplete();
+export default function SavePage({ simulationName, simulationId, token, onComplete, onCancel }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleSave() {
+    setLoading(true);
+    setError('');
+    try {
+      await apiRequest(`/v1/simulations/${simulationId}/save`, {
+        method: 'POST',
+        token,
+      });
+      onComplete();
+    } catch (requestError) {
+      setError(requestError.message);
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
@@ -12,10 +28,12 @@ export default function SavePage({ simulationName, onComplete, onCancel }) {
         <p className="save-page__eyebrow">SAVE SIMULATION</p>
         <h1>시뮬레이션 저장</h1>
         <p><strong>{simulationName}</strong>의 현재 상태를 저장하시겠습니까?</p>
-        <p className="save-page__notice">저장 API 연동은 준비 중입니다.</p>
+        {error && <p className="message error" role="alert">{error}</p>}
         <div className="save-page__actions">
-          <button type="button" onClick={handleSave}>저장</button>
-          <button type="button" className="save-page__cancel" onClick={onCancel}>취소</button>
+          <button type="button" onClick={handleSave} disabled={loading}>
+            {loading ? '저장 중...' : '저장'}
+          </button>
+          <button type="button" className="save-page__cancel" onClick={onCancel} disabled={loading}>취소</button>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## 작업 개요

SavePage(S8)와 MyPage(S9)의 스텁 구현을 실제 API 호출로 교체한다.

## 관련 Issue

관련 Issue 없음

## 변경 내용

- **SavePage**: `simulationId`·`token` props 추가, `POST /simulations/{id}/save` 호출, 로딩 및 오류 상태 표시
- **MyPage**: GET `/simulations` 응답을 `{ data: [] }` 포맷과 배열 모두 처리하도록 수정, `POST /simulations/{id}/restore` 불러오기 구현, `onRestore` 콜백 추가
- **App.jsx**: SavePage에 `simulationId`·`token` 전달, MyPage에 `onRestore` 콜백 연결
- **mock handlers**: save·restore 엔드포인트 추가
- **App.test.jsx**: MyPage 불러오기 버튼 기대값 업데이트 (`'불러오기 · 준비 중'` → `'불러오기'`)

## 결정 사항 및 이유

- GET `/simulations` 응답 파싱 시 `Array.isArray(result) ? result : (result.data ?? [])` 패턴을 사용했다. mock이 배열을 반환하고 실제 API가 `{ data: [] }` 포맷을 반환하므로, 두 환경 모두 지원하기 위함이다.
- restore 응답(`{ id, status, current_day, current_tick }`)은 name 필드가 없어 시뮬레이션 뷰의 헤더에 simulation.name이 undefined로 표시될 수 있다. restore API 스펙 보완이 필요하다.

## 테스트 / 확인 내용

- [ ] 로컬 실행 확인
- [x] 주요 기능 동작 확인 (`npm run build` ✅, 109/109 tests ✅)
- [ ] 에러 케이스 확인
- [ ] 관련 문서 업데이트 확인

## AI 사용 여부

사용 여부: 사용함
사용한 작업: SavePage·MyPage API 연결 구현, App.jsx prop 연결, mock handler 추가, 테스트 업데이트
사람이 검토한 내용: diff 전체 검토 필요

## 리뷰어가 봐야 할 부분

- `MyPage.jsx`: restore 성공 후 `onRestore(simulation)`으로 App에 전달되는 객체가 `{ id, status, current_day, current_tick }` 이므로 `simulation.name`이 없어 시뮬레이션 뷰 헤더가 빈값으로 표시될 수 있음. restore API 응답에 name 포함 여부를 혜정에게 확인 필요
- `App.jsx`: restore 후 `personaId`와 `personaSetupDone`을 세팅하지 않으면 PersonaSelectPage로 리다이렉트될 수 있음. 현재 onRestore 콜백은 스펙 지정값 그대로 구현됨