### PR TITLE
[Fix] 배포 UI 연동 오류 수정

### DIFF
--- a/backend/app/services/runtime_dependency.py
+++ b/backend/app/services/runtime_dependency.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
 
+from fastapi import HTTPException, status
+
 from app.core.config import Settings, get_settings
 from app.repositories.memory_repository import MemoryRepository
 from app.simulation.agent_runtime import AgentRuntime
@@ -32,7 +34,13 @@ def create_agent_runtime(settings: Settings) -> AgentRuntime:
 
 
 def get_agent_runtime() -> AgentRuntime:
-    return create_agent_runtime(get_settings())
+    try:
+        return create_agent_runtime(get_settings())
+    except RuntimeConfigurationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Agent Runtime API 키가 설정되지 않았습니다. 관리자에게 문의해 주세요.",
+        ) from exc
 
 
 def get_policy_evaluator() -> Callable[

--- a/backend/tests/test_runtime_dependency.py
+++ b/backend/tests/test_runtime_dependency.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import HTTPException
 
 from app.core.config import Settings
 from app.services import runtime_dependency
@@ -79,3 +80,17 @@ def test_factory_builds_anthropic_runtime_with_configured_metadata(monkeypatch):
 def test_factory_rejects_missing_or_blank_api_key(api_key):
     with pytest.raises(RuntimeConfigurationError, match="ANTHROPIC_API_KEY"):
         create_agent_runtime(settings(anthropic_api_key=api_key))
+
+
+def test_dependency_returns_service_unavailable_when_runtime_is_not_configured(monkeypatch):
+    monkeypatch.setattr(
+        runtime_dependency,
+        "get_settings",
+        lambda: settings(anthropic_api_key=None),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        runtime_dependency.get_agent_runtime()
+
+    assert exc_info.value.status_code == 503
+    assert "API 키" in exc_info.value.detail

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -36,7 +36,7 @@ button:disabled { opacity: .6; cursor: wait; }
 .sim-workspace { position: absolute; inset: 0; display: block; }
 
 .sim-left, .sim-right { position: absolute; z-index: 20; top: 4px; bottom: 148px; overflow: hidden; backdrop-filter: blur(16px); }
-.sim-left { left: 12px; width: 230px; padding: 0; }
+.sim-left { left: 12px; z-index: 25; width: 230px; padding: 0; background: rgba(10,20,50,.98); }
 .sim-right { right: 12px; width: 290px; padding: 0; overflow-y: auto; }
 .sim-left h1 { margin: 0; padding: 14px 16px 2px; overflow: hidden; color: var(--c-text); font-family: var(--f-serif-ko); font-size: 15px; text-overflow: ellipsis; white-space: nowrap; }
 .agent-count { margin: 0; padding: 0 16px 10px; color: var(--c-text-3); font: 10px var(--f-mono); letter-spacing: .1em; }
@@ -59,7 +59,7 @@ button:disabled { opacity: .6; cursor: wait; }
 .agent-list-copy small::before { content: attr(data-location) " · "; }
 .persona-tag { margin-left: auto; color: var(--c-cream); font: 9px var(--f-mono); }
 
-.map-view-panel { position: absolute; z-index: 15; left: 254px; right: 314px; top: 4px; bottom: 148px; padding: 0; overflow: hidden; }
+.map-view-panel { position: absolute; z-index: 15; left: 254px; right: 314px; top: 4px; bottom: 148px; padding: 0; overflow: hidden; isolation: isolate; }
 .sim-right .inspector-panel { border: 0; box-shadow: none; background: transparent; }
 .sim-right .relationship-modal-btn { margin: 0 16px 16px; width: calc(100% - 32px); color: var(--c-cream); background: var(--c-cream-muted); border-color: rgba(212,178,111,.35); }
 .runtime-persona-setup { position: fixed; left: -10000px; width: 1px; height: 1px; overflow: hidden; }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -23,6 +23,7 @@ button:disabled { opacity: .6; cursor: wait; }
 .tick-info { font-family: var(--f-mono); font-size: 12px; color: var(--c-text-2); }
 .header-controls, .header-right { display: flex; align-items: center; gap: 8px; }
 .header-controls { margin-left: auto; }
+.header-controls, .header-right, .sim-brand, .tick-info { flex-shrink: 0; }
 .topbar-action, .header-controls button { min-width: auto; padding: 6px 10px; border-color: var(--c-border); color: var(--c-text-2); font-size: 12px; background: rgba(16,26,56,.7); }
 .topbar-action:hover, .header-controls button:hover { color: var(--c-text); border-color: var(--c-border-hi); }
 .header-save { color: var(--c-bg); background: var(--c-cream); border-color: var(--c-cream); }
@@ -75,6 +76,16 @@ button:disabled { opacity: .6; cursor: wait; }
 .inspector-modal dl { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
 .inspector-modal dd { text-align: right; }
 @media (max-width: 1100px) { .sim-screen { min-width: 0; } .sim-left { width: 210px; } .sim-right { width: 260px; } .map-view-panel { left: 234px; right: 284px; } .profile { display: none; } }
+@media (max-width: 1280px) {
+  .sim-topbar { padding: 0 12px; gap: 7px; }
+  .sim-brand, .profile { display: none; }
+  .header-controls, .header-right { gap: 4px; }
+  .topbar-action, .header-controls button { padding: 6px 7px; }
+}
+@media (max-width: 1040px) {
+  .tick-info { display: none; }
+  .sim-topbar { overflow-x: auto; }
+}
 
 /* === Auth Panel (Login Card) === */
 .auth-panel { position: relative; z-index: 1; width: min(440px, calc(100vw - 32px)); background: rgba(12, 24, 58, 0.85); backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); border: 1px solid rgba(100, 130, 200, 0.3); border-radius: 14px; padding: 40px; display: flex; flex-direction: column; gap: 20px; }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -23,7 +23,7 @@ button:disabled { opacity: .6; cursor: wait; }
 .tick-info { font-family: var(--f-mono); font-size: 12px; color: var(--c-text-2); }
 .header-controls, .header-right { display: flex; align-items: center; gap: 8px; }
 .header-controls { margin-left: auto; }
-.header-controls, .header-right, .sim-brand, .tick-info { flex-shrink: 0; }
+.header-controls, .header-right, .sim-brand-mark, .sim-brand, .tick-info { flex-shrink: 0; }
 .topbar-action, .header-controls button { min-width: auto; padding: 6px 10px; border-color: var(--c-border); color: var(--c-text-2); font-size: 12px; background: rgba(16,26,56,.7); }
 .topbar-action:hover, .header-controls button:hover { color: var(--c-text); border-color: var(--c-border-hi); }
 .header-save { color: var(--c-bg); background: var(--c-cream); border-color: var(--c-cream); }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -227,6 +227,13 @@ function classifyTickError(requestError) {
     };
   }
 
+  if (status === 503) {
+    return {
+      type: "RUNTIME_NOT_CONFIGURED",
+      message: requestError.message,
+    };
+  }
+
   if (status >= 500) {
     return {
       type: "RUNTIME",
@@ -263,6 +270,7 @@ export default function App() {
   const [managementView, setManagementView] = useState(null); // null | "settings" | "replay" | "snapshot" | "sharing"
   const [isImported, setIsImported] = useState(false); // 이 Simulation이 공유 설정을 가져와 생성됐는지
   const [sharedBrowserOpen, setSharedBrowserOpen] = useState(false);
+  const [recentShare, setRecentShare] = useState(null);
   const refreshAgentsSilentlyRef = useRef(null);
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -294,6 +302,7 @@ export default function App() {
     setManagementView(null);
     setIsImported(false);
     setSharedBrowserOpen(false);
+    setRecentShare(null);
   }
 
   function handleEnroll(newSimulation) {
@@ -415,8 +424,6 @@ export default function App() {
   if (screen === "save") return (
     <SavePage
       simulationName={simulation?.name ?? "시뮬레이션"}
-      simulationId={simulationId}
-      token={auth.access_token}
       onComplete={() => setScreen("simulation")}
       onCancel={() => setScreen("simulation")}
     />
@@ -530,6 +537,7 @@ export default function App() {
         {sharedBrowserOpen ? (
           <SharedBrowser
             token={auth.access_token}
+            recentShare={recentShare}
             onImported={handleImported}
             onClose={() => setSharedBrowserOpen(false)}
           />
@@ -744,6 +752,10 @@ export default function App() {
                   token={auth.access_token}
                   simulationId={simulation.id}
                   simulationStatus={simulation.status}
+                  onShareCreated={setRecentShare}
+                  onShareCancelled={(shareId) => {
+                    setRecentShare((current) => current?.id === shareId ? null : current);
+                  }}
                 />
               )}
             </div>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import App from './App.jsx'
@@ -163,16 +163,28 @@ describe('Slice 0 UI', () => {
 
     await userEvent.click(screen.getByRole('button', { name: '관계 보기' }))
 
-    expect(await screen.findByRole('dialog', { name: '관계 그래프' })).toBeInTheDocument()
-    expect(screen.getByText('호감도 12')).toBeInTheDocument()
-    expect(screen.getByText('친밀도 23')).toBeInTheDocument()
-    expect(screen.getByText('신뢰도 34')).toBeInTheDocument()
-    expect(screen.getByText('긴장도 45')).toBeInTheDocument()
-    expect(screen.getByText('경쟁 56')).toBeInTheDocument()
-    expect(screen.getByText('의존도 67')).toBeInTheDocument()
+    const dialog = await screen.findByRole('dialog', { name: '관계 그래프' })
+    await vi.waitFor(() => expect(dialog.querySelector('svg.rm-svg line')).not.toBeNull())
+    fireEvent.click(dialog.querySelector('svg.rm-svg line'))
 
-    await userEvent.click(screen.getByRole('button', { name: '아델' }))
-    expect(screen.queryByRole('dialog', { name: '관계 그래프' })).not.toBeInTheDocument()
+    const detail = dialog.querySelector('.rel-detail')
+    expect(detail).not.toBeNull()
+    expect(within(detail).getByText('호감도')).toBeInTheDocument()
+    expect(within(detail).getByText('12')).toBeInTheDocument()
+    expect(within(detail).getByText('친밀도')).toBeInTheDocument()
+    expect(within(detail).getByText('23')).toBeInTheDocument()
+    expect(within(detail).getByText('신뢰도')).toBeInTheDocument()
+    expect(within(detail).getByText('34')).toBeInTheDocument()
+    expect(within(detail).getByText('긴장도')).toBeInTheDocument()
+    expect(within(detail).getByText('45')).toBeInTheDocument()
+    expect(within(detail).getByText('경쟁')).toBeInTheDocument()
+    expect(within(detail).getByText('56')).toBeInTheDocument()
+    expect(within(detail).getByText('의존도')).toBeInTheDocument()
+    expect(within(detail).getByText('67')).toBeInTheDocument()
+
+    await userEvent.click(within(dialog).getByRole('button', { name: '아델 선택' }))
+    expect(within(dialog).getByText('아델 선택 중')).toBeInTheDocument()
+    expect(within(dialog).getByRole('button', { name: '아델 선택' })).toHaveAttribute('aria-pressed', 'true')
     expect(screen.getByRole('heading', { name: '아델' })).toBeInTheDocument()
   })
 

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -299,23 +299,18 @@ describe('Slice 0 UI', () => {
     await setupSimulationWithAgents(fetchMock)
     await userEvent.click(screen.getByRole('button', { name: '저장' }))
     expect(screen.getByRole('heading', { name: '시뮬레이션 저장' })).toBeInTheDocument()
-    await userEvent.click(screen.getByRole('button', { name: '취소' }))
+    await userEvent.click(screen.getByRole('button', { name: '돌아가기' }))
     expect(screen.getByRole('heading', { name: 'Magic Academy Simulation' })).toBeInTheDocument()
   })
 
-  it('SavePage에 현재 Simulation과 인증 정보를 연결해 저장한다', async () => {
+  it('SavePage에서 자동 저장을 안내하고 API 호출 없이 돌아온다', async () => {
     const fetchMock = await setupSimulationWithAgents()
-    fetchMock.mockImplementationOnce(() => response({ data: { id: simulation.id, status: 'PAUSED' } }))
-
     await userEvent.click(screen.getByRole('button', { name: '저장' }))
-    await userEvent.click(screen.getByRole('button', { name: '저장' }))
+    expect(screen.getByRole('status')).toHaveTextContent('자동으로 저장됩니다')
+    await userEvent.click(screen.getByRole('button', { name: '확인' }))
 
     expect(await screen.findByRole('heading', { name: simulation.name })).toBeInTheDocument()
-    expect(fetchMock.mock.calls.some(([url, options]) =>
-      url.endsWith(`/v1/simulations/${simulation.id}/save`) &&
-      options?.method === 'POST' &&
-      options?.headers?.Authorization === 'Bearer token'
-    )).toBe(true)
+    expect(fetchMock.mock.calls.some(([url]) => url.endsWith(`/v1/simulations/${simulation.id}/save`))).toBe(false)
   })
   it('shows loading state while a tick is running', async () => {
     const fetchMock = await setupSimulationWithAgents()
@@ -445,6 +440,18 @@ describe('Slice 0 UI', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('이미 진행 중인 Tick이 있습니다')
     expect(screen.getByRole('button', { name: '다시 시도' })).toBeInTheDocument()
   })
+
+  it('Runtime API 키가 없으면 설정 안내를 표시한다', async () => {
+    const fetchMock = await setupSimulationWithAgents()
+    fetchMock.mockImplementationOnce(() => response({
+      detail: 'Agent Runtime API 키가 설정되지 않았습니다. 관리자에게 문의해 주세요.',
+    }, 503))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tick 실행' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Agent Runtime API 키가 설정되지 않았습니다')
+  })
+
   it('does not treat a 409 with a different error code as TICK_ALREADY_RUNNING', async () => {
     const fetchMock = await setupSimulationWithAgents()
     fetchMock.mockImplementationOnce(() => response({

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -11,6 +11,7 @@ const ERROR_MESSAGES = {
   409: "이미 적용되었거나 Simulation이 시작되어 변경할 수 없습니다.",
   422: "시작 조건을 만족하지 않습니다.",
   500: "서버 오류가 발생했습니다.",
+  503: "서비스가 아직 준비되지 않았습니다.",
 };
 
 export async function apiRequest(path, { token, ...options } = {}) {

--- a/frontend/src/components/ErrorMessage.jsx
+++ b/frontend/src/components/ErrorMessage.jsx
@@ -13,6 +13,7 @@ const STATUS_LABELS = {
   409: "처리할 수 없습니다",
   422: "규칙 위반",
   500: "서버 오류",
+  503: "서비스 준비 안 됨",
 };
 
 export default function ErrorMessage({ error }) {

--- a/frontend/src/components/ReplayPanel.jsx
+++ b/frontend/src/components/ReplayPanel.jsx
@@ -3,7 +3,7 @@
 // Replay 진입 + 실행 기록(tick) 목록 선택 + 선택한 tick 상세 조회.
 // 조회만 하며 부수 효과 없음(§3.12, §3.13).
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getReplayList, getReplayTick } from "../api/simulationHistory.js";
 import ErrorMessage from "./ErrorMessage";
 
@@ -16,6 +16,7 @@ export default function ReplayPanel({ token, simulationId }) {
   const [detail, setDetail] = useState(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState(null);
+  const detailRequestId = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -42,6 +43,7 @@ export default function ReplayPanel({ token, simulationId }) {
   }, [token, simulationId]);
 
   async function handleSelectTick(tickNumber) {
+    const requestId = ++detailRequestId.current;
     setSelectedTick(tickNumber);
     setDetailError(null);
     setDetail(null);
@@ -52,11 +54,15 @@ export default function ReplayPanel({ token, simulationId }) {
     setDetailLoading(true);
     try {
       const data = await getReplayTick(token, simulationId, tickNumber);
+      if (requestId !== detailRequestId.current) return;
       setDetail(data);
     } catch (requestError) {
+      if (requestId !== detailRequestId.current) return;
       setDetailError(requestError);
     } finally {
-      setDetailLoading(false);
+      if (requestId === detailRequestId.current) {
+        setDetailLoading(false);
+      }
     }
   }
 

--- a/frontend/src/components/ReplayPanel.jsx
+++ b/frontend/src/components/ReplayPanel.jsx
@@ -43,9 +43,13 @@ export default function ReplayPanel({ token, simulationId }) {
 
   async function handleSelectTick(tickNumber) {
     setSelectedTick(tickNumber);
-    setDetailLoading(true);
     setDetailError(null);
     setDetail(null);
+    if (tickNumber === 0) {
+      setDetailLoading(false);
+      return;
+    }
+    setDetailLoading(true);
     try {
       const data = await getReplayTick(token, simulationId, tickNumber);
       setDetail(data);
@@ -84,6 +88,11 @@ export default function ReplayPanel({ token, simulationId }) {
 
       {selectedTick !== null && (
         <div className="replay-detail" aria-live="polite">
+          {selectedTick === 0 && (
+            <p className="message">
+              Tick 0은 실행 전 초기 상태입니다. 실행 결과 대신 Snapshot에서 조회해 주세요.
+            </p>
+          )}
           {detailLoading && <p className="message">Tick {selectedTick} 데이터를 불러오는 중...</p>}
           {detailError && <ErrorMessage error={detailError} />}
 

--- a/frontend/src/components/ReplayPanel.test.jsx
+++ b/frontend/src/components/ReplayPanel.test.jsx
@@ -54,4 +54,17 @@ describe("ReplayPanel", () => {
     await waitFor(() => expect(api.getReplayTick).toHaveBeenCalledWith("tok", "sim_01", 1));
     expect(await screen.findByText(/수업/)).toBeInTheDocument();
   });
+
+  it("Tick 0은 RuntimeResult를 조회하지 않고 초기 상태로 안내한다", async () => {
+    api.getReplayList.mockResolvedValue({
+      items: [{ tick_number: 0, simulation_day: 1 }],
+      meta: { has_more: false },
+    });
+
+    render(<ReplayPanel token="tok" simulationId="sim_01" />);
+    fireEvent.click(await screen.findByRole("button", { name: /Tick 0/ }));
+
+    expect(screen.getByText(/실행 전 초기 상태/)).toBeInTheDocument();
+    expect(api.getReplayTick).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/ReplayPanel.test.jsx
+++ b/frontend/src/components/ReplayPanel.test.jsx
@@ -67,4 +67,33 @@ describe("ReplayPanel", () => {
     expect(screen.getByText(/실행 전 초기 상태/)).toBeInTheDocument();
     expect(api.getReplayTick).not.toHaveBeenCalled();
   });
+
+  it("Tick 0 선택 후 늦게 도착한 이전 Tick 상세를 표시하지 않는다", async () => {
+    let resolveTickOne;
+    api.getReplayList.mockResolvedValue({
+      items: [
+        { tick_number: 0, simulation_day: 1 },
+        { tick_number: 1, simulation_day: 1 },
+      ],
+      meta: { has_more: false },
+    });
+    api.getReplayTick.mockImplementation(() => new Promise((resolve) => {
+      resolveTickOne = resolve;
+    }));
+
+    render(<ReplayPanel token="tok" simulationId="sim_01" />);
+    fireEvent.click(await screen.findByRole("button", { name: /Tick 1/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Tick 0/ }));
+
+    resolveTickOne({
+      tick_number: 1,
+      simulation_day: 1,
+      events: [{ id: "late", title: "늦은 응답", event_type: "CLASS" }],
+      agent_snapshots: [],
+      relationship_deltas: [],
+    });
+
+    expect(await screen.findByText(/실행 전 초기 상태/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText("늦은 응답 (CLASS)")).not.toBeInTheDocument());
+  });
 });

--- a/frontend/src/components/SchoolMap.css
+++ b/frontend/src/components/SchoolMap.css
@@ -12,6 +12,8 @@
 }
 
 .school-map-toolbar {
+  position: relative;
+  z-index: 3;
   display: flex;
   align-items: center;
   padding: 8px 12px;
@@ -166,7 +168,9 @@
   gap: 4px;
   justify-content: center;
   flex-wrap: wrap;
-  max-width: 120px;
+  width: max-content;
+  max-width: 104px;
+  min-height: 26px;
 }
 
 .map-agent-dot-sm {

--- a/frontend/src/components/SchoolMap.jsx
+++ b/frontend/src/components/SchoolMap.jsx
@@ -2,11 +2,11 @@ import { useState } from "react";
 import "./SchoolMap.css";
 
 const SPACES = [
-  { code: "classroom",  name: "교실",   emoji: "🏫", top: "28%", left: "38%", bgImage: "/assets/classroom.png" },
-  { code: "restaurant", name: "식당",   emoji: "🍽️", top: "48%", left: "62%", bgImage: "/assets/restaurant.png" },
-  { code: "library",    name: "도서관", emoji: "📚", top: "62%", left: "30%", bgImage: "/assets/library.png" },
-  { code: "lab",        name: "연구실", emoji: "⚗️", top: "30%", left: "68%", bgImage: "/assets/lab.png" },
-  { code: "dormitory",  name: "기숙사", emoji: "🏠", top: "65%", left: "58%", bgImage: "/assets/dormitory.png" },
+  { code: "classroom",  name: "교실",   emoji: "🏫", top: "24%", left: "28%", bgImage: "/assets/classroom.png" },
+  { code: "restaurant", name: "식당",   emoji: "🍽️", top: "49%", left: "56%", bgImage: "/assets/restaurant.png" },
+  { code: "library",    name: "도서관", emoji: "📚", top: "69%", left: "23%", bgImage: "/assets/library.png" },
+  { code: "lab",        name: "연구실", emoji: "⚗️", top: "23%", left: "73%", bgImage: "/assets/lab.png" },
+  { code: "dormitory",  name: "기숙사", emoji: "🏠", top: "77%", left: "67%", bgImage: "/assets/dormitory.png" },
 ];
 
 const ACTION_LABEL = {

--- a/frontend/src/components/SharedBrowser.jsx
+++ b/frontend/src/components/SharedBrowser.jsx
@@ -22,7 +22,7 @@ function rosterSummary(payload) {
   return { studentCount, professorCount, organizationCount: payload?.organizations?.length ?? 0 };
 }
 
-export default function SharedBrowser({ token, onImported, onClose }) {
+export default function SharedBrowser({ token, recentShare, onImported, onClose }) {
   const [query, setQuery] = useState("");
   const [shares, setShares] = useState([]);
   const [listLoading, setListLoading] = useState(true);
@@ -43,7 +43,18 @@ export default function SharedBrowser({ token, onImported, onClose }) {
     setListError(null);
     try {
       const results = await listShares(token, { q });
-      setShares(results ?? []);
+      const publicShares = results ?? [];
+      const normalizedQuery = (q ?? "").trim().toLowerCase();
+      const recentMatches = recentShare && (
+        !normalizedQuery ||
+        recentShare.title?.toLowerCase().includes(normalizedQuery) ||
+        recentShare.description?.toLowerCase().includes(normalizedQuery)
+      );
+      setShares(
+        recentMatches && !publicShares.some((item) => item.id === recentShare.id)
+          ? [recentShare, ...publicShares]
+          : publicShares
+      );
     } catch (requestError) {
       setListError(requestError);
     } finally {

--- a/frontend/src/components/SharedBrowser.test.jsx
+++ b/frontend/src/components/SharedBrowser.test.jsx
@@ -50,6 +50,16 @@ describe("SharedBrowser", () => {
     expect(await screen.findByText("공개된 공유 설정이 없습니다.")).toBeInTheDocument();
   });
 
+  it("방금 만든 비공개 공유는 작성자의 둘러보기 목록에 표시한다", async () => {
+    api.listShares.mockResolvedValue([]);
+    const privateShare = { ...sampleShare, id: "share_private", visibility: "private" };
+
+    render(<SharedBrowser token="tok" recentShare={privateShare} />);
+
+    expect(await screen.findByText("마법 대학 표준 설정")).toBeInTheDocument();
+    expect(screen.getByText("private")).toBeInTheDocument();
+  });
+
   it("목록 항목을 선택하면 상세와 roster 요약을 보여준다", async () => {
     api.listShares.mockResolvedValue([sampleShare]);
     api.getShareDetail.mockResolvedValue(sampleDetail);

--- a/frontend/src/components/SharingPanel.jsx
+++ b/frontend/src/components/SharingPanel.jsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { cancelShare, createShare } from "../api/sharing.js";
 import ErrorMessage from "./ErrorMessage";
 
-export default function SharingPanel({ token, simulationId, simulationStatus }) {
+export default function SharingPanel({ token, simulationId, simulationStatus, onShareCreated, onShareCancelled }) {
   const isReady = (simulationStatus || "").toLowerCase() === "ready";
 
   const [visibility, setVisibility] = useState("private");
@@ -30,6 +30,7 @@ export default function SharingPanel({ token, simulationId, simulationStatus }) 
     try {
       const result = await createShare(token, simulationId, { visibility, title, description });
       setShare(result);
+      onShareCreated?.(result);
       setCancelError(null);
     } catch (requestError) {
       setError(requestError);
@@ -43,6 +44,7 @@ export default function SharingPanel({ token, simulationId, simulationStatus }) 
     setCancelError(null);
     try {
       await cancelShare(token, share.id);
+      onShareCancelled?.(share.id);
       setShare(null);
     } catch (requestError) {
       setCancelError(requestError);
@@ -95,6 +97,11 @@ export default function SharingPanel({ token, simulationId, simulationStatus }) 
           <p className="message">
             설정이 공유되었습니다. ({share.visibility})
           </p>
+          {share.visibility !== "public" && (
+            <p className="message">
+              이 공유는 공개 검색에는 노출되지 않지만, 현재 브라우저의 공유 설정 둘러보기에서 확인할 수 있습니다.
+            </p>
+          )}
           <dl>
             <dt>공유 ID</dt>
             <dd>{share.id}</dd>

--- a/frontend/src/components/SharingPanel.test.jsx
+++ b/frontend/src/components/SharingPanel.test.jsx
@@ -47,6 +47,25 @@ describe("SharingPanel", () => {
     });
   });
 
+  it("공유 생성 결과를 둘러보기 연결 콜백에 전달한다", async () => {
+    const createdShare = { id: "share_03", visibility: "private", title: "내 설정" };
+    const onShareCreated = vi.fn();
+    api.createShare.mockResolvedValue(createdShare);
+
+    render(
+      <SharingPanel
+        token="tok"
+        simulationId="sim_01"
+        simulationStatus="ready"
+        onShareCreated={onShareCreated}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "공유하기" }));
+
+    expect(await screen.findByText(/공개 검색에는 노출되지 않지만/)).toBeInTheDocument();
+    expect(onShareCreated).toHaveBeenCalledWith(createdShare);
+  });
+
   it("실행 중 Simulation 공유 시 409 오류를 표시한다", async () => {
     const error = new Error("이미 적용되었거나 Simulation이 시작되어 변경할 수 없습니다.");
     error.status = 409;

--- a/frontend/src/pages/SavePage.jsx
+++ b/frontend/src/pages/SavePage.jsx
@@ -1,27 +1,6 @@
-import { useState } from 'react';
-import { apiRequest } from '../api/client.js';
 import './SavePage.css';
 
-export default function SavePage({ simulationName, simulationId, token, onComplete, onCancel }) {
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
-
-  async function handleSave() {
-    setLoading(true);
-    setError('');
-    try {
-      await apiRequest(`/v1/simulations/${simulationId}/save`, {
-        method: 'POST',
-        token,
-      });
-      onComplete();
-    } catch (requestError) {
-      setError(requestError.message);
-    } finally {
-      setLoading(false);
-    }
-  }
-
+export default function SavePage({ simulationName, onComplete, onCancel }) {
   return (
     <div className="save-bg-wrap">
       <div className="save-bg" aria-hidden="true" />
@@ -70,8 +49,10 @@ export default function SavePage({ simulationName, simulationId, token, onComple
               </div>
             </div>
 
-            {error && <p className="message error" role="alert">{error}</p>}
-            <p className="save-modal__hint">저장 후에도 시뮬레이션을 계속 진행할 수 있습니다.</p>
+            <p className="message" role="status">
+              Simulation과 Tick 결과는 실행할 때마다 자동으로 저장됩니다.
+            </p>
+            <p className="save-modal__hint">별도의 수동 저장 없이 안전하게 계속 진행할 수 있습니다.</p>
           </div>
 
           <div className="save-modal__footer">
@@ -79,17 +60,15 @@ export default function SavePage({ simulationName, simulationId, token, onComple
               type="button"
               className="btn btn-ghost"
               onClick={onCancel}
-              disabled={loading}
             >
-              취소
+              돌아가기
             </button>
             <button
               type="button"
               className="btn btn-primary"
-              onClick={handleSave}
-              disabled={loading}
+              onClick={onComplete}
             >
-              {loading ? '저장 중...' : '저장'}
+              확인
             </button>
           </div>
         </div>

--- a/frontend/src/pages/SavePage.test.jsx
+++ b/frontend/src/pages/SavePage.test.jsx
@@ -4,80 +4,42 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import SavePage from './SavePage.jsx';
 
-function response(body, status = 200) {
-  return Promise.resolve({
-    ok: status >= 200 && status < 300,
-    status,
-    json: () => Promise.resolve(body),
-  });
-}
-
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
 });
 
 describe('SavePage', () => {
-  it('저장 API 성공 후 onComplete를 호출한다', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(() => response({ data: { id: 'sim-01' } }));
+  it('자동 저장을 안내하고 확인하면 onComplete를 호출한다', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
     const onComplete = vi.fn();
 
     render(
       <SavePage
         simulationName="첫 번째 시뮬레이션"
-        simulationId="sim-01"
-        token="token"
         onComplete={onComplete}
         onCancel={vi.fn()}
       />,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: '저장' }));
+    expect(screen.getByRole('status')).toHaveTextContent('자동으로 저장됩니다');
+    await userEvent.click(screen.getByRole('button', { name: '확인' }));
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'http://localhost:8000/v1/simulations/sim-01/save',
-      expect.objectContaining({ method: 'POST' }),
-    );
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  it('저장 중 버튼을 비활성화해 중복 제출을 막는다', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise(() => {}));
-
+  it('닫기를 누르면 onCancel을 호출한다', async () => {
+    const onCancel = vi.fn();
     render(
       <SavePage
         simulationName="첫 번째 시뮬레이션"
-        simulationId="sim-01"
-        token="token"
         onComplete={vi.fn()}
-        onCancel={vi.fn()}
+        onCancel={onCancel}
       />,
     );
 
-    const saveButton = screen.getByRole('button', { name: '저장' });
-    await userEvent.click(saveButton);
-    await userEvent.click(screen.getByRole('button', { name: '저장 중...' }));
-
-    expect(screen.getByRole('button', { name: '저장 중...' })).toBeDisabled();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('저장 실패 오류를 표시하고 다시 시도할 수 있다', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation(() => response({}, 500));
-
-    render(
-      <SavePage
-        simulationName="첫 번째 시뮬레이션"
-        simulationId="sim-01"
-        token="token"
-        onComplete={vi.fn()}
-        onCancel={vi.fn()}
-      />,
-    );
-
-    await userEvent.click(screen.getByRole('button', { name: '저장' }));
-
-    expect(await screen.findByRole('alert')).toHaveTextContent('서버 오류가 발생했습니다.');
-    expect(screen.getByRole('button', { name: '저장' })).toBeEnabled();
+    await userEvent.click(screen.getByRole('button', { name: '돌아가기' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## 작업 개요

Railway 배포 환경에서 확인된 Tick, Replay, 저장, 공유 목록 및 상단 UI 연동 오류를 수정합니다.

## 관련 Issue

Closes #218

## 변경 내용

- Runtime API 키 미설정 시 네트워크 오류 대신 명확한 503 안내 반환
- Replay Tick 0을 초기 Snapshot으로 안내하고 잘못된 RuntimeResult 조회 방지
- 방금 생성한 private/unlisted 공유를 작성자의 둘러보기 목록에 표시
- 존재하지 않는 수동 저장 API 호출을 제거하고 자동 저장 정책 안내
- 좁은 화면에서 상단 메뉴가 겹치지 않도록 반응형 스타일 보완

## 결정 사항 및 이유

공개 공유 목록 API는 public 항목만 반환하는 기존 접근 제어 계약을 유지했습니다. private/unlisted 공유는 전역 목록에 노출하지 않고 현재 사용자가 방금 생성한 항목만 프론트 상태로 합쳐 표시합니다. Tick 0은 실행 결과가 없는 초기 상태이므로 RuntimeResult 상세 API를 호출하지 않습니다.

## 테스트 / 확인 내용

- [x] 프론트 관련 테스트 20개 통과
- [x] Frontend lint 실행 확인(기존 경고 3건)
- [x] Frontend production build 통과
- [x] Backend Python 구문 검사 통과
- [ ] Backend pytest 실행(로컬 pytest 의존성 부재)
- [x] 관련 문서 계약 대조

## AI 사용 여부

사용 여부: 사용함
사용한 작업: 배포 로그 원인 분석, 회귀 테스트 작성, UI/API 오류 처리 수정
사람이 검토한 내용: Railway 실제 증상 및 화면 동작 확인

## 리뷰어가 봐야 할 부분

- private/unlisted 공유가 공개 API 결과에 노출되지 않는지
- Runtime 미설정 503 처리와 Tick 0 Replay 분기가 기존 API 계약을 유지하는지
- 상단 메뉴의 1280px/1040px 반응형 동작


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 공유 생성 후 비공개 공유도 최근 공유 목록에서 바로 확인할 수 있습니다.
  - 공유 공개 범위에 따른 안내 메시지가 표시됩니다.
  - 저장 화면에서 별도 저장 없이 자동 저장 안내를 확인하고 시뮬레이션으로 돌아갈 수 있습니다.
  - 실행 전 초기 상태(Tick 0)를 별도 조회 없이 확인할 수 있습니다.

- **버그 수정**
  - 런타임 설정이 준비되지 않은 경우 서비스 준비 상태와 API 키 안내가 표시됩니다.
  - 좁은 화면에서 상단 메뉴와 주요 버튼의 표시 및 사용성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->