### PR TITLE
[Feature] MainPage Hero + Nav + 시뮬레이션 카드 그리드 구현

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -109,7 +109,7 @@ describe('Slice 0 UI', () => {
     createFetchMock()
     render(<App />)
     await login()
-    expect(await screen.findByRole('heading', { name: 'Owner A님, 환영합니다.' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Owner A님의 마법학교' })).toBeInTheDocument()
     await completeOnboarding()
     expect(await screen.findByText('Agent 6명')).toBeInTheDocument()
     expect(document.querySelectorAll('[data-agent-id]')).toHaveLength(6)
@@ -254,7 +254,7 @@ describe('Slice 0 UI', () => {
     expect(await screen.findByRole('main')).toHaveClass('auth-shell')
     await login()
 
-    expect(await screen.findByRole('heading', { name: 'Owner B님, 환영합니다.' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Owner B님의 마법학교' })).toBeInTheDocument()
     expect(screen.queryByRole('heading', { name: 'Magic Academy Simulation' })).not.toBeInTheDocument()
     expect(document.querySelectorAll('[data-agent-id]')).toHaveLength(0)
   })
@@ -269,7 +269,7 @@ describe('Slice 0 UI', () => {
     expect(screen.getByText('Magic Academy Simulation')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '불러오기' })).toBeEnabled()
     await userEvent.click(screen.getByRole('button', { name: '뒤로가기' }))
-    expect(screen.getByRole('heading', { name: 'Owner A님, 환영합니다.' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Owner A님의 마법학교' })).toBeInTheDocument()
   })
 
   it('MyPage restore 성공 후 Persona 설정을 복구하고 Simulation 화면으로 이동한다', async () => {

--- a/frontend/src/pages/MainPage.css
+++ b/frontend/src/pages/MainPage.css
@@ -1,28 +1,392 @@
 .main-page {
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
+  background: var(--c-bg, #060d20);
+  color: var(--c-text, #f2f5fc);
+  font-family: var(--f-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+}
+
+/* ── Hero ── */
+.main-hero {
+  position: relative;
+  height: 440px;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.main-hero__bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 75% 15%, rgba(94, 96, 232, 0.14), transparent 55%),
+    linear-gradient(to bottom, rgba(6, 13, 32, 0.35), rgba(6, 13, 32, 0.55)),
+    url('/assets/concept/academy-night-background.png') center / cover;
+  transform: scale(1.03);
+}
+
+.main-hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, transparent 30%, var(--c-bg, #060d20) 100%);
+}
+
+/* ── Nav ── */
+.main-nav {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 54px;
+  background: rgba(11, 14, 35, 0.6);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--c-border, rgba(70, 100, 180, 0.24));
+  display: flex;
+  align-items: center;
+  padding: 0 var(--s-8, 32px);
+  gap: var(--s-4, 16px);
+  z-index: 10;
+}
+
+.main-nav__brand {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2, 8px);
+  font-family: var(--f-serif-en, 'Playfair Display', Georgia, serif);
+  font-size: var(--t-base, 0.9375rem);
+  font-weight: 600;
+  color: var(--c-text, #f2f5fc);
+  letter-spacing: 0.04em;
+}
+
+.main-nav__brand img {
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.main-nav__links {
+  display: flex;
+  gap: var(--s-5, 20px);
+  margin-left: var(--s-4, 16px);
+}
+
+.main-nav__link {
+  font-size: var(--t-sm, 0.8125rem);
+  color: var(--c-text-2, #a4b5d6);
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color var(--tr-fast, 150ms ease);
+}
+
+.main-nav__link:hover,
+.main-nav__link--active {
+  color: var(--c-text, #f2f5fc);
+}
+
+.main-nav__user {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--s-3, 12px);
+}
+
+.main-nav__profile-btn {
+  font-size: var(--t-sm, 0.8125rem);
+  color: var(--c-text-2, #a4b5d6);
+  background: none;
+  border: none;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0;
+  transition: color var(--tr-fast, 150ms ease);
+}
+
+.main-nav__profile-btn:hover {
+  color: var(--c-text, #f2f5fc);
+}
+
+/* ── Hero Content ── */
+.main-hero__content {
+  position: absolute;
+  bottom: var(--s-8, 32px);
+  left: var(--s-12, 48px);
+}
+
+.main-hero__eyebrow {
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: var(--t-xs, 0.6875rem);
+  color: #d4b26f;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  margin: 0 0 var(--s-2, 8px);
+}
+
+.main-hero__title {
+  font-family: var(--f-serif-ko, 'Noto Serif KR', Georgia, serif);
+  font-size: 3rem;
+  font-weight: 600;
+  color: var(--c-text, #f2f5fc);
+  line-height: 1.2;
+  margin: 0;
+}
+
+.main-hero__sub {
+  font-size: var(--t-base, 0.9375rem);
+  color: var(--c-text-2, #a4b5d6);
+  margin: var(--s-2, 8px) 0 0;
+}
+
+.main-hero__cta {
+  margin-top: var(--s-6, 24px);
+  display: flex;
+  gap: var(--s-3, 12px);
+}
+
+.main-cta-primary {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--s-4, 16px) var(--s-8, 32px);
+  background: linear-gradient(135deg, #6e70f2, #4a4dd0);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--r-lg, 14px);
+  font-size: var(--t-md, 1rem);
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(94, 96, 232, 0.35);
+  transition: all var(--tr-fast, 150ms ease);
+}
+
+.main-cta-primary:hover {
+  background: linear-gradient(135deg, #8082f5, #5e60e8);
+  box-shadow: 0 6px 20px rgba(94, 96, 232, 0.5);
+  transform: translateY(-1px);
+}
+
+.main-cta-outline {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--s-4, 16px) var(--s-8, 32px);
+  background: rgba(11, 24, 56, 0.6);
+  color: var(--c-text, #f2f5fc);
+  border: 1px solid var(--c-border, rgba(70, 100, 180, 0.24));
+  border-radius: var(--r-lg, 14px);
+  font-size: var(--t-md, 1rem);
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  transition: all var(--tr-fast, 150ms ease);
+}
+
+.main-cta-outline:hover {
+  border-color: var(--c-border-hi, rgba(212, 178, 111, 0.30));
+  background: var(--c-surface-hi, #122450);
+  color: #fff;
+}
+
+/* ── Main Content ── */
+.main-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--s-6, 24px) var(--s-12, 48px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-6, 24px);
+}
+
+/* ── Section Header ── */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--s-4, 16px);
+}
+
+.section-title {
+  font-size: var(--t-base, 0.9375rem);
+  font-weight: 500;
+  color: var(--c-text, #f2f5fc);
+}
+
+.section-more {
+  font-size: var(--t-sm, 0.8125rem);
+  color: var(--c-text-2, #a4b5d6);
+  background: none;
+  border: none;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0;
+  transition: color var(--tr-fast, 150ms ease);
+}
+
+.section-more:hover {
+  color: var(--c-primary, #5e60e8);
+}
+
+/* ── Sim Grid ── */
+.sim-grid {
   display: grid;
-  place-items: center;
-  padding: var(--s-6);
-  background: radial-gradient(circle at top, var(--c-surface-hi), var(--c-bg) 58%);
-  color: var(--c-text);
-  font-family: var(--f-ui);
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--s-4, 16px);
 }
 
-.main-page__card {
-  width: min(560px, 100%);
-  padding: var(--s-12);
-  border: 1px solid var(--c-border-hi);
-  border-radius: var(--r-xl);
-  background: var(--c-surface-card);
-  box-shadow: var(--sh-lg);
-  text-align: center;
+/* ── Sim Card ── */
+.sim-card {
+  background: rgba(14, 23, 48, 0.7);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--c-border, rgba(70, 100, 180, 0.24));
+  border-radius: var(--r-lg, 14px);
+  overflow: hidden;
+  cursor: pointer;
+  transition: all var(--tr-fast, 150ms ease);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
 }
 
-.main-page__eyebrow { margin: 0 0 var(--s-4); color: var(--c-cream); font-family: var(--f-serif-en); letter-spacing: .15em; }
-.main-page h1 { margin: 0; font-family: var(--f-serif-ko); font-size: var(--t-2xl); }
-.main-page__description { margin: var(--s-4) 0 var(--s-8); color: var(--c-text-2); }
-.main-page__actions { display: grid; gap: var(--s-3); }
-.main-page__actions button { padding: var(--s-3) var(--s-6); border-radius: var(--r-md); }
-.main-page__primary { background: var(--c-primary); color: var(--c-text); }
-.main-page__primary:hover { background: var(--c-primary-hover); }
-.main-page__secondary { border: 1px solid var(--c-border-hi); background: transparent; color: var(--c-cream); }
+.sim-card:hover {
+  border-color: var(--c-border-hi, rgba(212, 178, 111, 0.30));
+  transform: translateY(-4px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5), 0 0 20px rgba(212, 178, 111, 0.12);
+}
+
+.sim-card:focus-visible {
+  outline: 2px solid var(--c-primary-ring, rgba(94, 96, 232, 0.38));
+  outline-offset: 2px;
+}
+
+.sim-card__thumb {
+  height: 100px;
+  position: relative;
+  overflow: hidden;
+  background: rgba(16, 26, 56, 0.6);
+}
+
+.sim-card__thumb-img {
+  width: 100%;
+  height: 100%;
+  background-image: url('/assets/concept/academy-night-background.png');
+  background-size: cover;
+  background-position: center;
+  filter: brightness(0.7) saturate(0.85);
+  transition: transform var(--tr-normal, 260ms ease);
+}
+
+.sim-card:hover .sim-card__thumb-img {
+  transform: scale(1.08);
+}
+
+.sim-card__thumb-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, transparent 30%, rgba(14, 23, 48, 0.95) 100%);
+}
+
+.sim-card__thumb-status {
+  position: absolute;
+  top: var(--s-2, 8px);
+  left: var(--s-2, 8px);
+}
+
+.sim-card__thumb-preview {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(6, 13, 32, 0.35);
+  opacity: 0;
+  transition: opacity var(--tr-fast, 150ms ease);
+}
+
+.sim-card:hover .sim-card__thumb-preview {
+  opacity: 1;
+}
+
+.sim-card__thumb-preview span {
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: var(--r-sm, 6px);
+  padding: 4px 10px;
+  backdrop-filter: blur(4px);
+  background: rgba(6, 13, 32, 0.4);
+}
+
+/* Status chips */
+.sim-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px var(--s-2, 8px);
+  border-radius: var(--r-sm, 6px);
+  font-family: var(--f-mono, monospace);
+  font-size: var(--t-xs, 0.6875rem);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.sim-status::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.sim-status--running { background: rgba(109, 230, 140, 0.12); color: #5ce67a; }
+.sim-status--running::before { background: #5ce67a; }
+
+.sim-status--paused { background: rgba(52, 179, 199, 0.14); color: #34b3c7; }
+.sim-status--paused::before { background: #34b3c7; }
+
+.sim-status--ended { background: rgba(219, 76, 76, 0.16); color: var(--c-critical, #db4c4c); }
+.sim-status--ended::before { background: var(--c-critical, #db4c4c); }
+
+/* Card body */
+.sim-card__body {
+  padding: var(--s-4, 16px);
+}
+
+.sim-card__name {
+  font-weight: 500;
+  color: var(--c-text, #f2f5fc);
+  font-size: var(--t-base, 0.9375rem);
+}
+
+.sim-card__meta {
+  font-family: var(--f-mono, 'JetBrains Mono', monospace);
+  font-size: var(--t-xs, 0.6875rem);
+  color: var(--c-text-2, #a4b5d6);
+  margin-top: var(--s-1, 4px);
+  letter-spacing: 0.06em;
+}
+
+/* New Simulation Card */
+.sim-card--new {
+  border: 1.5px dashed var(--c-border, rgba(70, 100, 180, 0.24));
+  background: rgba(14, 23, 48, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: var(--s-3, 12px);
+  min-height: 160px;
+  color: var(--c-text-2, #a4b5d6);
+  font-size: var(--t-sm, 0.8125rem);
+}
+
+.sim-card--new:hover {
+  border-color: var(--c-primary, #5e60e8);
+  color: #fff;
+  background: rgba(94, 96, 232, 0.12);
+  box-shadow: 0 0 20px rgba(94, 96, 232, 0.25);
+  transform: translateY(-4px);
+}

--- a/frontend/src/pages/MainPage.jsx
+++ b/frontend/src/pages/MainPage.jsx
@@ -1,17 +1,108 @@
 import './MainPage.css';
 
-export default function MainPage({ displayName, onStart, onMyPage }) {
+const PLACEHOLDER_SIMS = [
+  { id: 'placeholder-1', name: '첫 번째 시뮬레이션', meta: 'TICK 07 · LEO 시점', status: 'RUNNING' },
+  { id: 'placeholder-2', name: 'Leo의 마법 생물 사건', meta: 'TICK 04 · RIA 시점', status: 'ENDED' },
+];
+
+const STATUS_CHIP = {
+  RUNNING: { label: 'RUNNING', cls: 'sim-status--running' },
+  PAUSED:  { label: 'PAUSED',  cls: 'sim-status--paused' },
+  ENDED:   { label: 'ENDED',   cls: 'sim-status--ended' },
+};
+
+export default function MainPage({ displayName, onStart, onMyPage, simulations = [] }) {
+  const cards = simulations.length > 0 ? simulations : PLACEHOLDER_SIMS;
+
   return (
-    <main className="main-page">
-      <section className="main-page__card">
-        <p className="main-page__eyebrow">MAGIC ACADEMY</p>
-        <h1>{displayName}님, 환영합니다.</h1>
-        <p className="main-page__description">마법 대학교의 새로운 이야기를 시작해 보세요.</p>
-        <div className="main-page__actions">
-          <button type="button" className="main-page__primary" onClick={onStart}>시뮬레이션 시작</button>
-          <button type="button" className="main-page__secondary" onClick={onMyPage}>마이페이지</button>
+    <div className="main-page">
+      <section className="main-hero">
+        <div className="main-hero__bg" />
+        <div className="main-hero__overlay" />
+
+        <nav className="main-nav" aria-label="주 내비게이션">
+          <span className="main-nav__brand">
+            <img src="/assets/concept/logo.png" alt="" width="34" height="34" />
+            Magic Academy
+          </span>
+          <div className="main-nav__links">
+            <span className="main-nav__link main-nav__link--active">홈</span>
+            <button type="button" className="main-nav__link" onClick={onMyPage}>마이페이지</button>
+          </div>
+          <div className="main-nav__user">
+            <button type="button" className="main-nav__profile-btn" onClick={onMyPage} aria-label="마이페이지로 이동">
+              {displayName}
+            </button>
+          </div>
+        </nav>
+
+        <div className="main-hero__content">
+          <p className="main-hero__eyebrow">MAGIC ACADEMY</p>
+          <h1 className="main-hero__title">{displayName}님의 마법학교</h1>
+          <p className="main-hero__sub">Agent들의 상태를 관찰하고, Magic Event의 원인을 추적합니다.</p>
+          <div className="main-hero__cta">
+            <button type="button" className="main-cta-primary" onClick={onStart}>
+              시뮬레이션 시작
+            </button>
+            <button type="button" className="main-cta-outline" onClick={onMyPage}>
+              기록 보기
+            </button>
+          </div>
         </div>
       </section>
-    </main>
+
+      <main className="main-content">
+        <div>
+          <div className="section-header">
+            <span className="section-title">이어서 관찰하기</span>
+            <button type="button" className="section-more" onClick={onMyPage}>전체 보기 →</button>
+          </div>
+          <div className="sim-grid">
+            {cards.map((sim) => {
+              const chip = STATUS_CHIP[sim.status] ?? STATUS_CHIP.RUNNING;
+              return (
+                <div
+                  key={sim.id}
+                  className="sim-card"
+                  role="button"
+                  tabIndex={0}
+                  onClick={onStart}
+                  onKeyDown={(e) => e.key === 'Enter' && onStart()}
+                >
+                  <div className="sim-card__thumb">
+                    <div className="sim-card__thumb-img" />
+                    <div className="sim-card__thumb-overlay" />
+                    <div className="sim-card__thumb-status">
+                      <span className={`sim-status ${chip.cls}`}>{chip.label}</span>
+                    </div>
+                    <div className="sim-card__thumb-preview">
+                      <span>▶ 이어서 관찰하기</span>
+                    </div>
+                  </div>
+                  <div className="sim-card__body">
+                    <div className="sim-card__name">{sim.name}</div>
+                    <div className="sim-card__meta">{sim.meta}</div>
+                  </div>
+                </div>
+              );
+            })}
+
+            <div
+              className="sim-card sim-card--new"
+              role="button"
+              tabIndex={0}
+              onClick={onStart}
+              onKeyDown={(e) => e.key === 'Enter' && onStart()}
+              aria-label="새 시뮬레이션 시작"
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+              <span>새 시뮬레이션 시작</span>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## 작업 개요

목업(08-main.html) 기준으로 MainPage를 완전히 재구현한다.
기존의 중앙 카드 레이아웃을 Hero(440px) + absolute 상단 Nav + 시뮬레이션 카드 그리드 구조로 교체한다.

## 관련 Issue

관련 Issue 없음

## 변경 내용

- `MainPage.jsx`: Hero 섹션(배경 이미지 + 그라디언트), absolute Nav(브랜드 / 링크 / 프로필 버튼), hero__content(eyebrow / h1 / sub / CTA), 시뮬레이션 카드 그리드(3-column) 구현
- `MainPage.css`: 디자인 시스템 토큰 전체 적용 + 미지원 토큰에 fallback 하드코딩, 카드 hover 애니메이션, status chip(RUNNING / PAUSED / ENDED) 스타일
- `App.test.jsx`: h1 텍스트 변경(`님, 환영합니다.` → `님의 마법학교`)에 따라 heading 어서션 3개 업데이트

## 결정 사항 및 이유

- **CSS fallback 패턴**: React 앱의 `design-system.css`에 없는 토큰(`--c-event`, `--t-4xl`, `--topbar-h`, `--c-surface-glass`)은 `var(--token, hardcoded)` 패턴으로 처리. 토큰 추가 없이 목업 색상을 재현하되, 추후 디자인 시스템 토큰이 추가되면 자동으로 반영됨.
- **PLACEHOLDER_SIMS**: `simulations` prop이 빈 배열일 때 정적 placeholder 2개를 표시. API 연동 전 화면 확인을 가능하게 하고, 연동 후 빈 배열이면 새 시뮬레이션 카드만 표시하는 구조로 자연스럽게 전환됨.
- **카드 그리드 3-column**: 목업(4-column) 대신 요구사항 기준 3-column 적용.
- **`simulations` prop 추가**: App.jsx 시그니처는 유지하고 새 prop은 default `[]`로 선언해 기존 호출부 수정 없이 호환.

## 테스트 / 확인 내용

- [x] 로컬 실행 확인 (`npx vite build` 통과)
- [x] 주요 기능 동작 확인 (`npx vitest run` 122/122 통과)
- [ ] 에러 케이스 확인
- [ ] 관련 문서 업데이트 확인

## AI 사용 여부

사용 여부: 사용함
사용한 작업: MainPage.jsx / MainPage.css 재구현, 테스트 어서션 업데이트
사람이 검토한 내용: 목업 대비 레이아웃 구조, CSS fallback 값, prop 시그니처 호환성, 테스트 결과

## 리뷰어가 봐야 할 부분

- `MainPage.css` fallback 하드코딩 값들 (`#d4b26f`, `3rem` 등) — `design-system.css`에 토큰 추가 시 일괄 교체 필요
- `simulations` prop 기본값 `[]` → placeholder 표시 동작 — API 연동 시 빈 배열 응답이면 새 카드만 표시되는 것이 의도한 동작인지 확인