### PR TITLE
[Fix] S8·S9 저장·불러오기 API 계약 보완

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -352,7 +352,18 @@ export default function App() {
     <MyPage
       auth={auth}
       onBack={() => setScreen("main")}
-      onRestore={(sim) => { setSimulationId(sim.id); setSimulation(sim); loadAgents(sim.id); setScreen("simulation"); }}
+      onRestore={(restoredSimulation) => {
+        const restoredPersona = restoredSimulation.user_persona;
+        setSimulationId(restoredSimulation.id);
+        setSimulation(restoredSimulation);
+        setPersonaId(restoredPersona.agent_id);
+        setPersonaAgentId(restoredPersona.agent_id);
+        setPersonaSetupDone(
+          restoredPersona.status === "APPLIED" && restoredPersona.locked
+        );
+        loadAgents(restoredSimulation.id);
+        setScreen("simulation");
+      }}
     />
   );
   if (screen === "branding") return <BrandingPage auth={auth} onEnroll={handleEnroll} />;

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -261,7 +261,7 @@ describe('Slice 0 UI', () => {
   it('opens MyPage from S1 and returns to S1', async () => {
     vi.spyOn(globalThis, 'fetch')
       .mockImplementationOnce(() => response({ access_token: 'token', token_type: 'bearer', user }))
-      .mockImplementationOnce(() => response([simulation]))
+      .mockImplementationOnce(() => response({ data: [simulation], meta: { next_cursor: null, has_more: false } }))
     render(<App />)
     await login()
     await userEvent.click(screen.getByRole('button', { name: '마이페이지' }))
@@ -272,6 +272,28 @@ describe('Slice 0 UI', () => {
     expect(screen.getByRole('heading', { name: 'Owner A님, 환영합니다.' })).toBeInTheDocument()
   })
 
+  it('MyPage restore 성공 후 Persona 설정을 복구하고 Simulation 화면으로 이동한다', async () => {
+    const restoredSimulation = {
+      ...simulation,
+      status: 'RUNNING',
+      updated_at: '2026-08-27T12:00:00Z',
+      user_persona: { agent_id: agents[1].id, status: 'APPLIED', locked: true },
+    }
+    vi.spyOn(globalThis, 'fetch')
+      .mockImplementationOnce(() => response({ access_token: 'token', token_type: 'bearer', user }))
+      .mockImplementationOnce(() => response({ data: [simulation], meta: { next_cursor: null, has_more: false } }))
+      .mockImplementationOnce(() => response({ data: restoredSimulation }))
+      .mockImplementationOnce(() => response(agents))
+
+    render(<App />)
+    await login()
+    await userEvent.click(screen.getByRole('button', { name: '마이페이지' }))
+    await userEvent.click(await screen.findByRole('button', { name: '불러오기' }))
+
+    expect(await screen.findByRole('heading', { name: simulation.name })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: '함께할 Persona를 선택하세요' })).not.toBeInTheDocument()
+  })
+
   it('opens SavePage from S5 and returns on cancel', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch')
     await setupSimulationWithAgents(fetchMock)
@@ -279,6 +301,21 @@ describe('Slice 0 UI', () => {
     expect(screen.getByRole('heading', { name: '시뮬레이션 저장' })).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: '취소' }))
     expect(screen.getByRole('heading', { name: 'Magic Academy Simulation' })).toBeInTheDocument()
+  })
+
+  it('SavePage에 현재 Simulation과 인증 정보를 연결해 저장한다', async () => {
+    const fetchMock = await setupSimulationWithAgents()
+    fetchMock.mockImplementationOnce(() => response({ data: { id: simulation.id, status: 'PAUSED' } }))
+
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+
+    expect(await screen.findByRole('heading', { name: simulation.name })).toBeInTheDocument()
+    expect(fetchMock.mock.calls.some(([url, options]) =>
+      url.endsWith(`/v1/simulations/${simulation.id}/save`) &&
+      options?.method === 'POST' &&
+      options?.headers?.Authorization === 'Bearer token'
+    )).toBe(true)
   })
   it('shows loading state while a tick is running', async () => {
     const fetchMock = await setupSimulationWithAgents()

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -22,7 +22,10 @@ export async function handleMockRequest(path, options = {}) {
 
   // 2. Simulation API
   if (path === "/v1/simulations" && method === "GET") {
-    return mockSimulations;
+    return {
+      data: mockSimulations,
+      meta: { next_cursor: null, has_more: false },
+    };
   }
   if (path === "/v1/simulations" && method === "POST") {
     const body = options.body ? JSON.parse(options.body) : {};
@@ -38,20 +41,29 @@ export async function handleMockRequest(path, options = {}) {
   if (/\/v1\/simulations\/[^/]+\/save$/.test(path) && method === "POST") {
     const id = path.split("/")[3];
     return {
-      id,
-      status: "PAUSED",
-      current_day: mockSimulations[0].current_day,
-      current_tick: mockSimulations[0].current_tick,
-      saved_at: new Date().toISOString(),
+      data: {
+        id,
+        status: "PAUSED",
+        current_day: mockSimulations[0].current_day,
+        current_tick: mockSimulations[0].current_tick,
+        saved_at: new Date().toISOString(),
+      },
     };
   }
   if (/\/v1\/simulations\/[^/]+\/restore$/.test(path) && method === "POST") {
     const id = path.split("/")[3];
     return {
-      id,
-      status: "RUNNING",
-      current_day: mockSimulations[0].current_day,
-      current_tick: mockSimulations[0].current_tick,
+      data: {
+        ...mockSimulations[0],
+        id,
+        status: "RUNNING",
+        updated_at: new Date().toISOString(),
+        user_persona: {
+          agent_id: mockAgents[1].id,
+          status: "APPLIED",
+          locked: true,
+        },
+      },
     };
   }
 

--- a/frontend/src/mocks/handlers.test.js
+++ b/frontend/src/mocks/handlers.test.js
@@ -19,7 +19,43 @@ describe('handleMockRequest', () => {
 
   it('returns mock simulations on GET /v1/simulations', async () => {
     const res = await handleMockRequest('/v1/simulations', { method: 'GET' })
-    expect(res).toEqual(mockSimulations)
+    expect(res).toEqual({
+      data: mockSimulations,
+      meta: { next_cursor: null, has_more: false },
+    })
+  })
+
+  it('returns the saved Simulation on POST /v1/simulations/:id/save', async () => {
+    const res = await handleMockRequest('/v1/simulations/sim-001/save', { method: 'POST' })
+
+    expect(res).toEqual({
+      data: expect.objectContaining({
+        id: 'sim-001',
+        status: 'PAUSED',
+        saved_at: expect.any(String),
+      }),
+    })
+  })
+
+  it('returns the restored Simulation and Persona on POST /v1/simulations/:id/restore', async () => {
+    const res = await handleMockRequest('/v1/simulations/sim-001/restore', {
+      method: 'POST',
+      body: '{}',
+    })
+
+    expect(res).toEqual({
+      data: expect.objectContaining({
+        id: 'sim-001',
+        name: expect.any(String),
+        status: 'RUNNING',
+        updated_at: expect.any(String),
+        user_persona: {
+          agent_id: expect.any(String),
+          status: 'APPLIED',
+          locked: true,
+        },
+      }),
+    })
   })
 
   it('returns mock agents on GET /v1/simulations/sim-001/agents', async () => {

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -20,7 +20,7 @@ export default function MyPage({ auth, onBack, onRestore }) {
     let active = true;
     apiRequest('/v1/simulations', { token: auth.access_token })
       .then((result) => {
-        if (active) setSimulations(Array.isArray(result) ? result : (result.data ?? []));
+        if (active) setSimulations(result.data);
       })
       .catch((requestError) => { if (active) setError(requestError.message); })
       .finally(() => { if (active) setLoading(false); });
@@ -31,11 +31,12 @@ export default function MyPage({ auth, onBack, onRestore }) {
     setRestoringId(id);
     setRestoreError('');
     try {
-      const simulation = await apiRequest(`/v1/simulations/${id}/restore`, {
+      const result = await apiRequest(`/v1/simulations/${id}/restore`, {
         method: 'POST',
         token: auth.access_token,
+        body: JSON.stringify({}),
       });
-      onRestore(simulation);
+      onRestore(result.data);
     } catch (requestError) {
       setRestoreError(requestError.message);
     } finally {

--- a/frontend/src/pages/MyPage.test.jsx
+++ b/frontend/src/pages/MyPage.test.jsx
@@ -1,0 +1,109 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import MyPage from './MyPage.jsx';
+
+const auth = { access_token: 'token' };
+const simulation = {
+  id: 'sim-01',
+  name: '첫 번째 시뮬레이션',
+  status: 'PAUSED',
+  current_day: 3,
+  current_tick: 7,
+  updated_at: '2026-08-27T12:00:00Z',
+};
+
+function response(body, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('MyPage', () => {
+  it('{data, meta} 목록 응답을 파싱한다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => response({
+      data: [simulation],
+      meta: { next_cursor: null, has_more: false },
+    }));
+
+    render(<MyPage auth={auth} onBack={vi.fn()} onRestore={vi.fn()} />);
+
+    expect(screen.getByText('목록을 불러오는 중...')).toBeInTheDocument();
+    expect(await screen.findByText('첫 번째 시뮬레이션')).toBeInTheDocument();
+  });
+
+  it('빈 목록을 표시한다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => response({
+      data: [],
+      meta: { next_cursor: null, has_more: false },
+    }));
+
+    render(<MyPage auth={auth} onBack={vi.fn()} onRestore={vi.fn()} />);
+
+    expect(await screen.findByText('저장된 시뮬레이션이 없습니다.')).toBeInTheDocument();
+  });
+
+  it('목록 조회 실패 오류를 표시한다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => response({}, 500));
+
+    render(<MyPage auth={auth} onBack={vi.fn()} onRestore={vi.fn()} />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('서버 오류가 발생했습니다.');
+  });
+
+  it('restore 응답의 data로 onRestore를 호출한다', async () => {
+    const restoredSimulation = {
+      ...simulation,
+      status: 'RUNNING',
+      user_persona: { agent_id: 'agent-01', status: 'APPLIED', locked: true },
+    };
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockImplementationOnce(() => response({ data: [simulation], meta: { next_cursor: null, has_more: false } }))
+      .mockImplementationOnce(() => response({ data: restoredSimulation }));
+    const onRestore = vi.fn();
+
+    render(<MyPage auth={auth} onBack={vi.fn()} onRestore={onRestore} />);
+    await userEvent.click(await screen.findByRole('button', { name: '불러오기' }));
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'http://localhost:8000/v1/simulations/sim-01/restore',
+      expect.objectContaining({ method: 'POST', body: '{}' }),
+    );
+    expect(onRestore).toHaveBeenCalledWith(restoredSimulation);
+  });
+
+  it('restore 중 모든 불러오기 버튼을 비활성화해 중복 실행을 막는다', async () => {
+    const secondSimulation = { ...simulation, id: 'sim-02', name: '두 번째 시뮬레이션' };
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockImplementationOnce(() => response({ data: [simulation, secondSimulation], meta: { next_cursor: null, has_more: false } }))
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    render(<MyPage auth={auth} onBack={vi.fn()} onRestore={vi.fn()} />);
+    const buttons = await screen.findAllByRole('button', { name: '불러오기' });
+    await userEvent.click(buttons[0]);
+
+    expect(screen.getByRole('button', { name: '불러오는 중...' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '불러오기' })).toBeDisabled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('restore 실패 오류를 표시하고 다시 시도할 수 있다', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockImplementationOnce(() => response({ data: [simulation], meta: { next_cursor: null, has_more: false } }))
+      .mockImplementationOnce(() => response({}, 500));
+
+    render(<MyPage auth={auth} onBack={vi.fn()} onRestore={vi.fn()} />);
+    await userEvent.click(await screen.findByRole('button', { name: '불러오기' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('서버 오류가 발생했습니다.');
+    expect(screen.getByRole('button', { name: '불러오기' })).toBeEnabled();
+  });
+});

--- a/frontend/src/pages/SavePage.test.jsx
+++ b/frontend/src/pages/SavePage.test.jsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import SavePage from './SavePage.jsx';
+
+function response(body, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('SavePage', () => {
+  it('저장 API 성공 후 onComplete를 호출한다', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(() => response({ data: { id: 'sim-01' } }));
+    const onComplete = vi.fn();
+
+    render(
+      <SavePage
+        simulationName="첫 번째 시뮬레이션"
+        simulationId="sim-01"
+        token="token"
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8000/v1/simulations/sim-01/save',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('저장 중 버튼을 비활성화해 중복 제출을 막는다', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise(() => {}));
+
+    render(
+      <SavePage
+        simulationName="첫 번째 시뮬레이션"
+        simulationId="sim-01"
+        token="token"
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const saveButton = screen.getByRole('button', { name: '저장' });
+    await userEvent.click(saveButton);
+    await userEvent.click(screen.getByRole('button', { name: '저장 중...' }));
+
+    expect(screen.getByRole('button', { name: '저장 중...' })).toBeDisabled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('저장 실패 오류를 표시하고 다시 시도할 수 있다', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => response({}, 500));
+
+    render(
+      <SavePage
+        simulationName="첫 번째 시뮬레이션"
+        simulationId="sim-01"
+        token="token"
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: '저장' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('서버 오류가 발생했습니다.');
+    expect(screen.getByRole('button', { name: '저장' })).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## 작업 개요

PR #221의 S8·S9 API 연동을 확정 예정인 restore 응답 계약에 맞게 보완하고 관련 테스트를 추가한다.

## 관련 Issue

관련 Issue 없음  
Follow-up: #221

## 변경 내용

- `GET /simulations` 응답을 `{ data, meta }` 구조로 파싱
- restore 요청에 빈 JSON 본문 `{}` 전달
- restore 응답의 `data`를 `onRestore`에 전달
- 복원된 `user_persona`로 Persona ID와 설정 완료 상태 복구
- 목록·save·restore mock 응답을 API 명세 구조로 수정
- SavePage·MyPage·App·mock 정상/로딩/오류/중복 실행 테스트 추가

## 결정 사항 및 이유

- restore 응답의 `user_persona.agent_id`, `status`, `locked`를 사용해 기존 Persona 상태를 복구한다.
- `status === "APPLIED"`이고 `locked === true`이면 Persona 설정이 완료된 것으로 판단한다.
- 프론트 전용 필드 대신 기존 User Persona 도메인 필드를 사용한다.
- 페이지네이션 UI는 추가하지 않고 목록 응답의 `data`만 사용한다.

## 테스트 / 확인 내용

- [x] SavePage 저장 성공·로딩·중복 제출 방지·오류 처리
- [x] MyPage 목록 로딩·빈 목록·오류 처리
- [x] MyPage restore 성공·로딩·중복 실행 방지·오류 처리
- [x] App Simulation·Persona 상태 연결
- [x] mock handler 계약 검증
- [x] 전체 테스트: 18개 파일, 122/122 통과
- [x] lint 성공
- [x] 프로덕션 빌드 성공

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: API 계약 분석, 테스트 작성, 프론트 연동 및 mock 보완
- 사람이 검토할 내용: restore 응답 계약과 Persona 상태 복구 기준

## 리뷰어가 봐야 할 부분

- 백엔드 `/restore` 구현이 확정 예정인 S9 저장본 불러오기 계약과 일치하는지
- status 대소문자와 `user_persona` 응답 필드가 명세대로 제공되는지