### PR TITLE
[Fix] BrandingPage 3단계 온보딩 슬라이드 복구

### DIFF
--- a/frontend/src/App.mock.test.jsx
+++ b/frontend/src/App.mock.test.jsx
@@ -34,8 +34,7 @@ describe('Mock 모드 통합 흐름', () => {
     await userEvent.click(screen.getByRole('button', { name: '로그인' }))
 
     await userEvent.click(await screen.findByRole('button', { name: '시뮬레이션 시작' }))
-    expect(await screen.findByRole('heading', { name: /마법이 살아 숨쉬는/ })).toBeInTheDocument()
-    await userEvent.click(screen.getByRole('button', { name: '입학하기' }))
+    await userEvent.click(await screen.findByRole('button', { name: '건너뛰기 →' }))
     await userEvent.click(await screen.findByRole('button', { name: '이 Persona로 시작하기 →' }))
     await userEvent.click(await screen.findByRole('button', { name: /시뮬레이션 시작/ }))
 

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -99,7 +99,7 @@ async function login() {
 
 async function completeOnboarding() {
   await userEvent.click(await screen.findByRole('button', { name: '시뮬레이션 시작' }))
-  await userEvent.click(await screen.findByRole('button', { name: '입학하기' }))
+  await userEvent.click(await screen.findByRole('button', { name: '건너뛰기 →' }))
   await userEvent.click(await screen.findByRole('button', { name: '이 Persona로 시작하기 →' }))
   await userEvent.click(await screen.findByRole('button', { name: /시뮬레이션 시작/ }))
 }
@@ -184,9 +184,9 @@ describe('Slice 0 UI', () => {
     render(<App />)
     await login()
     await userEvent.click(await screen.findByRole('button', { name: '시뮬레이션 시작' }))
-    await userEvent.click(await screen.findByRole('button', { name: '입학하기' }))
+    await userEvent.click(await screen.findByRole('button', { name: '건너뛰기 →' }))
 
-    expect(screen.getByRole('button', { name: '입학 중...' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '시작 중...' })).toBeDisabled()
   })
 
   it('shows an inline error when enrollment fails', async () => {
@@ -197,10 +197,10 @@ describe('Slice 0 UI', () => {
     render(<App />)
     await login()
     await userEvent.click(await screen.findByRole('button', { name: '시뮬레이션 시작' }))
-    await userEvent.click(await screen.findByRole('button', { name: '입학하기' }))
+    await userEvent.click(await screen.findByRole('button', { name: '건너뛰기 →' }))
 
     expect(await screen.findByRole('alert')).toHaveTextContent('서버 오류가 발생했습니다.')
-    expect(screen.getByRole('button', { name: '입학하기' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: '건너뛰기 →' })).toBeEnabled()
   })
 
   it('shows the basic 401 message', async () => {
@@ -249,7 +249,7 @@ describe('Slice 0 UI', () => {
     render(<App />)
     await login()
     await userEvent.click(await screen.findByRole('button', { name: '시뮬레이션 시작' }))
-    await userEvent.click(await screen.findByRole('button', { name: '입학하기' }))
+    await userEvent.click(await screen.findByRole('button', { name: '건너뛰기 →' }))
 
     expect(await screen.findByRole('main')).toHaveClass('auth-shell')
     await login()

--- a/frontend/src/pages/BrandingPage.jsx
+++ b/frontend/src/pages/BrandingPage.jsx
@@ -2,7 +2,50 @@ import { useState } from 'react';
 import { apiRequest } from '../api/client.js';
 import './BrandingPage.css';
 
+const SLIDES = [
+  {
+    badge: 'Multi-Agent Simulation',
+    badgeColor: '#d4b26f',
+    badgeBg: 'rgba(212, 178, 111, 0.14)',
+    badgeBorder: 'rgba(212, 178, 111, 0.35)',
+    charName: 'Leo',
+    mbti: 'ESTP',
+    charImg: '/assets/character/Leo_ESTP.png',
+    nameColor: '#d4b26f',
+    ringColor: '#d4b26f',
+    bubbleBorder: 'rgba(70, 100, 180, 0.24)',
+    text: '안녕! 여긴 마법학교야.\n우리는 너의 지시 없이도, 알아서 관계 맺고 갈등하고 사건을 만들어.',
+  },
+  {
+    badge: 'Agent Intelligence',
+    badgeColor: '#5e60e8',
+    badgeBg: 'rgba(94, 96, 232, 0.14)',
+    badgeBorder: 'rgba(94, 96, 232, 0.38)',
+    charName: 'Adel',
+    mbti: 'ISTJ',
+    charImg: '/assets/character/Adel_ISTJ.png',
+    nameColor: '#db4c4c',
+    ringColor: '#db4c4c',
+    bubbleBorder: 'rgba(219, 76, 76, 0.38)',
+    text: '결계의 순환이 불규칙해...\n규율은 지켜야 하는데, 피로가 너무 누적됐어.',
+  },
+  {
+    badge: 'Causal Observatory',
+    badgeColor: '#34b3c7',
+    badgeBg: 'rgba(52, 179, 199, 0.14)',
+    badgeBorder: 'rgba(52, 179, 199, 0.32)',
+    charName: 'Inspector',
+    mbti: null,
+    charImg: null,
+    nameColor: '#34b3c7',
+    ringColor: '#34b3c7',
+    bubbleBorder: 'rgba(52, 179, 199, 0.32)',
+    text: 'Magic Event가 발생하면,\n1문장 서사와 정밀 인과를 함께 보여드릴게요.',
+  },
+];
+
 export default function BrandingPage({ auth, onEnroll }) {
+  const [slide, setSlide] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -23,27 +66,98 @@ export default function BrandingPage({ auth, onEnroll }) {
     }
   }
 
+  function handleCta() {
+    if (slide < SLIDES.length) {
+      setSlide(slide + 1);
+    } else {
+      handleEnroll();
+    }
+  }
+
+  const current = SLIDES[slide - 1];
+  const isLast = slide === SLIDES.length;
+
   return (
     <div className="branding-page">
-      <div className="branding-page__content">
-        <p className="branding-page__label">MAGIC ACADEMY</p>
-        <h1 className="branding-page__title">
-          마법이 살아 숨쉬는<br />마법 대학교
-        </h1>
-        <p className="branding-page__desc">
-          마법사들이 관계를 맺고, 사건을 만들며, 세계를 변화시키는<br />
-          멀티 에이전트 시뮬레이션에 오신 것을 환영합니다.
-        </p>
-        {error && (
-          <p className="branding-page__error" role="alert">{error}</p>
-        )}
-        <button
-          className="branding-page__btn"
-          onClick={handleEnroll}
-          disabled={loading}
-        >
-          {loading ? '입학 중...' : '입학하기'}
+      <button className="ob-skip" onClick={handleEnroll} disabled={loading}>
+        건너뛰기 →
+      </button>
+
+      <div className="ob-slide-wrap">
+        <div className="onboarding__brand">MAGIC ACADEMY</div>
+
+        <div className="ob-slide-content" key={slide}>
+          <div
+            className="ob-badge"
+            style={{ background: current.badgeBg, borderColor: current.badgeBorder }}
+          >
+            <div
+              className="ob-badge-dot"
+              style={{ background: current.badgeColor, boxShadow: `0 0 6px ${current.badgeColor}` }}
+            />
+            <span className="ob-badge-text" style={{ color: current.badgeColor }}>
+              {current.badge}
+            </span>
+          </div>
+
+          <div className="chat-msg">
+            {current.charImg ? (
+              <div
+                className="chat-avatar"
+                style={{
+                  backgroundImage: `url(${current.charImg})`,
+                  borderColor: current.ringColor,
+                  boxShadow: `0 0 16px ${current.ringColor}66`,
+                }}
+                role="img"
+                aria-label={`${current.charName} 아바타`}
+              />
+            ) : (
+              <div
+                className="chat-avatar chat-avatar--glyph"
+                style={{ borderColor: current.ringColor, boxShadow: `0 0 16px ${current.ringColor}66` }}
+                aria-label="Inspector 아바타"
+              >
+                ◎
+              </div>
+            )}
+            <div className="chat-bubble" style={{ borderColor: current.bubbleBorder }}>
+              <div className="chat-name" style={{ color: current.nameColor }}>
+                {current.charName}{current.mbti ? ` · ${current.mbti}` : ''}
+              </div>
+              <div className="chat-text">
+                {current.text.split('\n').map((line, i, arr) => (
+                  <span key={i}>{line}{i < arr.length - 1 && <br />}</span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {error && <p className="ob-error" role="alert">{error}</p>}
+        </div>
+
+        <button className="ob-cta" onClick={handleCta} disabled={loading}>
+          {loading ? '시작 중...' : isLast ? '시작하기' : '다음 →'}
         </button>
+
+        <div className="ob-pagination">
+          <div className="ob-dots">
+            {SLIDES.map((_, i) => (
+              <div
+                key={i}
+                className={`ob-dot${slide === i + 1 ? ' active' : ''}`}
+                onClick={() => setSlide(i + 1)}
+                role="button"
+                aria-label={`${i + 1}번째 슬라이드로 이동`}
+                tabIndex={0}
+                onKeyDown={(e) => e.key === 'Enter' && setSlide(i + 1)}
+              />
+            ))}
+          </div>
+          <span className="ob-pagenum">
+            {String(slide).padStart(2, '0')} / {String(SLIDES.length).padStart(2, '0')}
+          </span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 작업 개요

PR #224 머지 충돌 해결 과정에서 `feature/s5-school-map`의 구 버전으로
덮어씌워져 삭제된 3단계 온보딩 슬라이드를 복원합니다.
복구 기준: 커밋 4887c4e (feat: BrandingPage를 온보딩 슬라이드 3단계로 교체)

## 관련 Issue

관련 Issue 없음

## 변경 내용

- `BrandingPage.jsx`: SLIDES 배열 3개(Leo/ESTP, Adel/ISTJ, Inspector) 복원
- `BrandingPage.jsx`: slide 상태(useState(1)), handleCta(), ob-skip 버튼 복원
- `BrandingPage.jsx`: ob-slide-wrap / ob-slide-content(key={slide}) / ob-dots / ob-pagenum 복원
- `App.test.jsx`: enrollment 테스트 5곳의 '입학하기' 버튼 쿼리 → '건너뛰기 →' 방식으로 교체
- `App.mock.test.jsx`: '입학하기' 버튼 쿼리 교체, 구버전 heading assert 제거

## 결정 사항 및 이유

- **건너뛰기 방식 테스트 수정**: ob-skip 버튼이 handleEnroll()을 직접 호출하므로
  enrollment 로직 검증이 동일하게 유지됨. 슬라이드 순서 방식 대비 테스트 변경 최소화.
- BrandingPage.css는 develop HEAD에 이미 올바른 버전이 포함되어 있어 변경 없음.

## 테스트 / 확인 내용

- [x] `npm run build` 통과
- [x] `npm test -- --run` 122개 전체 통과
- [ ] 로컬 브라우저에서 슬라이드 전환 동작 확인
- [ ] 건너뛰기 버튼 동작 확인

## AI 사용 여부

- 사용 여부: 사용함
- 사용한 작업: 커밋 이력 기반 원본 코드 복원, 테스트 수정
- 사람이 검토한 내용: 복원 범위, 테스트 수정 방식

## 리뷰어가 봐야 할 부분

- `App.test.jsx:203` — 에러 후 버튼 활성화 검증이 '건너뛰기 →' 기준으로 변경됨
- 슬라이드 3번에서 '시작하기' 클릭 시 handleEnroll() 호출 여부