### PR TITLE
[Feature] BrandingPage를 온보딩 슬라이드 3단계로 교체

### DIFF
--- a/frontend/src/pages/BrandingPage.css
+++ b/frontend/src/pages/BrandingPage.css
@@ -1,69 +1,236 @@
 .branding-page {
   min-height: 100vh;
-  background-color: var(--c-bg);
-  background-image: url('/assets/character/character.png');
-  background-position: right center;
-  background-size: contain;
-  background-repeat: no-repeat;
+  background-color: var(--c-bg, #060d20);
   display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.ob-skip {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  background: rgba(6, 13, 32, 0.5);
+  border: 1px solid var(--c-border, rgba(70, 100, 180, 0.24));
+  color: var(--c-text-2, #a4b5d6);
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  padding: 6px 12px;
+  border-radius: var(--r-sm, 6px);
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  transition: color var(--tr-fast, 150ms ease), border-color var(--tr-fast, 150ms ease), background var(--tr-fast, 150ms ease);
+  z-index: 10;
+}
+
+.ob-skip:hover:not(:disabled) {
+  color: var(--c-cream, #d4b26f);
+  border-color: var(--c-cream-ring, rgba(212, 178, 111, 0.35));
+  background: rgba(6, 13, 32, 0.7);
+}
+
+.ob-skip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ob-slide-wrap {
+  width: 440px;
+  background: rgba(6, 13, 32, 0.94);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(212, 178, 111, 0.20);
+  border-radius: var(--r-lg, 14px);
+  padding: 32px 28px 24px;
+  display: flex;
+  flex-direction: column;
+}
+
+.onboarding__brand {
+  font-family: var(--f-serif-en, 'Playfair Display', Georgia, serif);
+  font-size: var(--t-sm, 13px);
+  font-weight: 600;
+  color: var(--c-cream, #d4b26f);
+  letter-spacing: 0.14em;
+  margin-bottom: 28px;
+}
+
+.ob-slide-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 148px;
+  animation: ob-float-up 450ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes ob-float-up {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.ob-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2, 8px);
+  padding: 4px 10px;
+  background: var(--c-cream-muted, rgba(212, 178, 111, 0.14));
+  border: 1px solid var(--c-cream-ring, rgba(212, 178, 111, 0.35));
+  border-radius: var(--r-sm, 6px);
+  width: fit-content;
+}
+
+.ob-badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ob-badge-text {
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.chat-msg {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.chat-avatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background-size: cover;
+  background-position: center top;
+  border: 2px solid var(--c-border-hi, rgba(212, 178, 111, 0.30));
+}
+
+.chat-avatar--glyph {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--c-inspector-muted, rgba(52, 179, 199, 0.14));
+  color: var(--c-inspector, #34b3c7);
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.chat-bubble {
+  position: relative;
+  flex: 1;
+  background: rgba(11, 24, 56, 0.9);
+  border: 1px solid var(--c-border, rgba(70, 100, 180, 0.24));
+  border-radius: 4px var(--r-md, 10px) var(--r-md, 10px) var(--r-md, 10px);
+  padding: 12px 14px;
+}
+
+.chat-bubble::before {
+  content: '';
+  position: absolute;
+  left: -6px;
+  top: 14px;
+  width: 10px;
+  height: 10px;
+  background: rgba(11, 24, 56, 0.9);
+  border-left: 1px solid var(--c-border, rgba(70, 100, 180, 0.24));
+  border-bottom: 1px solid var(--c-border, rgba(70, 100, 180, 0.24));
+  transform: rotate(45deg);
+}
+
+.chat-name {
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: 11px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.chat-text {
+  font-family: var(--f-serif-ko, 'Noto Serif KR', Georgia, serif);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--c-text, #f2f5fc);
+}
+
+.ob-error {
+  font-size: var(--t-sm, 13px);
+  color: var(--c-critical, #db4c4c);
+  margin: 0;
+}
+
+.ob-cta {
+  width: 100%;
+  height: 48px;
+  background: var(--c-primary, #5e60e8);
+  color: #ffffff;
+  border: 1px solid var(--c-primary-hover, rgba(115, 117, 245, 0.5));
+  border-radius: var(--r-md, 10px);
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: var(--t-sm, 13px);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-2, 8px);
+  box-shadow: 0 4px 16px rgba(94, 96, 232, 0.35);
+  transition: background var(--tr-fast, 150ms ease), transform var(--tr-fast, 150ms ease), box-shadow var(--tr-fast, 150ms ease);
+  margin-top: 24px;
+}
+
+.ob-cta:hover:not(:disabled) {
+  background: var(--c-primary-hover, #7375f5);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(94, 96, 232, 0.5);
+}
+
+.ob-cta:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ob-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--c-border, rgba(70, 100, 180, 0.24));
+}
+
+.ob-dots {
+  display: flex;
+  gap: var(--s-2, 8px);
   align-items: center;
 }
 
-.branding-page__content {
-  max-width: 480px;
-  padding: var(--s-12) var(--s-10);
-  display: flex;
-  flex-direction: column;
-  gap: var(--s-5);
-}
-
-.branding-page__label {
-  font-family: var(--f-serif-en);
-  font-size: var(--t-sm);
-  color: var(--c-cream);
-  letter-spacing: 0.15em;
-  margin: 0;
-}
-
-.branding-page__title {
-  font-family: var(--f-serif-ko);
-  font-size: var(--t-2xl);
-  color: var(--c-text);
-  margin: 0;
-  line-height: 1.4;
-}
-
-.branding-page__desc {
-  font-size: var(--t-base);
-  color: var(--c-text-2);
-  margin: 0;
-  line-height: 1.75;
-}
-
-.branding-page__error {
-  font-size: var(--t-sm);
-  color: var(--c-critical);
-  margin: 0;
-}
-
-.branding-page__btn {
-  width: fit-content;
-  padding: var(--s-3) var(--s-8);
-  background-color: var(--c-primary);
-  color: var(--c-text);
-  border: none;
-  border-radius: var(--r-md);
-  font-size: var(--t-md);
-  font-family: var(--f-ui);
+.ob-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(212, 178, 111, 0.25);
   cursor: pointer;
-  transition: background-color var(--tr-fast);
+  transition: all var(--tr-normal, 260ms ease);
 }
 
-.branding-page__btn:hover:not(:disabled) {
-  background-color: var(--c-primary-hover);
+.ob-dot.active {
+  background: var(--c-cream, #d4b26f);
+  width: 20px;
+  border-radius: 3px;
+  box-shadow: 0 0 8px rgba(212, 178, 111, 0.5);
 }
 
-.branding-page__btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.ob-pagenum {
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: 11px;
+  color: var(--c-text-3, #62759e);
+  letter-spacing: 0.1em;
 }

--- a/frontend/src/pages/BrandingPage.jsx
+++ b/frontend/src/pages/BrandingPage.jsx
@@ -2,7 +2,50 @@ import { useState } from 'react';
 import { apiRequest } from '../api/client.js';
 import './BrandingPage.css';
 
+const SLIDES = [
+  {
+    badge: 'Multi-Agent Simulation',
+    badgeColor: '#d4b26f',
+    badgeBg: 'rgba(212, 178, 111, 0.14)',
+    badgeBorder: 'rgba(212, 178, 111, 0.35)',
+    charName: 'Leo',
+    mbti: 'ESTP',
+    charImg: '/assets/character/Leo_ESTP.png',
+    nameColor: '#d4b26f',
+    ringColor: '#d4b26f',
+    bubbleBorder: 'rgba(70, 100, 180, 0.24)',
+    text: '안녕! 여긴 마법학교야.\n우리는 너의 지시 없이도, 알아서 관계 맺고 갈등하고 사건을 만들어.',
+  },
+  {
+    badge: 'Agent Intelligence',
+    badgeColor: '#5e60e8',
+    badgeBg: 'rgba(94, 96, 232, 0.14)',
+    badgeBorder: 'rgba(94, 96, 232, 0.38)',
+    charName: 'Adel',
+    mbti: 'ISTJ',
+    charImg: '/assets/character/Adel_ISTJ.png',
+    nameColor: '#db4c4c',
+    ringColor: '#db4c4c',
+    bubbleBorder: 'rgba(219, 76, 76, 0.38)',
+    text: '결계의 순환이 불규칙해...\n규율은 지켜야 하는데, 피로가 너무 누적됐어.',
+  },
+  {
+    badge: 'Causal Observatory',
+    badgeColor: '#34b3c7',
+    badgeBg: 'rgba(52, 179, 199, 0.14)',
+    badgeBorder: 'rgba(52, 179, 199, 0.32)',
+    charName: 'Inspector',
+    mbti: null,
+    charImg: null,
+    nameColor: '#34b3c7',
+    ringColor: '#34b3c7',
+    bubbleBorder: 'rgba(52, 179, 199, 0.32)',
+    text: 'Magic Event가 발생하면,\n1문장 서사와 정밀 인과를 함께 보여드릴게요.',
+  },
+];
+
 export default function BrandingPage({ auth, onEnroll }) {
+  const [slide, setSlide] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -23,27 +66,98 @@ export default function BrandingPage({ auth, onEnroll }) {
     }
   }
 
+  function handleCta() {
+    if (slide < SLIDES.length) {
+      setSlide(slide + 1);
+    } else {
+      handleEnroll();
+    }
+  }
+
+  const current = SLIDES[slide - 1];
+  const isLast = slide === SLIDES.length;
+
   return (
     <div className="branding-page">
-      <div className="branding-page__content">
-        <p className="branding-page__label">MAGIC ACADEMY</p>
-        <h1 className="branding-page__title">
-          마법이 살아 숨쉬는<br />마법 대학교
-        </h1>
-        <p className="branding-page__desc">
-          마법사들이 관계를 맺고, 사건을 만들며, 세계를 변화시키는<br />
-          멀티 에이전트 시뮬레이션에 오신 것을 환영합니다.
-        </p>
-        {error && (
-          <p className="branding-page__error" role="alert">{error}</p>
-        )}
-        <button
-          className="branding-page__btn"
-          onClick={handleEnroll}
-          disabled={loading}
-        >
-          {loading ? '입학 중...' : '입학하기'}
+      <button className="ob-skip" onClick={handleEnroll} disabled={loading}>
+        건너뛰기 →
+      </button>
+
+      <div className="ob-slide-wrap">
+        <div className="onboarding__brand">MAGIC ACADEMY</div>
+
+        <div className="ob-slide-content" key={slide}>
+          <div
+            className="ob-badge"
+            style={{ background: current.badgeBg, borderColor: current.badgeBorder }}
+          >
+            <div
+              className="ob-badge-dot"
+              style={{ background: current.badgeColor, boxShadow: `0 0 6px ${current.badgeColor}` }}
+            />
+            <span className="ob-badge-text" style={{ color: current.badgeColor }}>
+              {current.badge}
+            </span>
+          </div>
+
+          <div className="chat-msg">
+            {current.charImg ? (
+              <div
+                className="chat-avatar"
+                style={{
+                  backgroundImage: `url(${current.charImg})`,
+                  borderColor: current.ringColor,
+                  boxShadow: `0 0 16px ${current.ringColor}66`,
+                }}
+                role="img"
+                aria-label={`${current.charName} 아바타`}
+              />
+            ) : (
+              <div
+                className="chat-avatar chat-avatar--glyph"
+                style={{ borderColor: current.ringColor, boxShadow: `0 0 16px ${current.ringColor}66` }}
+                aria-label="Inspector 아바타"
+              >
+                ◎
+              </div>
+            )}
+            <div className="chat-bubble" style={{ borderColor: current.bubbleBorder }}>
+              <div className="chat-name" style={{ color: current.nameColor }}>
+                {current.charName}{current.mbti ? ` · ${current.mbti}` : ''}
+              </div>
+              <div className="chat-text">
+                {current.text.split('\n').map((line, i, arr) => (
+                  <span key={i}>{line}{i < arr.length - 1 && <br />}</span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {error && <p className="ob-error" role="alert">{error}</p>}
+        </div>
+
+        <button className="ob-cta" onClick={handleCta} disabled={loading}>
+          {loading ? '시작 중...' : isLast ? '시작하기' : '다음 →'}
         </button>
+
+        <div className="ob-pagination">
+          <div className="ob-dots">
+            {SLIDES.map((_, i) => (
+              <div
+                key={i}
+                className={`ob-dot${slide === i + 1 ? ' active' : ''}`}
+                onClick={() => setSlide(i + 1)}
+                role="button"
+                aria-label={`${i + 1}번째 슬라이드로 이동`}
+                tabIndex={0}
+                onKeyDown={(e) => e.key === 'Enter' && setSlide(i + 1)}
+              />
+            ))}
+          </div>
+          <span className="ob-pagenum">
+            {String(slide).padStart(2, '0')} / {String(SLIDES.length).padStart(2, '0')}
+          </span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 작업 개요

기존 단순 랜딩 형태의 BrandingPage를 3단계 온보딩 슬라이드로 전면 교체한다.
목업(`01-onboarding.html`) 기준 레이아웃과 디자인 토큰(`magic-academy-v2.css`)을 적용했다.

## 관련 Issue

관련 Issue 없음

## 변경 내용

- `BrandingPage.jsx`: SLIDES 배열 기반 3단계 온보딩 구조로 교체
  - 슬라이드 1: Multi-Agent Simulation / Leo(ESTP)
  - 슬라이드 2: Agent Intelligence / Adel(ISTJ)
  - 슬라이드 3: Causal Observatory / Inspector(◎ 글리프)
  - `key={slide}` 패턴으로 슬라이드 전환 시 CSS 애니메이션(`ob-float-up`) 자동 재실행
  - 건너뛰기 버튼 우상단 고정, "시작하기" CTA에서 `onEnroll()` 호출 유지
- `BrandingPage.css`: 슬라이드 UI 전용 스타일로 전면 교체
  - dot 인디케이터(active 시 pill 형태로 확장), 01/03 페이지 번호
  - Inspector 슬라이드: 이미지 없이 `.chat-avatar--glyph` 렌더링(◎)
  - `@keyframes ob-float-up` 슬라이드 전환 애니메이션

## 결정 사항 및 이유

- **`academy-night-background.png` 미사용**: React public 폴더에 에셋 없음 → CSS 순수 dark 배경(`var(--c-bg, #060d20)`)으로 대체. 기능적으로 동등하며 에셋 없이도 목업 의도를 충족.
- **`key={slide}` 리마운트 패턴**: CSS 애니메이션 재실행을 위해 ref 기반 reset 대신 `key` prop 변경으로 컴포넌트 리마운트. 목업의 transition 의도에 부합하며 코드가 단순.
- **건너뛰기 버튼 `disabled` 처리**: API 호출 중 중복 요청 방지.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인 (`VITE_USE_MOCK=true`)
- [x] 주요 기능 동작 확인 (3슬라이드 전환, 건너뛰기, 시작하기 → PersonaSelectPage 진입)
- [x] `npx vite build` 빌드 통과
- [x] Playwright headless로 전체 플로우 검증 (로그인 → MainPage → BrandingPage → 3슬라이드 → PersonaSelectPage)
- [ ] 에러 케이스 확인 (API 실패 시 에러 메시지 렌더링은 코드 상 처리됨, mock 환경 내 직접 트리거 미실시)
- [ ] 관련 문서 업데이트 확인 (해당 없음)

## AI 사용 여부

사용 여부: 사용함
사용한 작업: BrandingPage.jsx/css 구현, 목업 기준 레이아웃 해석, Playwright 검증 스크립트 작성
사람이 검토한 내용: 슬라이드 데이터(텍스트·색상), 전체 컴포넌트 구조 및 CSS, 플로우 검증 결과

## 리뷰어가 봐야 할 부분

- 슬라이드 전환 시 `ob-float-up` 애니메이션이 의도대로 재실행되는지 (`key={slide}` 패턴)
- Inspector 슬라이드 글리프(◎) 렌더링이 디자인 의도와 일치하는지
- `handleEnroll()` 내 API 호출 로직은 기존 코드 그대로 유지했으므로 확인 불필요