### PR TITLE
[Feature] RelationshipModal SVG 관계 그래프 재구현

### DIFF
--- a/frontend/src/components/RelationshipModal.css
+++ b/frontend/src/components/RelationshipModal.css
@@ -1,72 +1,317 @@
-.relationship-modal-backdrop {
+/* ── Backdrop ──────────────────────────────────────────────────── */
+.rel-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 30;
+  background: rgba(6, 13, 32, 0.6);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
-.relationship-modal {
-  background: #fff;
-  border-radius: 8px;
-  width: min(90vw, 640px);
-  max-height: 80vh;
-  overflow-y: auto;
-  padding: 24px;
+/* ── Modal inner ────────────────────────────────────────────────── */
+.rel-modal__inner {
+  background: rgba(8, 16, 42, 0.97);
+  border: 1px solid var(--c-border-hi);
+  border-radius: var(--r-xl);
+  width: 1060px;
+  height: 720px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  overflow: hidden;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.7);
+  animation: float-up 300ms ease both;
 }
 
-.relationship-modal-header {
+/* ── Header ─────────────────────────────────────────────────────── */
+.rel-modal__header {
+  padding: var(--s-4) var(--s-6);
+  border-bottom: 1px solid var(--c-border);
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--s-4);
+  flex-shrink: 0;
+  background: rgba(6, 13, 32, 0.8);
 }
 
-.relationship-modal-header h2 {
-  margin: 0;
+.rel-modal__title {
+  font-family: var(--f-serif-en);
+  font-size: var(--t-base);
+  font-weight: 600;
+  color: var(--c-text);
+  white-space: nowrap;
 }
 
-.relationship-modal-body {
+.rel-modal__selected-label {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--c-text-2);
+  white-space: nowrap;
+}
+
+.rel-filter-chips {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  gap: var(--s-2);
+  margin-left: auto;
+  flex-wrap: nowrap;
+  overflow-x: auto;
 }
 
-.relationship-entry {
-  border: 1px solid #e1e3e6;
-  border-radius: 6px;
-  padding: 12px;
+.rel-modal__close {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--c-border);
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.relationship-node {
-  font-weight: bold;
-  font-size: 1rem;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  background: none;
-  border: none;
-  padding: 0;
-  text-align: left;
+  color: var(--c-text-2);
+  flex-shrink: 0;
+  transition: background var(--tr-fast), color var(--tr-fast);
+}
+.rel-modal__close:hover { background: var(--c-surface-hi); color: var(--c-text); }
+.rel-modal__close:focus-visible { outline: 2px solid var(--c-primary-ring); outline-offset: 2px; }
+
+/* ── Chips (filter + scope) ─────────────────────────────────────── */
+.chip {
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-family: var(--f-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--c-text-2);
+  background: rgba(11, 24, 56, 0.7);
+  border: 1px solid var(--c-border);
+  cursor: pointer;
+  transition: all var(--tr-fast);
+  white-space: nowrap;
+}
+.chip:hover { color: var(--c-text); border-color: var(--c-border-hi); }
+.chip:focus-visible { outline: 2px solid var(--c-primary-ring); outline-offset: 2px; }
+.chip.active { color: #d9d9ff; background: rgba(94, 96, 232, 0.18); border-color: rgba(140, 143, 255, 0.48); }
+
+.chip.chip-favor.active   { color: #5CE67A;             background: rgba(92, 230, 122, 0.12); border-color: rgba(92, 230, 122, 0.4); }
+.chip.chip-trust.active   { color: var(--c-inspector);  background: rgba(52, 179, 199, 0.12); border-color: rgba(52, 179, 199, 0.4); }
+.chip.chip-tension.active { color: var(--c-critical);   background: rgba(219, 76, 76, 0.12);  border-color: rgba(219, 76, 76, 0.4); }
+.chip.chip-dep.active     { color: var(--c-cream);      background: rgba(212, 178, 111, 0.12); border-color: rgba(212, 178, 111, 0.4); }
+
+/* ── Scope bar ──────────────────────────────────────────────────── */
+.scope-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--c-border);
+  background: rgba(6, 13, 32, 0.72);
+  flex-shrink: 0;
+  overflow-x: auto;
 }
 
-.relationship-metrics {
+.scope-label {
+  margin-right: 6px;
+  color: var(--c-text-3);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+/* ── Body ───────────────────────────────────────────────────────── */
+.rel-modal__body {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: var(--c-bg);
+}
+
+/* SVG edge layer */
+.rm-svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* Edge lines */
+.edge-base {
+  fill: none;
+  stroke-linecap: round;
+  transition: opacity 0.2s;
+  cursor: pointer;
+}
+.edge-favor   { stroke: rgba(92, 230, 122, 0.55);  stroke-width: 2; }
+.edge-trust   { stroke: rgba(52, 179, 199, 0.55);  stroke-width: 2; stroke-dasharray: 5 2; }
+.edge-tension { stroke: rgba(219, 76, 76, 0.55);   stroke-width: 2; stroke-dasharray: 3 3; }
+.edge-dep     { stroke: rgba(212, 178, 111, 0.5);  stroke-width: 1.5; }
+.edge-neutral { stroke: rgba(169, 174, 199, 0.25); stroke-width: 1; }
+
+/* ── Graph nodes (DOM overlay) ──────────────────────────────────── */
+.graph-node {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s-2);
+  cursor: pointer;
+  user-select: none;
+  transition: opacity 0.2s;
+}
+.graph-node:focus-visible {
+  outline: 2px solid var(--c-primary-ring);
+  outline-offset: 4px;
+  border-radius: 50%;
+}
+
+.graph-node__portrait {
+  border-radius: 50%;
+  border: 2px solid var(--c-border-hi);
+  background-color: var(--c-surface-hi);
+  object-fit: cover;
+  display: block;
+  transition: border-color var(--tr-fast), transform var(--tr-fast), box-shadow var(--tr-fast);
+}
+
+.graph-node__portrait--fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--c-text-2);
+  background: var(--c-surface-hi);
+}
+
+.graph-node:hover .graph-node__portrait {
+  transform: scale(1.08);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.graph-node.selected .graph-node__portrait {
+  border-color: var(--c-primary);
+  box-shadow: var(--sh-primary);
+  transform: scale(1.1);
+}
+
+.graph-node__name {
+  font-size: var(--t-xs);
+  font-weight: 500;
+  color: var(--c-text);
+  background: rgba(18, 36, 80, 0.85);
+  backdrop-filter: blur(4px);
+  padding: 2px var(--s-2);
+  border-radius: var(--r-sm);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+/* ── Footer ─────────────────────────────────────────────────────── */
+.rel-modal__footer {
+  padding: var(--s-3) var(--s-6);
+  border-top: 1px solid var(--c-border);
+  display: flex;
+  align-items: center;
+  gap: var(--s-4);
+  flex-shrink: 0;
+  background: rgba(6, 13, 32, 0.7);
+}
+
+/* ── Legend ─────────────────────────────────────────────────────── */
+.rel-legend {
+  display: flex;
+  align-items: center;
+  gap: var(--s-4);
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  flex-shrink: 0;
 }
 
-.relationship-metrics li {
-  font-size: 0.875rem;
-  background: #f1f3f5;
-  border-radius: 4px;
-  padding: 2px 8px;
+.rel-legend-item {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  font-size: var(--t-xs);
+  color: var(--c-text-2);
+  white-space: nowrap;
+}
+
+.rel-legend-line {
+  width: 18px;
+  height: 2px;
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+
+/* ── Edge detail (footer right) ─────────────────────────────────── */
+.rel-detail {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--s-4);
+  min-width: 260px;
+  flex-shrink: 0;
+}
+
+.rel-detail-pair {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+}
+
+.rel-detail-portrait {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background-size: cover;
+  background-position: center top;
+  border: 1.5px solid var(--c-border);
+  flex-shrink: 0;
+}
+
+.rel-arrow {
+  font-family: var(--f-mono);
+  font-size: var(--t-sm);
+  color: var(--c-primary);
+}
+
+.rel-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rel-stat-row {
+  display: flex;
+  gap: var(--s-2);
+  font-family: var(--f-mono);
+  font-size: var(--t-xs);
+}
+
+.rel-stat-key { color: var(--c-text-3); }
+.rel-stat-val { color: var(--c-text); }
+
+/* ── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .rel-modal__inner {
+    width: 100%;
+    height: calc(100vh - 84px);
+    min-height: 620px;
+  }
+  .rel-modal__header { flex-wrap: wrap; padding: 12px; gap: 8px; }
+  .rel-filter-chips  { order: 2; width: 100%; margin-left: 0; }
+  .scope-bar         { overflow-x: auto; }
+  .rel-modal__footer { overflow-x: auto; }
+  .rel-detail        { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rel-modal__inner  { animation: none; }
+  .edge-base,
+  .graph-node__portrait,
+  .graph-node        { transition: none; }
 }

--- a/frontend/src/components/RelationshipModal.jsx
+++ b/frontend/src/components/RelationshipModal.jsx
@@ -1,66 +1,367 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { apiRequest } from "../api/client.js";
 import "./RelationshipModal.css";
 
-export default function RelationshipModal({ selectedAgent, agents, auth, onSelectAgent, onClose }) {
-  const [relationships, setRelationships] = useState([]);
+// ── Layout constants ──────────────────────────────────────────────
+const GRAPH_W   = 1060;
+const GRAPH_H   = 530;
+const CENTER    = { x: GRAPH_W / 2, y: GRAPH_H / 2 };
+const RADIUS    = Math.min(GRAPH_W, GRAPH_H) * 0.35;
+const SEL_R     = 30;
+const NORM_R    = 24;
+const ARROW_GAP = 7;
+
+const EDGE_CONFIG = {
+  favor:   { stroke: "rgba(92,230,122,0.55)",  dash: null,    fill: "rgba(92,230,122,0.7)",  sw: 2   },
+  trust:   { stroke: "rgba(52,179,199,0.55)",  dash: "5 2",   fill: "rgba(52,179,199,0.7)",  sw: 2   },
+  tension: { stroke: "rgba(219,76,76,0.55)",   dash: "3 3",   fill: "rgba(219,76,76,0.7)",   sw: 2   },
+  dep:     { stroke: "rgba(212,178,111,0.5)",  dash: null,    fill: "rgba(212,178,111,0.7)", sw: 1.5 },
+  neutral: { stroke: "rgba(169,174,199,0.25)", dash: null,    fill: "rgba(169,174,199,0.4)", sw: 1   },
+};
+
+const FILTER_CHIPS = [
+  { key: "all",     label: "전체",        cls: "" },
+  { key: "favor",   label: "호감·친밀",   cls: "chip-favor" },
+  { key: "trust",   label: "신뢰",        cls: "chip-trust" },
+  { key: "tension", label: "긴장·라이벌", cls: "chip-tension" },
+  { key: "dep",     label: "의존",        cls: "chip-dep" },
+];
+
+const SCOPE_CHIPS = [
+  { key: "all",    label: "전체" },
+  { key: "focus",  label: "선택 Agent 중심" },
+  { key: "direct", label: "직접 관계만" },
+];
+
+const LEGEND_ITEMS = [
+  { label: "호감·친밀",   lineStyle: { background: "#5CE67A" } },
+  { label: "신뢰",        lineStyle: { background: "var(--c-inspector)" } },
+  { label: "긴장·라이벌", lineStyle: { borderTop: "2px dashed var(--c-critical)", background: "transparent" } },
+  { label: "의존",        lineStyle: { background: "var(--c-cream)" } },
+  { label: "중립",        lineStyle: { background: "rgba(169,174,199,0.3)" } },
+];
+
+function classifyEdge(rel) {
+  if ((rel.tension    ?? 0) > 50 || (rel.rivalry    ?? 0) > 50) return "tension";
+  if ((rel.trust      ?? 0) > 50)                                return "trust";
+  if ((rel.affection  ?? 0) > 50 || (rel.closeness  ?? 0) > 50) return "favor";
+  if ((rel.dependency ?? 0) > 50)                                return "dep";
+  return "neutral";
+}
+
+function computePositions(centerId, agents) {
+  const positions = { [centerId]: { ...CENTER } };
+  const others = agents.filter(a => a.id !== centerId);
+  others.forEach((agent, i) => {
+    const angle = (2 * Math.PI * i / others.length) - Math.PI / 2;
+    positions[agent.id] = {
+      x: CENTER.x + RADIUS * Math.cos(angle),
+      y: CENTER.y + RADIUS * Math.sin(angle),
+    };
+  });
+  return positions;
+}
+
+export default function RelationshipModal({
+  selectedAgent: initialAgent,
+  agents,
+  auth,
+  onSelectAgent,
+  onClose,
+}) {
+  const [localSel, setLocalSel]    = useState(initialAgent);
+  const [edges, setEdges]          = useState([]);
+  const [activeFilter, setFilter]  = useState("all");
+  const [scope, setScope]          = useState("all");
+  const [selectedEdge, setSelEdge] = useState(null);
 
   useEffect(() => {
-    apiRequest(`/v1/agents/${selectedAgent.id}/relationships`, {
-      token: auth.access_token,
-    })
-      .then((data) => setRelationships(data))
-      .catch(() => {});
-  }, [selectedAgent.id]);
+    if (!agents.length || !auth) return;
+    Promise.allSettled(
+      agents.map(agent =>
+        apiRequest(`/v1/agents/${agent.id}/relationships`, {
+          token: auth.access_token,
+        })
+      )
+    ).then(results => {
+      const all = [];
+      results.forEach((r, i) => {
+        if (r.status === "fulfilled") {
+          (r.value ?? []).forEach(rel =>
+            all.push({ sourceId: agents[i].id, ...rel })
+          );
+        }
+      });
+      setEdges(all);
+    });
+  }, [agents, auth]);
 
-  const agentById = Object.fromEntries(agents.map((a) => [a.id, a]));
+  const positions = useMemo(
+    () => computePositions(localSel.id, agents),
+    [localSel.id, agents]
+  );
 
-  function handleNodeClick(agentId) {
-    const agent = agentById[agentId];
-    if (agent) onSelectAgent(agent);
-    onClose();
+  const agentById = useMemo(
+    () => Object.fromEntries(agents.map(a => [a.id, a])),
+    [agents]
+  );
+
+  const directIds = useMemo(() => {
+    const s = new Set([localSel.id]);
+    edges.forEach(e => {
+      if (e.sourceId        === localSel.id) s.add(e.target_agent_id);
+      if (e.target_agent_id === localSel.id) s.add(e.sourceId);
+    });
+    return s;
+  }, [localSel.id, edges]);
+
+  function edgeOpacity(e, type) {
+    if (activeFilter !== "all" && type !== activeFilter) return 0.1;
+    if (scope === "focus") {
+      return (e.sourceId === localSel.id || e.target_agent_id === localSel.id) ? 1 : 0.06;
+    }
+    if (scope === "direct") {
+      const ok =
+        directIds.has(e.sourceId) &&
+        directIds.has(e.target_agent_id) &&
+        (e.sourceId === localSel.id || e.target_agent_id === localSel.id);
+      return ok ? 1 : 0.06;
+    }
+    return 1;
+  }
+
+  function nodeOpacity(agentId) {
+    return scope === "direct" && !directIds.has(agentId) ? 0.3 : 1;
+  }
+
+  function handleNodeClick(agent) {
+    setLocalSel(agent);
+    setSelEdge(null);
+    onSelectAgent(agent);
+  }
+
+  function renderEdges() {
+    return edges.flatMap((rel, idx) => {
+      const p1 = positions[rel.sourceId];
+      const p2 = positions[rel.target_agent_id];
+      if (!p1 || !p2) return [];
+
+      const type = classifyEdge(rel);
+      const opacity = edgeOpacity(rel, type);
+      const { stroke, dash, sw } = EDGE_CONFIG[type];
+
+      const dx = p2.x - p1.x;
+      const dy = p2.y - p1.y;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (len < 1) return [];
+
+      const ux = dx / len;
+      const uy = dy / len;
+      const ox = (-dy / len) * 5;
+      const oy = ( dx / len) * 5;
+
+      const r1 = rel.sourceId       === localSel.id ? SEL_R : NORM_R;
+      const r2 = rel.target_agent_id === localSel.id ? SEL_R : NORM_R;
+
+      const x1a = p1.x + ux * r1 + ox,            y1a = p1.y + uy * r1 + oy;
+      const x2a = p2.x - ux * (r2 + ARROW_GAP) + ox, y2a = p2.y - uy * (r2 + ARROW_GAP) + oy;
+
+      const x1b = p2.x - ux * r2 - ox,            y1b = p2.y - uy * r2 - oy;
+      const x2b = p1.x + ux * (r1 + ARROW_GAP) - ox, y2b = p1.y + uy * (r1 + ARROW_GAP) - oy;
+
+      const lineProps = {
+        stroke,
+        strokeWidth: sw,
+        strokeDasharray: dash ?? undefined,
+        strokeLinecap: "round",
+        style: { opacity, cursor: "pointer", transition: "opacity 0.2s" },
+        onClick: () => setSelEdge(rel),
+      };
+
+      return [
+        <line key={`${idx}-ab`} className={`edge-base edge-${type}`}
+          x1={x1a} y1={y1a} x2={x2a} y2={y2a}
+          markerEnd={`url(#arr-${type})`} {...lineProps}
+        />,
+        <line key={`${idx}-ba`} className={`edge-base edge-${type}`}
+          x1={x1b} y1={y1b} x2={x2b} y2={y2b}
+          markerEnd={`url(#arr-${type})`} {...lineProps}
+        />,
+      ];
+    });
   }
 
   return (
-    <div className="relationship-modal-backdrop" onClick={onClose}>
+    <div className="rel-modal" onClick={onClose}>
       <div
         role="dialog"
         aria-label="관계 그래프"
-        className="relationship-modal"
-        onClick={(e) => e.stopPropagation()}
+        aria-modal="true"
+        className="rel-modal__inner"
+        onClick={e => e.stopPropagation()}
       >
-        <div className="relationship-modal-header">
-          <h2>관계 그래프</h2>
-          <button type="button" onClick={onClose}>닫기</button>
+        <div className="rel-modal__header">
+          <span className="rel-modal__title">관계 그래프</span>
+          <span className="rel-modal__selected-label">{localSel.name} 선택 중</span>
+          <div className="rel-filter-chips">
+            {FILTER_CHIPS.map(({ key, label, cls }) => (
+              <button
+                key={key}
+                type="button"
+                className={["chip", cls, activeFilter === key ? "active" : ""].filter(Boolean).join(" ")}
+                onClick={() => setFilter(key)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="rel-modal__close"
+            aria-label="닫기"
+            onClick={onClose}
+          >
+            <svg width="10" height="10" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M3 3L11 11M11 3L3 11" stroke="#a4b5d6" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
         </div>
-        <div className="relationship-modal-body">
-          {relationships.map((rel, idx) => {
-            const targetAgent = agentById[rel.target_agent_id];
-            const targetName = targetAgent?.name ?? String(rel.target_agent_id);
-            return (
-              <div key={idx} className="relationship-entry">
-                <button
-                  type="button"
-                  className="relationship-node"
-                  onClick={() => handleNodeClick(rel.target_agent_id)}
+
+        <div className="scope-bar">
+          <span className="scope-label">보이는 Agent</span>
+          {SCOPE_CHIPS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              className={["chip", "scope-chip", scope === key ? "active" : ""].filter(Boolean).join(" ")}
+              onClick={() => setScope(key)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="rel-modal__body">
+          <svg
+            className="rm-svg"
+            viewBox={`0 0 ${GRAPH_W} ${GRAPH_H}`}
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <defs>
+              {Object.entries(EDGE_CONFIG).map(([type, { fill }]) => (
+                <marker
+                  key={type}
+                  id={`arr-${type}`}
+                  markerWidth="7"
+                  markerHeight="7"
+                  refX="5"
+                  refY="3"
+                  orient="auto"
                 >
-                  {targetName}
-                </button>
-                <ul className="relationship-metrics">
-                  <li>호감도 {rel.affection}</li>
-                  <li>친밀도 {rel.closeness}</li>
-                  <li>신뢰도 {rel.trust}</li>
-                  <li>긴장도 {rel.tension}</li>
-                  <li>경쟁 {rel.rivalry}</li>
-                  <li>의존도 {rel.dependency}</li>
-                </ul>
+                  <path d="M0,0 L0,6 L7,3 z" fill={fill} />
+                </marker>
+              ))}
+            </defs>
+            {renderEdges()}
+          </svg>
+
+          {agents.map(agent => {
+            const pos = positions[agent.id];
+            if (!pos) return null;
+            const isSel = agent.id === localSel.id;
+            const r     = isSel ? SEL_R : NORM_R;
+            return (
+              <div
+                key={agent.id}
+                className={`graph-node${isSel ? " selected" : ""}`}
+                data-id={agent.id}
+                data-testid={`graph-node-${agent.id}`}
+                style={{ left: `${pos.x - r}px`, top: `${pos.y - r}px`, opacity: nodeOpacity(agent.id) }}
+                role="button"
+                tabIndex={0}
+                aria-label={`${agent.name} 선택`}
+                aria-pressed={isSel}
+                onClick={() => handleNodeClick(agent)}
+                onKeyDown={e => {
+                  if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleNodeClick(agent); }
+                }}
+              >
+                <AgentPortrait agent={agent} size={r * 2} />
+                <div className="graph-node__name">
+                  {agent.name}{agent.mbti_type ? ` · ${agent.mbti_type}` : ""}
+                </div>
               </div>
             );
           })}
-          {relationships.length === 0 && (
-            <p className="message">관계 데이터를 불러오는 중...</p>
-          )}
         </div>
+
+        <div className="rel-modal__footer">
+          <ul className="rel-legend" role="list" aria-label="범례">
+            {LEGEND_ITEMS.map(({ label, lineStyle }) => (
+              <li key={label} className="rel-legend-item">
+                <div className="rel-legend-line" style={lineStyle} aria-hidden="true" />
+                <span>{label}</span>
+              </li>
+            ))}
+          </ul>
+          {selectedEdge && <EdgeDetail edge={selectedEdge} agentById={agentById} />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentPortrait({ agent, size }) {
+  const [err, setErr] = useState(false);
+  const src = `/assets/character/${agent.name}_${agent.mbti_type ?? ""}.png`;
+  return err ? (
+    <div
+      className="graph-node__portrait graph-node__portrait--fallback"
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      {agent.name.slice(0, 2)}
+    </div>
+  ) : (
+    <img
+      src={src}
+      alt=""
+      aria-hidden="true"
+      className="graph-node__portrait"
+      style={{ width: size, height: size }}
+      onError={() => setErr(true)}
+    />
+  );
+}
+
+function EdgeDetail({ edge, agentById }) {
+  const src = agentById[edge.sourceId];
+  const tgt = agentById[edge.target_agent_id];
+  if (!src || !tgt) return null;
+  const stats = [
+    ["호감도", edge.affection],
+    ["친밀도", edge.closeness],
+    ["신뢰도", edge.trust],
+    ["긴장도", edge.tension],
+    ["경쟁",   edge.rivalry],
+    ["의존도", edge.dependency],
+  ].filter(([, v]) => v !== undefined && v !== null);
+  const bg = a => `url(/assets/character/${a.name}_${a.mbti_type ?? ""}.png)`;
+  return (
+    <div className="rel-detail">
+      <div className="rel-detail-pair">
+        <div className="rel-detail-portrait" style={{ backgroundImage: bg(src) }} role="img" aria-label={src.name} />
+        <div className="rel-arrow">↔</div>
+        <div className="rel-detail-portrait" style={{ backgroundImage: bg(tgt) }} role="img" aria-label={tgt.name} />
+      </div>
+      <div className="rel-stats">
+        {stats.map(([key, val]) => (
+          <div key={key} className="rel-stat-row">
+            <span className="rel-stat-key">{key}</span>
+            <span className="rel-stat-val">{val}</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/components/RelationshipModal.test.jsx
+++ b/frontend/src/components/RelationshipModal.test.jsx
@@ -1,0 +1,195 @@
+import { cleanup, render, screen, fireEvent, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RelationshipModal from './RelationshipModal.jsx';
+import * as client from '../api/client.js';
+
+vi.mock('../api/client.js', () => ({
+  apiRequest: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const selectedAgent = { id: 'agent-1', name: 'Adel', mbti_type: 'ISTJ' };
+const agents = [
+  { id: 'agent-1', name: 'Adel', mbti_type: 'ISTJ' },
+  { id: 'agent-2', name: 'Leo', mbti_type: 'ESTP' },
+  { id: 'agent-3', name: 'Ria', mbti_type: 'INFP' },
+];
+const auth = { access_token: 'tok' };
+
+describe('RelationshipModal', () => {
+  beforeEach(() => {
+    client.apiRequest.mockResolvedValue([]);
+  });
+
+  it('dialog role과 제목을 렌더링한다', () => {
+    render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('관계 그래프')).toBeInTheDocument();
+    expect(screen.getByText('Adel 선택 중')).toBeInTheDocument();
+  });
+
+  it('닫기 버튼 클릭 시 onClose가 호출된다', () => {
+    const onClose = vi.fn();
+    render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByLabelText('닫기'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('backdrop 클릭 시 onClose가 호출된다', () => {
+    const onClose = vi.fn();
+    render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByRole('dialog').parentElement);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('모든 Agent 노드 라벨을 렌더링한다', async () => {
+    render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={() => {}}
+      />
+    );
+    await screen.findByTestId('graph-node-agent-1'); // wait for loading to finish
+    expect(screen.getByTestId('graph-node-agent-1')).toBeInTheDocument();
+    expect(screen.getByTestId('graph-node-agent-2')).toBeInTheDocument();
+    expect(screen.getByTestId('graph-node-agent-3')).toBeInTheDocument();
+  });
+
+  it('필터 chip을 클릭하면 해당 chip에 active 클래스가 추가된다', () => {
+    render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={() => {}}
+      />
+    );
+    const favorChip = screen.getByRole('button', { name: '호감·친밀' });
+    expect(favorChip).not.toHaveClass('active');
+    fireEvent.click(favorChip);
+    expect(favorChip).toHaveClass('active');
+  });
+
+  it('scope chip을 클릭하면 해당 chip에 active 클래스가 추가된다', () => {
+    render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={() => {}}
+      />
+    );
+    const focusChip = screen.getByRole('button', { name: '선택 Agent 중심' });
+    fireEvent.click(focusChip);
+    expect(focusChip).toHaveClass('active');
+  });
+
+  it('다른 노드를 클릭하면 onSelectAgent가 해당 Agent와 함께 호출된다', async () => {
+    const onSelectAgent = vi.fn();
+    render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={onSelectAgent}
+        onClose={() => {}}
+      />
+    );
+    const leoNode = await screen.findByTestId('graph-node-agent-2');
+    fireEvent.click(leoNode);
+    expect(onSelectAgent).toHaveBeenCalledWith(agents[1]);
+  });
+
+  it('SVG 엣지 레이어가 렌더링된다', async () => {
+    const { container } = render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={() => {}}
+      />
+    );
+    await vi.waitFor(() => {
+      expect(container.querySelector('svg.rm-svg')).toBeInTheDocument();
+    });
+  });
+
+  it('범례 항목 5가지가 footer에 표시된다', () => {
+    const { container } = render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={() => {}}
+      />
+    );
+    const legend = container.querySelector('[aria-label="범례"]');
+    expect(legend).toBeInTheDocument();
+    expect(within(legend).getByText('호감·친밀')).toBeInTheDocument();
+    expect(within(legend).getByText('신뢰')).toBeInTheDocument();
+    expect(within(legend).getByText('긴장·라이벌')).toBeInTheDocument();
+    expect(within(legend).getByText('의존')).toBeInTheDocument();
+    expect(within(legend).getByText('중립')).toBeInTheDocument();
+  });
+
+  it('엣지 데이터가 있으면 API 응답을 바탕으로 SVG line을 렌더링한다', async () => {
+    client.apiRequest.mockImplementation((path) => {
+      if (path.includes('agent-1')) {
+        return Promise.resolve([
+          { target_agent_id: 'agent-2', affection: 80, closeness: 70, trust: 30, tension: 10, rivalry: 5, dependency: 20 },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const { container } = render(
+      <RelationshipModal
+        selectedAgent={selectedAgent}
+        agents={agents}
+        auth={auth}
+        onSelectAgent={() => {}}
+        onClose={() => {}}
+      />
+    );
+
+    await vi.waitFor(() => {
+      const lines = container.querySelectorAll('svg.rm-svg line');
+      expect(lines.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/mocks/fixtures/relationships.js
+++ b/frontend/src/mocks/fixtures/relationships.js
@@ -1,0 +1,65 @@
+const PROF = "01900000-0000-7000-8000-000000000011";
+const ADEL = "01900000-0000-7000-8000-000000000012";
+const LEO  = "01900000-0000-7000-8000-000000000013";
+const RIA  = "01900000-0000-7000-8000-000000000014";
+const KAI  = "01900000-0000-7000-8000-000000000015";
+const SERA = "01900000-0000-7000-8000-000000000016";
+
+function rel(id, name, { affection, closeness, trust, tension, rivalry, dep, type }) {
+  return {
+    target_agent_id: id,
+    target_agent_name: name,
+    affection,
+    closeness,
+    trust,
+    tension,
+    rivalry,
+    dependency: dep,
+    relationship_type: type,
+  };
+}
+
+export const mockRelationships = {
+  [PROF]: [
+    rel(ADEL, "아델", { affection: 30, closeness: 40, trust: 65, tension: 10, rivalry: 0, dep: 15, type: "신뢰" }),
+    rel(LEO,  "레오", { affection: 20, closeness: 25, trust: 25, tension: 45, rivalry: 0, dep: 5,  type: "우려" }),
+    rel(RIA,  "리아", { affection: 35, closeness: 35, trust: 55, tension: 5,  rivalry: 0, dep: 10, type: "신뢰" }),
+    rel(KAI,  "카이", { affection: 25, closeness: 30, trust: 45, tension: 20, rivalry: 0, dep: 5,  type: "중립" }),
+    rel(SERA, "세라", { affection: 35, closeness: 40, trust: 60, tension: 5,  rivalry: 0, dep: 8,  type: "신뢰" }),
+  ],
+  [ADEL]: [
+    rel(LEO,  "레오", { affection: -8, closeness: 30, trust: 25, tension: 72, rivalry: 20, dep: 10, type: "긴장" }),
+    rel(RIA,  "리아", { affection: 72, closeness: 68, trust: 85, tension: 12, rivalry: 0,  dep: 20, type: "우호" }),
+    rel(KAI,  "카이", { affection: 15, closeness: 31, trust: 31, tension: 35, rivalry: 25, dep: 15, type: "중립" }),
+    rel(SERA, "세라", { affection: 55, closeness: 44, trust: 44, tension: 20, rivalry: 0,  dep: 18, type: "우호" }),
+    rel(PROF, "에단", { affection: 25, closeness: 35, trust: 70, tension: 8,  rivalry: 0,  dep: 20, type: "신뢰" }),
+  ],
+  [LEO]: [
+    rel(ADEL, "아델", { affection: 10, closeness: 25, trust: 20, tension: 40, rivalry: 15, dep: 5,  type: "긴장" }),
+    rel(RIA,  "리아", { affection: 80, closeness: 75, trust: 78, tension: 15, rivalry: 0,  dep: 25, type: "친구" }),
+    rel(KAI,  "카이", { affection: 60, closeness: 55, trust: 65, tension: 22, rivalry: 30, dep: 10, type: "우호" }),
+    rel(SERA, "세라", { affection: 30, closeness: 30, trust: 35, tension: 25, rivalry: 0,  dep: 8,  type: "중립" }),
+    rel(PROF, "에단", { affection: 15, closeness: 25, trust: 20, tension: 55, rivalry: 0,  dep: 10, type: "긴장" }),
+  ],
+  [RIA]: [
+    rel(ADEL, "아델", { affection: 70, closeness: 65, trust: 82, tension: 10, rivalry: 0,  dep: 22, type: "우호" }),
+    rel(LEO,  "레오", { affection: 75, closeness: 70, trust: 72, tension: 18, rivalry: 0,  dep: 28, type: "친구" }),
+    rel(KAI,  "카이", { affection: 25, closeness: 30, trust: 40, tension: 30, rivalry: 0,  dep: 12, type: "중립" }),
+    rel(SERA, "세라", { affection: 45, closeness: 45, trust: 48, tension: 18, rivalry: 0,  dep: 75, type: "의존" }),
+    rel(PROF, "에단", { affection: 40, closeness: 35, trust: 60, tension: 5,  rivalry: 0,  dep: 15, type: "신뢰" }),
+  ],
+  [KAI]: [
+    rel(ADEL, "아델", { affection: 15, closeness: 30, trust: 30, tension: 35, rivalry: 30, dep: 62, type: "의존" }),
+    rel(LEO,  "레오", { affection: 55, closeness: 50, trust: 60, tension: 25, rivalry: 20, dep: 12, type: "우호" }),
+    rel(RIA,  "리아", { affection: 25, closeness: 28, trust: 38, tension: 28, rivalry: 0,  dep: 10, type: "중립" }),
+    rel(SERA, "세라", { affection: 30, closeness: 40, trust: 48, tension: 45, rivalry: 10, dep: 8,  type: "긴장" }),
+    rel(PROF, "에단", { affection: 20, closeness: 30, trust: 45, tension: 30, rivalry: 0,  dep: 15, type: "중립" }),
+  ],
+  [SERA]: [
+    rel(ADEL, "아델", { affection: 58, closeness: 50, trust: 48, tension: 20, rivalry: 0,  dep: 15, type: "우호" }),
+    rel(LEO,  "레오", { affection: 35, closeness: 32, trust: 30, tension: 28, rivalry: 0,  dep: 10, type: "중립" }),
+    rel(RIA,  "리아", { affection: 72, closeness: 68, trust: 65, tension: 18, rivalry: 0,  dep: 70, type: "의존·우호" }),
+    rel(KAI,  "카이", { affection: 28, closeness: 38, trust: 48, tension: 45, rivalry: 8,  dep: 5,  type: "긴장" }),
+    rel(PROF, "에단", { affection: 38, closeness: 42, trust: 65, tension: 5,  rivalry: 0,  dep: 12, type: "신뢰" }),
+  ],
+};

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -2,6 +2,7 @@ import { mockAgents } from "./fixtures/agents.js";
 import { mockSimulations } from "./fixtures/simulations.js";
 import { mockAuthUser } from "./fixtures/auth.js";
 import { mockWorldMap } from "./fixtures/worldMap.js";
+import { mockRelationships } from "./fixtures/relationships.js";
 
 /**
  * 백엔드 미완성 시 프론트엔드 독립 실행을 지원하는 Mock API 핸들러
@@ -72,7 +73,13 @@ export async function handleMockRequest(path, options = {}) {
     return mockWorldMap;
   }
 
-  // 4. Agents API
+  // 4. Relationship API (must come before broad agents check)
+  if (/\/v1\/agents\/[^/]+\/relationships$/.test(path) && method === "GET") {
+    const agentId = path.split("/")[3];
+    return mockRelationships[agentId] ?? [];
+  }
+
+  // 5. Agents API
   if (path.includes("/agents") && method === "GET") {
     return mockAgents;
   }


### PR DESCRIPTION
## 작업 개요

`RelationshipModal`의 텍스트 목록 구현을 목업(`05-relationship.html`) 기반의 SVG 그래프로 전면 교체한다.
선택된 Agent를 중심에 두고 나머지 Agent를 원형 배치하며, 방향성 edge와 필터·범위 제어 UI를 제공한다.

## 관련 Issue

관련 Issue 없음

## 변경 내용

- `RelationshipModal.jsx` 전면 재작성
  - 전체 Agent의 관계 데이터를 `Promise.allSettled`로 병렬 로드
  - 선택 Agent 중심 + 나머지 원형 배치 (`computePositions`, 고정 viewBox 1060×530)
  - SVG edge 5종: 호감(`favor`) · 신뢰(`trust`) · 긴장(`tension`) · 의존(`dep`) · 중립(`neutral`)
  - A→B / B→A 양방향 edge에 ±5px 수직 오프셋 적용
  - 필터 chip(관계 유형 5종) + scope chip(전체/선택중심/직접) 상태 관리
  - edge 클릭 시 footer 상세 패널(지표 6종) 표시
  - 노드 클릭 시 `onSelectAgent` 호출, 모달 유지 (`onClose` 미호출)
- `RelationshipModal.css` 전면 재작성
  - `rel-modal__*` / `graph-node` / `chip` 계층 구조로 통일
  - 목업 디자인 시스템 토큰(`--c-primary`, `--c-critical`, `--c-cream` 등) 사용
- `mocks/fixtures/relationships.js` 신규 추가
  - 6 Agent × 5 관계 = 30개 방향성 관계 mock 데이터 (5종 edge type 분포)
- `mocks/handlers.js` 수정
  - `/v1/agents/:id/relationships` 핸들러를 broad `/agents` 매칭 앞에 추가 (충돌 방지)
- `RelationshipModal.test.jsx` 신규 추가
  - 10개 단위 테스트 (dialog 렌더링, 닫기, backdrop, 노드 클릭, 필터/scope chip, SVG 레이어, 범례, edge 렌더링)

## 결정 사항 및 이유

**고정 viewBox(1060×530) 선택**: ResizeObserver 기반 동적 좌표 대신 목업 치수를 고정 기준으로 사용. SVG 자체가 `width:100%; height:100%`로 컨테이너에 맞게 스케일되므로 좌표 계산 복잡도를 줄일 수 있다.

**mock 핸들러 순서**: 기존 `path.includes("/agents")` 조건이 relationship URL도 매칭해 데이터를 잘못 반환했음. 정규식으로 relationship 엔드포인트를 먼저 매칭해 충돌을 차단했다.

**edge type 분류 순서**: `tension > trust > favor > dep > neutral` 순으로 체크. 긴장/경쟁이 호감보다 관계 성격을 더 명확하게 나타내므로 우선 분류한다.

## 테스트 / 확인 내용

- [x] `npm run build` 통과
- [x] 단위 테스트 10/10 통과 (`vitest`)
- [ ] 로컬 개발 서버에서 RelationshipModal 시각적 동작 확인
- [ ] 노드 클릭 시 선택 Agent 변경 확인
- [ ] 필터·scope chip 동작 확인
- [ ] edge 클릭 시 footer 상세 패널 표시 확인
- [ ] 관련 문서 업데이트 확인

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: RelationshipModal JSX/CSS 재구현, mock 데이터 설계, 테스트 작성
- 사람이 검토한 내용: edge type 분류 로직, mock 핸들러 라우팅 순서, 커밋 내용 전체

## 리뷰어가 봐야 할 부분

- `classifyEdge()` 분류 순서 (`tension` 우선 → `favor` 후순위) — 도메인 의도와 일치하는지 확인
- `computePositions()`: 고정 1060×530 기준 좌표가 작은 화면에서 clipping 없이 보이는지 확인
- `mocks/handlers.js` 핸들러 순서 변경이 기존 Agent API 동작에 영향 없는지 확인