### PR TITLE
[Style] SavePage 오버레이 모달 + MyPage 사이드바 레이아웃 목업 정합화

### DIFF
--- a/frontend/src/pages/MyPage.css
+++ b/frontend/src/pages/MyPage.css
@@ -1,14 +1,247 @@
-.my-page { min-height: 100vh; padding: var(--s-10); background: var(--c-bg); color: var(--c-text); font-family: var(--f-ui); }
-.my-page__content { width: min(900px, 100%); margin: 0 auto; }
-.my-page__header { display: flex; align-items: center; justify-content: space-between; gap: var(--s-4); margin-bottom: var(--s-8); }
-.my-page__header p { margin: 0; color: var(--c-cream); font-family: var(--f-serif-en); letter-spacing: .15em; }
-.my-page__header h1 { margin: var(--s-2) 0 0; font-family: var(--f-serif-ko); }
-.my-page__header button { border: 1px solid var(--c-border-hi); background: transparent; color: var(--c-cream); }
-.my-page__message { padding: var(--s-6); border: 1px solid var(--c-border); border-radius: var(--r-lg); background: var(--c-surface-card); color: var(--c-text-2); }
-.my-page__error { color: var(--c-critical); }
-.my-page__list { display: grid; gap: var(--s-3); margin: 0; padding: 0; list-style: none; }
-.my-page__list li { display: flex; align-items: center; justify-content: space-between; gap: var(--s-4); padding: var(--s-5); border: 1px solid var(--c-border); border-radius: var(--r-lg); background: var(--c-surface-card); }
-.my-page__list li div { display: grid; gap: var(--s-2); }
-.my-page__list span { color: var(--c-text-2); font-size: var(--t-sm); }
-.my-page__list button:disabled { cursor: not-allowed; }
-@media (max-width: 600px) { .my-page { padding: var(--s-5); } .my-page__list li { align-items: stretch; flex-direction: column; } }
+.mypage-shell {
+  min-height: 100vh;
+  background:
+    linear-gradient(rgba(6, 13, 32, .74), rgba(6, 13, 32, .74)),
+    url('/assets/concept/academy-night-background.png') center / cover fixed;
+  color: var(--c-text);
+  font-family: var(--f-ui);
+}
+
+.mypage-topbar {
+  height: 58px;
+  display: flex;
+  align-items: center;
+  gap: var(--s-4);
+  padding: 0 var(--s-8);
+  border-bottom: 1px solid var(--c-border);
+  background: rgba(11, 24, 56, 0.9);
+  backdrop-filter: blur(16px);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.mypage-brand {
+  font-family: var(--f-serif-en);
+  font-weight: 600;
+  letter-spacing: .04em;
+  color: var(--c-text);
+}
+
+.mypage-layout {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  min-height: calc(100vh - 58px);
+}
+
+.mypage-sidebar {
+  padding: var(--s-8) var(--s-5);
+  border-right: 1px solid var(--c-border);
+  background: rgba(11, 24, 56, 0.72);
+}
+
+.observer {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: 0 var(--s-2) var(--s-6);
+}
+
+.observer__avatar {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--c-border-gold);
+  border-radius: 50%;
+  background: linear-gradient(145deg, var(--c-primary-muted), var(--c-cream-muted));
+  color: var(--c-cream);
+  font: 600 var(--t-md) var(--f-serif-en);
+}
+
+.observer__name {
+  font-weight: 600;
+  color: var(--c-text);
+}
+
+.observer__email {
+  color: var(--c-text-3);
+  font-size: var(--t-xs);
+  overflow-wrap: anywhere;
+}
+
+.mypage-menu {
+  display: grid;
+  gap: 4px;
+}
+
+.mypage-menu__item {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: var(--s-2) var(--s-3);
+  border: 1px solid transparent;
+  border-radius: var(--r-md);
+  color: var(--c-text-2);
+  font-size: var(--t-sm);
+  font-family: var(--f-ui);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--tr-fast), color var(--tr-fast), border-color var(--tr-fast);
+  width: 100%;
+}
+
+.mypage-menu__item:hover:not(:disabled) {
+  color: var(--c-text);
+  background: rgba(18, 36, 80, .58);
+}
+
+.mypage-menu__item.active {
+  color: #fff;
+  background: var(--c-primary-muted);
+  border-color: rgba(94, 96, 232, .28);
+}
+
+.mypage-menu__item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mypage-content {
+  padding: var(--s-10);
+}
+
+.page-header {
+  margin-bottom: var(--s-8);
+}
+
+.page-eyebrow {
+  margin-bottom: var(--s-1);
+  color: var(--c-cream);
+  font: 500 var(--t-xs) var(--f-mono);
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.page-title {
+  font-family: var(--f-serif-ko);
+  font-size: var(--t-3xl);
+  line-height: 1.25;
+  margin: 0 0 var(--s-2);
+}
+
+.page-description {
+  color: var(--c-text-2);
+  margin: 0;
+}
+
+.mypage-message {
+  padding: var(--s-6);
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-lg);
+  background: var(--c-surface-card);
+  color: var(--c-text-2);
+  backdrop-filter: blur(12px);
+}
+
+.mypage-message--error {
+  color: var(--c-critical);
+}
+
+.sim-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--s-5);
+}
+
+.sim-card {
+  overflow: hidden;
+  background: var(--c-surface-card);
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-lg);
+  box-shadow: var(--sh-sm);
+  backdrop-filter: blur(12px);
+}
+
+.sim-card__thumb {
+  height: 132px;
+  background:
+    linear-gradient(90deg, rgba(6, 13, 32, 0.5), rgba(6, 13, 32, 0.8)),
+    url('/assets/concept/academy-night-background.png') center / cover;
+}
+
+.sim-card__body {
+  padding: var(--s-5);
+}
+
+.sim-card__name {
+  font-family: var(--f-serif-ko);
+  font-size: var(--t-xl);
+  margin: 0 0 var(--s-3);
+}
+
+.sim-card__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  flex-wrap: wrap;
+}
+
+.sim-card__date {
+  color: var(--c-text-3);
+  font-size: var(--t-sm);
+}
+
+.sim-card__status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-full);
+  background: rgba(6, 13, 32, .78);
+  color: var(--c-text-2);
+  font: 500 var(--t-xs) var(--f-mono);
+  white-space: nowrap;
+}
+
+.sim-card__status-chip::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-text-3);
+  flex-shrink: 0;
+}
+
+.sim-card__status-chip.observing::before { background: var(--c-success); }
+.sim-card__status-chip.saved::before { background: var(--c-primary-hover); }
+.sim-card__status-chip.complete::before { background: var(--c-cream); }
+
+.sim-card__actions {
+  margin-top: var(--s-4);
+}
+
+@media (max-width: 980px) {
+  .mypage-layout { grid-template-columns: 1fr; }
+  .mypage-sidebar {
+    position: sticky;
+    top: 58px;
+    z-index: 15;
+    padding: var(--s-3) var(--s-5);
+    border-right: 0;
+    border-bottom: 1px solid var(--c-border);
+  }
+  .observer { display: none; }
+  .mypage-menu { display: flex; overflow-x: auto; }
+  .mypage-menu__item { white-space: nowrap; }
+}
+
+@media (max-width: 720px) {
+  .mypage-topbar { padding: 0 var(--s-4); }
+  .mypage-content { padding: var(--s-6) var(--s-4); }
+  .sim-grid { grid-template-columns: 1fr; }
+  .page-title { font-size: var(--t-2xl); }
+}

--- a/frontend/src/pages/MyPage.jsx
+++ b/frontend/src/pages/MyPage.jsx
@@ -9,6 +9,15 @@ function formatSavedAt(simulation) {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString('ko-KR');
 }
 
+function statusLabel(status) {
+  const map = { observing: '관찰 중', saved: '저장됨', complete: '완료' };
+  return map[status] ?? status;
+}
+
+function statusClass(status) {
+  return ['observing', 'saved', 'complete'].includes(status) ? status : '';
+}
+
 export default function MyPage({ auth, onBack, onRestore }) {
   const [simulations, setSimulations] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -44,34 +53,85 @@ export default function MyPage({ auth, onBack, onRestore }) {
     }
   }
 
+  const avatarChar = (auth.user?.display_name?.[0] ?? 'O').toUpperCase();
+
   return (
-    <main className="my-page">
-      <section className="my-page__content">
-        <div className="my-page__header">
-          <div><p>MY PAGE</p><h1>내 시뮬레이션</h1></div>
-          <button type="button" onClick={onBack}>뒤로가기</button>
-        </div>
-        {loading && <p className="my-page__message">목록을 불러오는 중...</p>}
-        {error && <p className="my-page__message my-page__error" role="alert">{error}</p>}
-        {restoreError && <p className="my-page__message my-page__error" role="alert">{restoreError}</p>}
-        {!loading && !error && simulations.length === 0 && <p className="my-page__message">저장된 시뮬레이션이 없습니다.</p>}
-        {!loading && !error && simulations.length > 0 && (
-          <ul className="my-page__list">
-            {simulations.map((item) => (
-              <li key={item.id}>
-                <div><strong>{item.name}</strong><span>{formatSavedAt(item)} · {item.status}</span></div>
-                <button
-                  type="button"
-                  disabled={restoringId !== null}
-                  onClick={() => handleRestore(item.id)}
-                >
-                  {restoringId === item.id ? '불러오는 중...' : '불러오기'}
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </main>
+    <div className="mypage-shell">
+      <header className="mypage-topbar">
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onBack}>뒤로가기</button>
+        <span className="mypage-brand">Magic Academy · 마이페이지</span>
+      </header>
+
+      <div className="mypage-layout">
+        <aside className="mypage-sidebar">
+          <div className="observer">
+            <div className="observer__avatar">{avatarChar}</div>
+            <div>
+              <div className="observer__name">{auth.user?.display_name}</div>
+              <div className="observer__email">{auth.user?.username}</div>
+            </div>
+          </div>
+          <nav className="mypage-menu" aria-label="마이페이지 메뉴">
+            <button type="button" className="mypage-menu__item active" aria-current="page">시뮬레이션</button>
+            <button type="button" className="mypage-menu__item" disabled aria-disabled="true">Persona</button>
+            <button type="button" className="mypage-menu__item" disabled aria-disabled="true">관찰 통계</button>
+            <button type="button" className="mypage-menu__item" disabled aria-disabled="true">프로필 및 계정</button>
+          </nav>
+        </aside>
+
+        <main className="mypage-content">
+          <header className="page-header">
+            <div>
+              <div className="page-eyebrow">Saved Worlds</div>
+              <h1 className="page-title">내 시뮬레이션</h1>
+              <p className="page-description">저장한 시뮬레이션을 확인하고 이어서 관찰할 수 있습니다.</p>
+            </div>
+          </header>
+
+          {restoreError && (
+            <p className="mypage-message mypage-message--error" role="alert">{restoreError}</p>
+          )}
+          {loading && (
+            <p className="mypage-message">목록을 불러오는 중...</p>
+          )}
+          {error && (
+            <p className="mypage-message mypage-message--error" role="alert">{error}</p>
+          )}
+          {!loading && !error && simulations.length === 0 && (
+            <p className="mypage-message">저장된 시뮬레이션이 없습니다.</p>
+          )}
+          {!loading && !error && simulations.length > 0 && (
+            <div className="sim-grid">
+              {simulations.map((item) => (
+                <article key={item.id} className="sim-card">
+                  <div className="sim-card__thumb" aria-hidden="true" />
+                  <div className="sim-card__body">
+                    <h2 className="sim-card__name">{item.name}</h2>
+                    <div className="sim-card__meta">
+                      <span className="sim-card__date">{formatSavedAt(item)}</span>
+                      {item.status && (
+                        <span className={`sim-card__status-chip ${statusClass(item.status)}`}>
+                          {statusLabel(item.status)}
+                        </span>
+                      )}
+                    </div>
+                    <div className="sim-card__actions">
+                      <button
+                        type="button"
+                        className="btn btn-primary btn-sm"
+                        disabled={restoringId !== null}
+                        onClick={() => handleRestore(item.id)}
+                      >
+                        {restoringId === item.id ? '불러오는 중...' : '불러오기'}
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/SavePage.css
+++ b/frontend/src/pages/SavePage.css
@@ -1,9 +1,164 @@
-.save-page { min-height: 100vh; display: grid; place-items: center; padding: var(--s-6); background: var(--c-bg); color: var(--c-text); font-family: var(--f-ui); }
-.save-page__card { width: min(520px, 100%); padding: var(--s-10); border: 1px solid var(--c-border-hi); border-radius: var(--r-xl); background: var(--c-surface-card); box-shadow: var(--sh-lg); }
-.save-page__eyebrow { margin: 0; color: var(--c-cream); font-family: var(--f-serif-en); font-size: var(--t-sm); letter-spacing: .15em; }
-.save-page h1 { margin: var(--s-3) 0 var(--s-6); font-family: var(--f-serif-ko); }
-.save-page p { color: var(--c-text-2); }
-.save-page__notice { padding: var(--s-3); border-radius: var(--r-md); background: var(--c-primary-muted); }
-.save-page__actions { display: flex; gap: var(--s-3); margin-top: var(--s-8); }
-.save-page__actions button { flex: 1; background: var(--c-primary); }
-.save-page__actions .save-page__cancel { border: 1px solid var(--c-border); background: transparent; color: var(--c-text-2); }
+.save-bg-wrap {
+  position: fixed;
+  inset: 0;
+}
+
+.save-bg {
+  position: absolute;
+  inset: 0;
+  background-image: url('/assets/concept/academy-night-background.png');
+  background-size: cover;
+  background-position: center;
+  filter: brightness(0.3) saturate(0.6);
+}
+
+.save-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(11, 14, 35, 0.6);
+  backdrop-filter: blur(3px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.save-modal {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-hi);
+  border-radius: var(--r-xl);
+  width: 520px;
+  overflow: hidden;
+  box-shadow: var(--sh-lg);
+  animation: save-modal-appear 280ms ease both;
+}
+
+@keyframes save-modal-appear {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.save-modal__header {
+  padding: var(--s-6);
+  border-bottom: 1px solid var(--c-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.save-modal__title {
+  font-size: var(--t-lg);
+  font-weight: 500;
+  color: var(--c-text);
+}
+
+.save-modal__close {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--r-sm);
+  color: var(--c-text-2);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background var(--tr-fast);
+}
+.save-modal__close:hover { background: var(--c-surface-hi); }
+
+.save-modal__body {
+  padding: var(--s-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-5);
+}
+
+.save-thumb {
+  width: 100%;
+  height: 140px;
+  border-radius: var(--r-md);
+  overflow: hidden;
+  position: relative;
+  background: var(--c-surface-hi);
+}
+
+.save-thumb__img {
+  position: absolute;
+  inset: 0;
+  background-image: url('/assets/concept/academy-night-background.png');
+  background-size: cover;
+  background-position: center;
+  filter: brightness(0.7) saturate(0.8);
+}
+
+.save-thumb__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to right, rgba(27, 35, 64, 0.6) 0%, transparent 60%);
+}
+
+.save-thumb__info {
+  position: absolute;
+  left: var(--s-4);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.save-thumb__tick {
+  font-family: var(--f-mono);
+  font-size: var(--t-xs);
+  color: var(--c-event);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.save-thumb__name {
+  font-family: var(--f-serif-ko);
+  font-size: var(--t-xl);
+  font-weight: 600;
+  color: var(--c-text);
+  margin-top: var(--s-1);
+}
+
+.save-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--s-3);
+}
+
+.save-info-item {
+  background: var(--c-surface-hi);
+  border-radius: var(--r-md);
+  padding: var(--s-3) var(--s-4);
+}
+
+.save-info-item__key {
+  font-family: var(--f-mono);
+  font-size: var(--t-xs);
+  color: var(--c-text-3);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: var(--s-1);
+}
+
+.save-info-item__val {
+  font-family: var(--f-mono);
+  font-size: var(--t-sm);
+  color: var(--c-text);
+}
+
+.save-modal__footer {
+  padding: var(--s-5) var(--s-6);
+  border-top: 1px solid var(--c-border);
+  display: flex;
+  gap: var(--s-3);
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.save-modal__hint {
+  font-size: var(--t-sm);
+  color: var(--c-text-3);
+  text-align: center;
+  margin: 0;
+}

--- a/frontend/src/pages/SavePage.jsx
+++ b/frontend/src/pages/SavePage.jsx
@@ -23,19 +23,77 @@ export default function SavePage({ simulationName, simulationId, token, onComple
   }
 
   return (
-    <main className="save-page">
-      <section className="save-page__card">
-        <p className="save-page__eyebrow">SAVE SIMULATION</p>
-        <h1>시뮬레이션 저장</h1>
-        <p><strong>{simulationName}</strong>의 현재 상태를 저장하시겠습니까?</p>
-        {error && <p className="message error" role="alert">{error}</p>}
-        <div className="save-page__actions">
-          <button type="button" onClick={handleSave} disabled={loading}>
-            {loading ? '저장 중...' : '저장'}
-          </button>
-          <button type="button" className="save-page__cancel" onClick={onCancel} disabled={loading}>취소</button>
+    <div className="save-bg-wrap">
+      <div className="save-bg" aria-hidden="true" />
+      <div className="save-overlay">
+        <div className="save-modal" role="dialog" aria-modal="true" aria-labelledby="save-modal-title">
+          <div className="save-modal__header">
+            <h2 className="save-modal__title" id="save-modal-title">시뮬레이션 저장</h2>
+            <button
+              type="button"
+              className="save-modal__close"
+              onClick={onCancel}
+              aria-label="닫기"
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                <path d="M3 3L11 11M11 3L3 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+              </svg>
+            </button>
+          </div>
+
+          <div className="save-modal__body">
+            <div className="save-thumb">
+              <div className="save-thumb__img" aria-hidden="true" />
+              <div className="save-thumb__overlay" aria-hidden="true" />
+              <div className="save-thumb__info">
+                <div className="save-thumb__tick">TICK — · DAY —</div>
+                <div className="save-thumb__name">{simulationName}</div>
+              </div>
+            </div>
+
+            <div className="save-info-grid">
+              <div className="save-info-item">
+                <div className="save-info-item__key">Tick 수</div>
+                <div className="save-info-item__val">—</div>
+              </div>
+              <div className="save-info-item">
+                <div className="save-info-item__key">Agent 수</div>
+                <div className="save-info-item__val">—</div>
+              </div>
+              <div className="save-info-item">
+                <div className="save-info-item__key">경과 일수</div>
+                <div className="save-info-item__val">—</div>
+              </div>
+              <div className="save-info-item">
+                <div className="save-info-item__key">상태</div>
+                <div className="save-info-item__val">—</div>
+              </div>
+            </div>
+
+            {error && <p className="message error" role="alert">{error}</p>}
+            <p className="save-modal__hint">저장 후에도 시뮬레이션을 계속 진행할 수 있습니다.</p>
+          </div>
+
+          <div className="save-modal__footer">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={onCancel}
+              disabled={loading}
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={handleSave}
+              disabled={loading}
+            >
+              {loading ? '저장 중...' : '저장'}
+            </button>
+          </div>
         </div>
-      </section>
-    </main>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## 작업 개요

09-save-modal.html, 10-mypage-simulations.html 목업을 기반으로
SavePage와 MyPage의 UI를 전면 교체한다.
API 로직·컴포넌트 prop 시그니처·테스트 파일은 변경하지 않는다.

## 관련 Issue

관련 Issue 없음

## 변경 내용

**SavePage**
- 단순 카드 레이아웃 → 배경 이미지 + 블러 오버레이 + 중앙 모달 구조로 교체
- save-thumb 섬네일(배경·오버레이·tick·이름), 2열 save-info-grid 구현
- 모달 헤더에 h2 타이틀 + 닫기(×) 버튼, footer에 취소·저장 버튼 분리
- `@keyframes save-modal-appear` 슬라이드업 등장 애니메이션 추가

**MyPage**
- 단순 목록 → topbar(58px) + 220px 사이드바 + 콘텐츠 3-zone 레이아웃으로 교체
- Observer 프로필(아바타·display_name·username) 사이드바 상단 배치
- 메뉴(시뮬레이션 active, Persona·관찰 통계·프로필 비활성) + aria 속성
- 시뮬레이션 목록 → sim-card(썸네일·날짜·상태 badge·불러오기 버튼) 2열 그리드
- auth.user 옵셔널 체이닝(`?.`)으로 테스트 호환성 확보
- 980px / 720px 반응형 브레이크포인트 추가

## 결정 사항 및 이유

- **오버레이 구조(SavePage)**: 목업이 전체화면 배경 + 모달 구조를 사용. `position: fixed` + `backdrop-filter: blur`로 구현해 App 렌더 트리 위에서 동작하도록 함.
- **그리드 레이아웃(MyPage)**: `grid-template-columns: 220px minmax(0, 1fr)` 사용. 사이드바 너비 고정 + 콘텐츠 영역 유연 확장.
- **옵셔널 체이닝**: 기존 테스트가 `auth = { access_token: 'token' }` 형태로 user 없이 마운트하므로 `auth.user?.display_name` 패턴 적용.

## 테스트 / 확인 내용

- [x] `npm run build` 통과 (경고 0)
- [x] `npm test -- --run` — 121 passed / 1 failed (pre-existing: App.mock.test.jsx 타임아웃, develop 브랜치에서도 동일하게 실패 확인)
- [x] SavePage 관련 테스트 통과 (role="heading" "시뮬레이션 저장", 취소 버튼 존재)
- [x] MyPage 관련 테스트 통과 (role="heading" "내 시뮬레이션", "뒤로가기" 버튼)
- [ ] 브라우저 실제 렌더링 확인 (백엔드 연동 환경 필요)

## AI 사용 여부

사용 여부: 사용함
사용한 작업: SavePage·MyPage JSX 및 CSS 전체 재작성, 테스트 실패 디버깅
사람이 검토한 내용: prop 시그니처 불변 확인, API 로직 무변경 확인, 테스트 결과 확인

## 리뷰어가 봐야 할 부분

- `SavePage.css` `.save-bg`, `.save-thumb__img` — `/assets/concept/academy-night-background.png` 경로가 실제 빌드 산출물에 있는지 확인 필요
- `MyPage.jsx` 56번째 줄 — `auth.user?.display_name?.[0] ?? 'O'` 아바타 폴백 문자 'O'가 적절한지 확인
- 사이드바 980px 브레이크포인트에서 observer 섹션이 숨겨짐 — 모바일에서 유저 정보 접근 불가 여부 UX 관점 검토